### PR TITLE
[Web] Reuse report tag icons from mobile in the frontend

### DIFF
--- a/frontend/src/components/CreateReportPanel.jsx
+++ b/frontend/src/components/CreateReportPanel.jsx
@@ -3,15 +3,9 @@ import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 import { apiFetch } from '../services/api.js'
 import { mapReport } from '../services/reportService.js'
+import { REPORT_TAGS } from '../utils/reportTagConfig.js'
 
-const TAGS = [
-  { value: 'MISSING_RAMP',    label: 'Missing Ramp',    icon: 'accessible_forward' },
-  { value: 'BROKEN_ELEVATOR', label: 'Broken Elevator',  icon: 'elevator' },
-  { value: 'NARROW_PASSAGE',  label: 'Narrow Passage',   icon: 'width_normal' },
-  { value: 'WET_FLOOR',       label: 'Wet Floor',        icon: 'water_drop' },
-  { value: 'CONSTRUCTION',    label: 'Construction',     icon: 'construction' },
-  { value: 'OTHER',           label: 'Other',            icon: 'more_horiz' },
-]
+const TAGS = Object.entries(REPORT_TAGS).map(([value, cfg]) => ({ value, ...cfg }))
 
 function CreateReportPanel({ position, onClose, onCreated }) {
   const { token, userId } = useAuth()
@@ -146,11 +140,8 @@ function CreateReportPanel({ position, onClose, onCreated }) {
               <button
                 key={t.value}
                 onClick={() => setTag(t.value)}
-                className={`flex flex-col items-center gap-1.5 p-3 rounded-xl border-2 transition-all text-xs font-semibold ${
-                  tag === t.value
-                    ? 'border-primary bg-primary-container/30 text-primary'
-                    : 'border-outline-variant/20 bg-surface-container text-on-surface-variant hover:border-primary/40'
-                }`}
+                className="flex flex-col items-center gap-1.5 p-3 rounded-xl border-2 transition-all text-xs font-semibold border-outline-variant/20 bg-surface-container text-on-surface-variant hover:border-primary/40"
+                style={tag === t.value ? { borderColor: t.color, backgroundColor: t.color + '1a', color: t.color } : {}}
               >
                 <span className="material-symbols-outlined text-xl">{t.icon}</span>
                 {t.label}

--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { agreeReport, disagreeReport, mapReport } from '../services/reportService.js'
 import { useAuth } from '../context/AuthContext.jsx'
+import { REPORT_TAGS } from '../utils/reportTagConfig.js'
 
 /**
  * ReportPanel
@@ -131,13 +132,21 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate }) 
                   <p className="text-xs text-on-surface-variant">{report.date}</p>
                 </div>
               </div>
-              {report.tags && (
+              {report.tags && report.tags.length > 0 && (
                 <div className="flex gap-2 flex-wrap justify-end">
-                  {report.tags.map(tag => (
-                    <span key={tag} className="px-3 py-1 bg-secondary-container text-on-secondary-container text-xs font-medium rounded-full">
-                      {tag}
-                    </span>
-                  ))}
+                  {report.tags.map(tag => {
+                    const cfg = REPORT_TAGS[tag] ?? { label: tag, icon: 'warning', color: '#767777' }
+                    return (
+                      <span
+                        key={tag}
+                        className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold text-white"
+                        style={{ backgroundColor: cfg.color }}
+                      >
+                        <span className="material-symbols-outlined leading-none" style={{ fontSize: '14px' }}>{cfg.icon}</span>
+                        {cfg.label}
+                      </span>
+                    )
+                  })}
                 </div>
               )}
             </div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -8,6 +8,7 @@ import RoutePanel from '../components/RoutePanel.jsx'
 import { getReports, mapReport } from '../services/reportService.js'
 import { useAuth } from '../context/AuthContext.jsx'
 import { useNavigate } from 'react-router-dom'
+import { REPORT_TAGS } from '../utils/reportTagConfig.js'
 
 function decodePolyline(encoded) {
   const coords = []
@@ -24,9 +25,9 @@ function decodePolyline(encoded) {
   return coords
 }
 
-function makeMarkerIcon(status) {
-  const borderColor = status === 'verified' ? '#176a21' : '#f59e0b'
-  const iconColor = status === 'verified' ? '#176a21' : '#d97706'
+function makeMarkerIcon(status, tag) {
+  const cfg = REPORT_TAGS[tag] ?? { icon: 'warning', color: '#767777' }
+  const borderColor = status === 'verified' ? '#176a21' : cfg.color
   return L.divIcon({
     className: '',
     html: `
@@ -41,10 +42,10 @@ function makeMarkerIcon(status) {
       ">
         <span class="material-symbols-outlined" style="
           font-size:20px;
-          color:${iconColor};
+          color:${borderColor};
           font-variation-settings:'FILL' 1;
           line-height:1;
-        ">warning</span>
+        ">${cfg.icon}</span>
       </div>`,
     iconSize: [40, 40],
     iconAnchor: [20, 20],
@@ -426,7 +427,7 @@ function Home() {
               <Marker
                 key={report.id}
                 position={[report.latitude, report.longitude]}
-                icon={makeMarkerIcon(report.status)}
+                icon={makeMarkerIcon(report.status, report.tags[0])}
                 eventHandlers={{ click: () => setSelectedReport(report) }}
               />
             ))}

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -1,4 +1,5 @@
 import { apiFetch } from './api.js'
+import { REPORT_TAGS } from '../utils/reportTagConfig.js'
 
 /**
  * Fetch all reports from the backend.
@@ -39,18 +40,9 @@ export async function disagreeReport(id, token) {
  * Map API ReportResponse fields to ReportPanel prop shape.
  */
 export function mapReport(r) {
-  const tagLabels = {
-    MISSING_RAMP: 'Missing Ramp',
-    BROKEN_ELEVATOR: 'Broken Elevator',
-    NARROW_PASSAGE: 'Narrow Passage',
-    WET_FLOOR: 'Wet Floor',
-    CONSTRUCTION: 'Construction',
-    OTHER: 'Other',
-  }
-
   return {
     id: r.reportId,
-    title: tagLabels[r.tag] || r.tag,
+    title: REPORT_TAGS[r.tag]?.label || r.tag,
     description: r.description,
     status: r.status === 'VERIFIED' ? 'verified' : 'unverified',
     date: r.publishDate
@@ -62,7 +54,7 @@ export function mapReport(r) {
     reportedBy: `User #${r.userId}`,
     agrees: r.agrees,
     disagrees: r.disagrees,
-    tags: [tagLabels[r.tag] || r.tag],
+    tags: r.tag ? [r.tag] : [],
     image: r.mediaUrls && r.mediaUrls.length > 0 ? r.mediaUrls[0] : null,
     latitude: r.latitude,
     longitude: r.longitude,

--- a/frontend/src/utils/reportTagConfig.js
+++ b/frontend/src/utils/reportTagConfig.js
@@ -1,0 +1,8 @@
+export const REPORT_TAGS = {
+  MISSING_RAMP:    { label: 'Missing Ramp',    icon: 'accessible_forward', color: '#B65900' },
+  BROKEN_ELEVATOR: { label: 'Broken Elevator',  icon: 'elevator',           color: '#B02500' },
+  NARROW_PASSAGE:  { label: 'Narrow Passage',   icon: 'compress',           color: '#495F69' },
+  WET_FLOOR:       { label: 'Wet Floor',         icon: 'water_drop',         color: '#006573' },
+  CONSTRUCTION:    { label: 'Construction',      icon: 'construction',       color: '#8B6A00' },
+  OTHER:           { label: 'Other',             icon: 'warning',            color: '#767777' },
+}


### PR DESCRIPTION
# 📝 Description
Fixes #261

Mirrors the Flutter mobile app's report tag icon and color system on the web. A shared `reportTagConfig.js` maps each backend tag key to its Material Symbol icon and color (matching `ReportTag` enum in `report_model.dart`), and all three places that display tags — map markers, ReportPanel, and CreateReportPanel — now use it.

**Icons changed:**
| Tag | Old icon | New icon | Color |
|---|---|---|---|
| Missing Ramp | `warning` | `accessible_forward` | `#B65900` |
| Broken Elevator | `warning` | `elevator` | `#B02500` |
| Narrow Passage | `width_normal` | `compress` | `#495F69` |
| Wet Floor | `warning` | `water_drop` | `#006573` |
| Construction | `warning` | `construction` | `#8B6A00` |
| Other | `more_horiz` | `warning` | `#767777` |

# 📊 Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
<img width="448" height="387" alt="image" src="https://github.com/user-attachments/assets/097e5c2c-c4c0-4c99-8990-485c35348f1f" />


![Map markers with report tag icons](<!-- drag and drop screenshot here -->)

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min