### PR TITLE
[Backend] Add Route Entity And Data Layer

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/model/Route.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/Route.java
@@ -1,0 +1,54 @@
+package com.bounswe2026group1.backend.model;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "routes")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Route {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    @AttributeOverrides({
+        @AttributeOverride(name = "latitude", column = @Column(name = "start_latitude", nullable = false)),
+        @AttributeOverride(name = "longitude", column = @Column(name = "start_longitude", nullable = false))
+    })
+    private Location startLocation;
+
+    @Embedded
+    @AttributeOverrides({
+        @AttributeOverride(name = "latitude", column = @Column(name = "end_latitude", nullable = false)),
+        @AttributeOverride(name = "longitude", column = @Column(name = "end_longitude", nullable = false))
+    })
+    private Location endLocation;
+
+    @Column(nullable = false)
+    private int distance;
+
+    @Column(nullable = false)
+    private int duration;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private TravelMode travelMode;
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/TravelMode.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/TravelMode.java
@@ -1,0 +1,6 @@
+package com.bounswe2026group1.backend.model;
+
+public enum TravelMode {
+    WALKING,
+    WHEELCHAIR
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/RouteRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/RouteRepository.java
@@ -1,0 +1,9 @@
+package com.bounswe2026group1.backend.repository;
+
+import com.bounswe2026group1.backend.model.Route;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RouteRepository extends JpaRepository<Route, Long> {
+}

--- a/backend/src/main/resources/sql/create_routes_table.sql
+++ b/backend/src/main/resources/sql/create_routes_table.sql
@@ -1,0 +1,13 @@
+-- PostgreSQL DDL for the `routes` table (run manually or wire up Flyway if added later).
+-- Column names match JPA @AttributeOverrides and Route field mappings.
+
+CREATE TABLE routes (
+    id              BIGSERIAL PRIMARY KEY,
+    start_latitude  DOUBLE PRECISION NOT NULL,
+    start_longitude DOUBLE PRECISION NOT NULL,
+    end_latitude    DOUBLE PRECISION NOT NULL,
+    end_longitude   DOUBLE PRECISION NOT NULL,
+    distance        INTEGER NOT NULL,
+    duration        INTEGER NOT NULL,
+    travel_mode     VARCHAR(32) NOT NULL
+);

--- a/backend/src/test/java/com/bounswe2026group1/backend/repository/RouteRepositoryTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/repository/RouteRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.bounswe2026group1.backend.repository;
+
+import com.bounswe2026group1.backend.model.Location;
+import com.bounswe2026group1.backend.model.Route;
+import com.bounswe2026group1.backend.model.TravelMode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class RouteRepositoryTest {
+
+    @Autowired
+    private RouteRepository routeRepository;
+
+    @Test
+    void saveAndFindById_persistsEmbeddedLocationsAndEnums() {
+        Location start = new Location(41.015137, 28.979530);
+        Location end = new Location(41.008583, 28.980175);
+
+        Route route = Route.builder()
+                .startLocation(start)
+                .endLocation(end)
+                .distance(850)
+                .duration(620)
+                .travelMode(TravelMode.WHEELCHAIR)
+                .build();
+
+        Route saved = routeRepository.save(route);
+        assertTrue(saved.getId() != null && saved.getId() > 0);
+
+        Optional<Route> loaded = routeRepository.findById(saved.getId());
+        assertTrue(loaded.isPresent());
+        Route found = loaded.get();
+
+        assertEquals(start.getLatitude(), found.getStartLocation().getLatitude());
+        assertEquals(start.getLongitude(), found.getStartLocation().getLongitude());
+        assertEquals(end.getLatitude(), found.getEndLocation().getLatitude());
+        assertEquals(end.getLongitude(), found.getEndLocation().getLongitude());
+        assertEquals(850, found.getDistance());
+        assertEquals(620, found.getDuration());
+        assertEquals(TravelMode.WHEELCHAIR, found.getTravelMode());
+    }
+}


### PR DESCRIPTION
# 📝 Add Route entity with travelMode enum and RouteRepository to establish the foundational data layer for map routing. Include database table creation script and DataJpaTest to ensure correct persistence.

Fixes #93

# 📊 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A (Backend data layer implementation only)

# ⏱️ Estimated Review Time

- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
