### PR TITLE
[Web] Comment Out Stale Google/Apple Auth Tests Failing CI

### DIFF
--- a/frontend/src/components/SocialAuthButtons.test.jsx
+++ b/frontend/src/components/SocialAuthButtons.test.jsx
@@ -1,20 +1,23 @@
-import { render, screen } from '@testing-library/react'
-import SocialAuthButtons from './SocialAuthButtons.jsx'
+// Commented out: SocialAuthButtons (Google/Apple OAuth) were removed from the app.
+// See: https://github.com/bounswe/bounswe2026group1/issues/133
 
-describe('SocialAuthButtons', () => {
-  it('renders Google button', () => {
-    render(<SocialAuthButtons />)
-    expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument()
-  })
+// import { render, screen } from '@testing-library/react'
+// import SocialAuthButtons from './SocialAuthButtons.jsx'
 
-  it('renders Apple button', () => {
-    render(<SocialAuthButtons />)
-    expect(screen.getByRole('button', { name: /apple/i })).toBeInTheDocument()
-  })
+// describe('SocialAuthButtons', () => {
+//   it('renders Google button', () => {
+//     render(<SocialAuthButtons />)
+//     expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument()
+//   })
 
-  it('both buttons are type="button" so they do not submit forms', () => {
-    render(<SocialAuthButtons />)
-    const buttons = screen.getAllByRole('button')
-    buttons.forEach((btn) => expect(btn).toHaveAttribute('type', 'button'))
-  })
-})
+//   it('renders Apple button', () => {
+//     render(<SocialAuthButtons />)
+//     expect(screen.getByRole('button', { name: /apple/i })).toBeInTheDocument()
+//   })
+
+//   it('both buttons are type="button" so they do not submit forms', () => {
+//     render(<SocialAuthButtons />)
+//     const buttons = screen.getAllByRole('button')
+//     buttons.forEach((btn) => expect(btn).toHaveAttribute('type', 'button'))
+//   })
+// })

--- a/frontend/src/pages/Login.test.jsx
+++ b/frontend/src/pages/Login.test.jsx
@@ -57,11 +57,13 @@ describe('Login page', () => {
       expect(screen.getByRole('link', { name: /forgot password/i })).toBeInTheDocument()
     })
 
-    it('renders Google and Apple social auth buttons', () => {
-      renderLogin()
-      expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /apple/i })).toBeInTheDocument()
-    })
+    // Commented out: Google/Apple OAuth buttons removed from the app.
+    // See: https://github.com/bounswe/bounswe2026group1/issues/133
+    // it('renders Google and Apple social auth buttons', () => {
+    //   renderLogin()
+    //   expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument()
+    //   expect(screen.getByRole('button', { name: /apple/i })).toBeInTheDocument()
+    // })
 
     it('renders a link to the signup page', () => {
       renderLogin()

--- a/frontend/src/pages/Signup.test.jsx
+++ b/frontend/src/pages/Signup.test.jsx
@@ -75,11 +75,13 @@ describe('Signup page', () => {
       expect(screen.getByRole('checkbox', { name: /terms of service/i })).toBeInTheDocument()
     })
 
-    it('renders Google and Apple social auth buttons', () => {
-      renderSignup()
-      expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /apple/i })).toBeInTheDocument()
-    })
+    // Commented out: Google/Apple OAuth buttons removed from the app.
+    // See: https://github.com/bounswe/bounswe2026group1/issues/133
+    // it('renders Google and Apple social auth buttons', () => {
+    //   renderSignup()
+    //   expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument()
+    //   expect(screen.getByRole('button', { name: /apple/i })).toBeInTheDocument()
+    // })
 
     it('renders a link to the login page', () => {
       renderSignup()


### PR DESCRIPTION
## 📝 Description

Fixes #133

Google and Apple OAuth buttons were removed from the web app, but the corresponding tests were never cleaned up. This caused the `Web Build & Test` CI job to fail on every push.

Commented out the stale tests (rather than deleting) to preserve context and allow easy restoration if social auth is re-added.

**Affected files:**
- `frontend/src/components/SocialAuthButtons.test.jsx` — entire file (3 tests)
- `frontend/src/pages/Login.test.jsx` — 1 test (`renders Google and Apple social auth buttons`)
- `frontend/src/pages/Signup.test.jsx` — 1 test (`renders Google and Apple social auth buttons`)

## 📊 Type of Change

- [x] Bug fix

## ✅ Acceptance Criteria/Checklist

- [x] Project builds successfully
- [x] Self-review completed
- [x] All remaining tests pass
- [ ] CI `Web Build & Test` job passes

## 📸 Screenshots/Recordings

N/A — CI fix only.

## ⏱️ Estimated Review Time

- [x] Under 5 min