### PR TITLE
[Web] Embed API Key In Web App Requests

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8080
+VITE_API_KEY=your-api-key-here

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,8 +1,9 @@
 const BASE_URL = import.meta.env.VITE_API_URL
+const API_KEY = import.meta.env.VITE_API_KEY
 
 export async function apiFetch(path, options = {}) {
   const res = await fetch(`${BASE_URL}${path}`, {
-    headers: { 'Content-Type': 'application/json', ...options.headers },
+    headers: { 'Content-Type': 'application/json', 'Mapcess-Key': API_KEY, ...options.headers },
     ...options,
   })
 


### PR DESCRIPTION
# 📝 Embed API Key In Web App Requests
Fixes #181

Reads `VITE_API_KEY` from environment variables and sets it as a default `Mapcess-Key` header in the central `apiFetch` wrapper, so every outgoing request from the web app includes the header required by the backend `ApiKeyFilter` added in PR #180.

Also adds `frontend/.env.example` documenting the new variable alongside the existing `VITE_API_URL`.

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min