### PR TITLE
[Mobile] Hotfix: SSE Configuration at Widget Test

### DIFF
--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -8,12 +8,16 @@ import 'package:mapcess/screens/login_screen.dart';
 import 'package:mapcess/screens/register_screen.dart';
 import 'package:mapcess/services/auth_service.dart';
 import 'package:mapcess/services/api_service.dart';
+import 'package:mapcess/services/sse_service.dart';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 Widget _withAuth(Widget screen) {
-  return ChangeNotifierProvider(
-    create: (_) => AuthService(),
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider(create: (_) => AuthService()),
+      Provider(create: (_) => SseService()),
+    ],
     child: MaterialApp(home: screen),
   );
 }
@@ -29,7 +33,7 @@ void main() {
 
   testWidgets('Mapcess smoke test', (WidgetTester tester) async {
     await tester.binding.setSurfaceSize(const Size(400, 900));
-    await tester.pumpWidget(MapcessApp(auth: AuthService()));
+    await tester.pumpWidget(MapcessApp(auth: AuthService(), sse: SseService()));
   });
 
   // ── ApiException.userMessage ────────────────────────────────────────────────


### PR DESCRIPTION
# 📝 SSE Configuration at Widget Test
Since this is a small hotfix, no separate issue was created.
`widget_test` is now configured with SSE.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
