### PR TITLE
[DevOps][Backend] Fix Swagger UI HTTPS Request URLs Behind Nginx Reverse Proxy

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/config/OpenApiConfig.java
@@ -13,19 +13,26 @@ public class OpenApiConfig {
 
     @Bean
     public OpenAPI openAPI() {
-        final String securitySchemeName = "bearerAuth";
+        final String bearerSchemeName = "bearerAuth";
+        final String apiKeySchemeName = "mapcessKey";
 
         return new OpenAPI()
                 .info(new Info()
                         .title("bounswe2026group1 API")
                         .description("REST API documentation for bounswe2026group1 backend")
                         .version("0.0.1"))
-                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .addSecurityItem(new SecurityRequirement()
+                        .addList(bearerSchemeName)
+                        .addList(apiKeySchemeName))
                 .components(new Components()
-                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
-                                .name(securitySchemeName)
+                        .addSecuritySchemes(bearerSchemeName, new SecurityScheme()
+                                .name(bearerSchemeName)
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
-                                .bearerFormat("JWT")));
+                                .bearerFormat("JWT"))
+                        .addSecuritySchemes(apiKeySchemeName, new SecurityScheme()
+                                .name("Mapcess-Key")
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)));
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -35,6 +35,7 @@ spring.config.import=optional:file:.env[.properties], optional:file:./backend/.e
 
 springdoc.swagger-ui.path=/swagger-ui
 springdoc.api-docs.path=/api-docs
+server.forward-headers-strategy=framework
 
 # The number of approvals required to change a report's status to VERIFIED
 app.report.verification.threshold=5


### PR DESCRIPTION
# 📝 Fix Swagger UI HTTPS Request URLs Behind Nginx Reverse Proxy
Fixes #192

- Adds `server.forward-headers-strategy=framework` to `application.properties` so Spring trusts `X-Forwarded-Proto` from Nginx, making Swagger UI generate `https://` URLs
- Adds `Mapcess-Key` as a security scheme in `OpenApiConfig` so Swagger UI shows an "Authorize" button for the API key

Note: Nginx config also needs `proxy_set_header X-Forwarded-Proto $scheme;` added manually on the server.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [ ] All tests passed

# 📸 Screenshots / Recordings
<!-- If applicable -->

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min