### PR TITLE
[Web] Fix broken ReportPanel tests from bad merge

### DIFF
--- a/frontend/src/components/ReportPanel.test.jsx
+++ b/frontend/src/components/ReportPanel.test.jsx
@@ -86,9 +86,9 @@ describe('ReportPanel', () => {
 
   test('calls onVoteChange with agree/disagree/null correctly', async () => {
     agreeReport
-      .mockResolvedValueOnce({ id: 'r1', agrees: 1, disagrees: 0 })
-      .mockResolvedValueOnce({ id: 'r1', agrees: 0, disagrees: 0 })
-    disagreeReport.mockResolvedValueOnce({ id: 'r1', agrees: 0, disagrees: 1 })
+      .mockResolvedValueOnce({ id: 'r1', agrees: 1, disagrees: 0, userVote: 'agree' })
+      .mockResolvedValueOnce({ id: 'r1', agrees: 0, disagrees: 0, userVote: null })
+    disagreeReport.mockResolvedValueOnce({ id: 'r1', agrees: 0, disagrees: 1, userVote: 'disagree' })
 
     renderPanel()
 
@@ -114,69 +114,6 @@ describe('ReportPanel', () => {
     await waitFor(() => {
       expect(onFollowChangeMock).toHaveBeenCalled()
       expect(followBtn.textContent.toLowerCase()).toMatch(/unfollow/)
-    })
-  })
-
-    it('calls onVoteChange with agree when agree vote is cast', async () => {
-      const fakeToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiaWQiOjEsInJvbGUiOiJVU0VSIn0.sig'
-      const onVoteChange = vi.fn()
-      reportService.agreeReport.mockResolvedValue({ ...MOCK_REPORT, agrees: 4, userVote: 'AGREE' })
-      reportService.mapReport.mockReturnValue({ ...MOCK_REPORT, agrees: 4, userVote: 'agree' })
-      const user = userEvent.setup()
-      renderPanel({ token: fakeToken, onVoteChange })
-
-      await user.click(screen.getByRole('button', { name: 'Agree' }))
-
-      await waitFor(() => {
-        expect(onVoteChange).toHaveBeenCalledWith('agree')
-      })
-    })
-
-    it('calls onVoteChange with disagree when disagree vote is cast', async () => {
-      const fakeToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiaWQiOjEsInJvbGUiOiJVU0VSIn0.sig'
-      const onVoteChange = vi.fn()
-      reportService.disagreeReport.mockResolvedValue({ ...MOCK_REPORT, disagrees: 2, userVote: 'DISAGREE' })
-      reportService.mapReport.mockReturnValue({ ...MOCK_REPORT, disagrees: 2, userVote: 'disagree' })
-      const user = userEvent.setup()
-      renderPanel({ token: fakeToken, onVoteChange })
-
-
-    const textarea = screen.getByPlaceholderText('Add a comment...')
-    const postBtn = screen.getByText(/post/i)
-
-    await user.type(textarea, 'New comment')
-    await act(async () => { await user.click(postBtn) })
-
-
-    it('calls onVoteChange with null when toggling off an existing agree vote', async () => {
-      const fakeToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiaWQiOjEsInJvbGUiOiJVU0VSIn0.sig'
-      const onVoteChange = vi.fn()
-      reportService.agreeReport.mockResolvedValue({ ...MOCK_REPORT, agrees: 2, userVote: null })
-      reportService.mapReport.mockReturnValue({ ...MOCK_REPORT, agrees: 2, userVote: null })
-      const user = userEvent.setup()
-      renderPanel({ token: fakeToken, userVote: 'agree', onVoteChange })
-
-      await user.click(screen.getByRole('button', { name: 'Agree' }))
-
-      await waitFor(() => {
-        expect(onVoteChange).toHaveBeenCalledWith(null)
-      })
-
-    })
-
-    it('calls onVoteChange with null when toggling off an existing disagree vote', async () => {
-      const fakeToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiaWQiOjEsInJvbGUiOiJVU0VSIn0.sig'
-      const onVoteChange = vi.fn()
-      reportService.disagreeReport.mockResolvedValue({ ...MOCK_REPORT, disagrees: 0, userVote: null })
-      reportService.mapReport.mockReturnValue({ ...MOCK_REPORT, disagrees: 0, userVote: null })
-      const user = userEvent.setup()
-      renderPanel({ token: fakeToken, userVote: 'disagree', onVoteChange })
-
-      await user.click(screen.getByRole('button', { name: 'Disagree' }))
-
-      await waitFor(() => {
-        expect(onVoteChange).toHaveBeenCalledWith(null)
-      })
     })
   })
 


### PR DESCRIPTION
# 📝 Description
Fixes the broken Web CI on main caused by PR #340's merge leaving duplicate test blocks in `ReportPanel.test.jsx`.

**Root causes:**
- Duplicate `it()` blocks (lines 120-181) referenced undefined `reportService` namespace and `MOCK_REPORT` variable from the old test version
- The existing `test()` block for vote changes was missing `userVote` in mock response data

**Fix:**
- Removed the duplicate broken test blocks (already covered by the new `test('calls onVoteChange with agree/disagree/null correctly')`)
- Added missing `userVote` field to vote mock data so `onVoteChange` receives the correct value

# 📊 Type of Change
- [x] Bug fix

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A — test-only fix

# ⏱️ Estimated Review Time
- [x] < 5 min