### PR TITLE
[Web] Show Success Toast After Report Submission

### DIFF
--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -26,7 +26,7 @@ function Toast({ message, type = 'success', duration = 3000, onDismiss }) {
   const icon = type === 'success' ? 'check_circle' : 'error'
 
   return (
-    <div className={`fixed bottom-8 left-1/2 -translate-x-1/2 z-[9999] flex items-center gap-3 px-6 py-4 rounded-2xl shadow-lg transition-all duration-300 ${colors} ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'}`}>
+    <div className={`fixed bottom-8 left-1/2 -translate-x-1/2 z-[9999] flex items-center gap-2 px-6 py-3 rounded-full shadow-lg transition-all duration-300 ${colors} ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'}`}>
       <span className="material-symbols-outlined" style={{ fontVariationSettings: "'FILL' 1" }}>
         {icon}
       </span>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -489,7 +489,7 @@ function Home() {
 
           {/* Pin drop hint */}
           {showCreatePanel && !newReportPin && (
-            <div className="absolute top-6 left-1/2 -translate-x-1/2 z-[1000] pointer-events-none">
+            <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-[1000] pointer-events-none">
               <div className="bg-primary text-on-primary px-6 py-3 rounded-full shadow-lg font-semibold text-sm flex items-center gap-2">
                 <span className="material-symbols-outlined text-base">location_on</span>
                 Click on the map to set report location


### PR DESCRIPTION
Fixes #290

Adds a success toast notification at the bottom of the screen after a report is successfully submitted. Toast auto-dismisses after 3 seconds.

- Added reusable Toast component with success/error variants and fade-out animation
- Wired toast into Home.jsx onCreated callback

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Success toast appears after report submission
- [x] Toast auto-dismisses after 3 seconds
- [x] Project builds successfully
- [x] I have performed a self-review

# ⏱️ Estimated Review Time
- [x] < 5 min