### PR TITLE
[Web] Fix Zoom Controls Overlapping Community Pulse Card

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -54,7 +54,7 @@ function makeMarkerIcon(status) {
 function ZoomControls() {
   const map = useMap()
   return (
-    <div className="absolute right-10 top-1/2 -translate-y-1/2 flex flex-col gap-2 z-[1000]">
+    <div className="absolute right-10 top-1/3 -translate-y-1/2 flex flex-col gap-2 z-[1000]">
       <button
         onClick={() => map.zoomIn()}
         className="w-12 h-12 bg-white/80 backdrop-blur-md rounded-xl flex items-center justify-center shadow-lg hover:bg-white text-secondary hover:text-primary transition-colors"


### PR DESCRIPTION
## 📝 Description

Fixes #198

Zoom controls were positioned at `top-1/2` (vertically centered), which caused them to overlap with the Community Pulse card in the bottom-right corner on certain screen heights. 

This fix moves the controls to `top-1/3` to ensure proper vertical separation between the map controls and the information cards.

## 📊 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [ ] All tests passed


## ⏱️ Estimated Review Time

- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min