### PR TITLE
[Backend] Add Swagger API Documentation to Backend

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -116,6 +116,11 @@
 			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>3.0.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/bounswe2026group1/backend/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/config/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package com.bounswe2026group1.backend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("bounswe2026group1 API")
+                        .description("REST API documentation for bounswe2026group1 backend")
+                        .version("0.0.1"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .name(securitySchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/register", "/auth/login").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET,
                                 "/api/reports", "/api/reports/**",
                                 "/api/comments", "/api/comments/**"

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spring.jpa.show-sql=true
 spring.sql.init.mode=always
 
 spring.config.import=optional:file:.env[.properties], optional:file:./backend/.env[.properties]
+
+springdoc.swagger-ui.path=/swagger-ui
+springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
# 📝 Add Swagger API Documentation to Backend
Fixes #118 

UI can be found in `/swagger-ui` endpoint and JSON spec can be found in this endpoint : `/api-docs`

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [x]  Documentation
<!-- Add/delete if they are not covering/relevant !-->
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
<!-- If applicable !-->
# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min

