### PR TITLE
[Backend] Add SSE broadcasts for report creation and deletion

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/service/PublicSseService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/PublicSseService.java
@@ -92,6 +92,36 @@ public class PublicSseService {
         return emitter;
     }
 
+    public void broadcastReportCreated(Report report) {
+        PublicSseEvent event = new PublicSseEvent(
+                "REPORT_CREATED",
+                report.getReportId(),
+                "create",
+                report.getAgrees(),
+                report.getDisagrees(),
+                report.getStatus().name(),
+                null,
+                null,
+                Instant.now()
+        );
+        sendToAll("report-created", event);
+    }
+
+    public void broadcastReportDeleted(Long reportId) {
+        PublicSseEvent event = new PublicSseEvent(
+                "REPORT_DELETED",
+                reportId,
+                "delete",
+                null,
+                null,
+                null,
+                null,
+                null,
+                Instant.now()
+        );
+        sendToAll("report-deleted", event);
+    }
+
     public void broadcastReportUpdated(Report report, String operation) {
         PublicSseEvent event = new PublicSseEvent(
                 "REPORT_UPDATED",

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -93,6 +93,7 @@ public class ReportService {
         Report report = new Report(user, location, request.getDescription(), request.getTag());
 
         Report saved = reportRepository.save(report);
+        publicSseService.broadcastReportCreated(saved);
         return ReportResponse.fromEntity(saved);
     }
 
@@ -110,6 +111,7 @@ public class ReportService {
     public boolean delete(Long id) {
         if (!reportRepository.existsById(id)) return false;
         reportRepository.deleteById(id);
+        publicSseService.broadcastReportDeleted(id);
         return true;
     }
 

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -123,6 +123,7 @@ class ReportServiceTest {
         assertEquals(Tag.MISSING_RAMP, result.getTag());
         assertEquals(ReportStatus.PENDING, result.getStatus());
         verify(reportRepository).save(any(Report.class));
+        verify(publicSseService).broadcastReportCreated(testReport);
     }
 
     @Test
@@ -157,6 +158,7 @@ class ReportServiceTest {
 
         assertTrue(result);
         verify(reportRepository).deleteById(1L);
+        verify(publicSseService).broadcastReportDeleted(1L);
     }
 
     @Test


### PR DESCRIPTION
# 📝 Description
Fixes #268

SSE was missing broadcasts for report creation and deletion. Mobile/web clients never received real-time updates for new or removed reports. Added `broadcastReportCreated` and `broadcastReportDeleted` to `PublicSseService` and wired them into `ReportService.create()` and `ReportService.delete()`.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min