### PR TITLE
[Backend] Return shortest route between wheelchair and ramp-assisted routes

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/service/OverpassService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/OverpassService.java
@@ -3,6 +3,7 @@ package com.bounswe2026group1.backend.service;
 import com.bounswe2026group1.backend.exception.RoutingException;
 import com.bounswe2026group1.backend.model.Location;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import tools.jackson.databind.JsonNode;
@@ -48,7 +49,7 @@ public class OverpassService {
 
         List<Location[]> stairEndpoints = parseStairEndpoints(response);
         if (stairEndpoints.isEmpty()) {
-            throw new RoutingException(
+            throw new RoutingException(HttpStatus.BAD_REQUEST,
                     "Ramps can currently only be added to stairs. No stair found within "
                     + SEARCH_RADIUS_METERS + "m of the reported location.");
         }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/OverpassService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/OverpassService.java
@@ -49,7 +49,8 @@ public class OverpassService {
         List<Location[]> stairEndpoints = parseStairEndpoints(response);
         if (stairEndpoints.isEmpty()) {
             throw new RoutingException(
-                    "No stair found within " + SEARCH_RADIUS_METERS + "m of the reported ramp location");
+                    "Ramps can currently only be added to stairs. No stair found within "
+                    + SEARCH_RADIUS_METERS + "m of the reported location.");
         }
 
         return findNearestStair(stairEndpoints, reportedPoint);

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RampReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RampReportService.java
@@ -2,12 +2,14 @@ package com.bounswe2026group1.backend.service;
 
 import com.bounswe2026group1.backend.dto.CreateRampReportRequest;
 import com.bounswe2026group1.backend.dto.RampReportResponse;
+import com.bounswe2026group1.backend.exception.RoutingException;
 import com.bounswe2026group1.backend.model.Location;
 import com.bounswe2026group1.backend.model.RampReport;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.repository.RampReportRepository;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -28,7 +30,15 @@ public class RampReportService {
         Location reportedPoint = new Location(request.getLatitude(), request.getLongitude());
 
         // Snap to nearest OSM stair — orientation resolved at routing time
-        Location[] endpoints = overpassService.snapToNearestStair(reportedPoint);
+        Location[] endpoints;
+        try {
+            endpoints = overpassService.snapToNearestStair(reportedPoint);
+        } catch (RoutingException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RoutingException(HttpStatus.BAD_REQUEST,
+                    "Could not verify stair location. Please try again later.");
+        }
 
         RampReport report = new RampReport(user, reportedPoint, request.getDescription(),
                 endpoints[0], endpoints[1]);

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -71,25 +71,26 @@ public class RouteService {
             }
         }
 
-        // 3. Wheelchair route — always returned, with obstacle avoidance
-        RoutingDirectionsResult wheelchairResult = fetchOrNull(start, end, TravelMode.WHEELCHAIR, avoidPolygons);
+        // 3. Ramp-Assisted Route — best of direct wheelchair vs multi-leg through ramp
+        RouteResponse bestWheelchair = null;
 
+        // Candidate A: direct wheelchair route with obstacle avoidance
+        RoutingDirectionsResult wheelchairResult = fetchOrNull(start, end, TravelMode.WHEELCHAIR, avoidPolygons);
         if (wheelchairResult != null) {
-            routes.add(RouteResponse.builder()
-                    .routeLabel("Wheelchair Route")
+            bestWheelchair = RouteResponse.builder()
+                    .routeLabel("Ramp-Assisted Route")
                     .distanceMeters(wheelchairResult.getDistanceMeters())
                     .durationSeconds(wheelchairResult.getDurationSeconds())
                     .mode(TravelMode.WHEELCHAIR)
                     .geometry(wheelchairResult.getGeometry())
                     .steps(wheelchairResult.getSteps())
                     .hasObstacles(false)
-                    .build());
+                    .build();
         }
 
-        // 4. Ramp-assisted Route — multi-leg through nearest ramp entry/exit
+        // Candidate B: multi-leg route through nearest ramp entry/exit
         RampReport ramp = obstacleService.findClosestRampInBoundingBox(start, end);
         if (ramp != null && ramp.getEntryPoint() != null && ramp.getExitPoint() != null) {
-            // Orient ramp: entry = endpoint closer to start, exit = endpoint closer to end
             Location rampA = ramp.getEntryPoint();
             Location rampB = ramp.getExitPoint();
             double distAToStart = haversineMeters(rampA, start);
@@ -98,7 +99,6 @@ public class RouteService {
             Location rampExit  = distAToStart <= distBToStart ? rampB : rampA;
 
             RoutingDirectionsResult leg1 = fetchOrNull(start, rampEntry, TravelMode.WHEELCHAIR, avoidPolygons);
-            // Leg 2 is the ramp itself — too short for ORS routing, modelled as a straight-line walk.
             RoutingDirectionsResult leg2 = straightLineLeg(rampEntry, rampExit);
             RoutingDirectionsResult leg3 = fetchOrNull(rampExit, end, TravelMode.WHEELCHAIR, avoidPolygons);
 
@@ -106,32 +106,36 @@ public class RouteService {
                 double totalDistance = leg1.getDistanceMeters() + leg2.getDistanceMeters() + leg3.getDistanceMeters();
                 double totalDuration = leg1.getDurationSeconds() + leg2.getDurationSeconds() + leg3.getDurationSeconds();
 
-                List<Location> combinedPath = new ArrayList<>();
-                combinedPath.addAll(PolylineDecoder.decode(leg1.getGeometry()));
-                combinedPath.addAll(PolylineDecoder.decode(leg2.getGeometry()));
-                combinedPath.addAll(PolylineDecoder.decode(leg3.getGeometry()));
+                // Pick the ramp-assisted multi-leg if it's shorter than the direct wheelchair route
+                if (bestWheelchair == null || totalDistance < bestWheelchair.getDistanceMeters()) {
+                    List<Location> combinedPath = new ArrayList<>();
+                    combinedPath.addAll(PolylineDecoder.decode(leg1.getGeometry()));
+                    combinedPath.addAll(PolylineDecoder.decode(leg2.getGeometry()));
+                    combinedPath.addAll(PolylineDecoder.decode(leg3.getGeometry()));
 
-                String combinedGeometry = PolylineEncoder.encode(combinedPath);
+                    List<RouteStep> combinedSteps = new ArrayList<>();
+                    if (leg1.getSteps() != null) combinedSteps.addAll(leg1.getSteps());
+                    combinedSteps.addAll(leg2.getSteps());
+                    combinedSteps.add(RouteStep.builder().instruction("Exit the ramp").maneuverType("ramp_exit").build());
+                    if (leg3.getSteps() != null) combinedSteps.addAll(leg3.getSteps());
 
-                List<RouteStep> combinedSteps = new ArrayList<>();
-                if (leg1.getSteps() != null) combinedSteps.addAll(leg1.getSteps());
-                // leg2 steps already contain "Take the ramp" from straightLineLeg
-                combinedSteps.addAll(leg2.getSteps());
-                combinedSteps.add(RouteStep.builder().instruction("Exit the ramp").maneuverType("ramp_exit").build());
-                if (leg3.getSteps() != null) combinedSteps.addAll(leg3.getSteps());
-
-                routes.add(RouteResponse.builder()
-                        .routeLabel("Ramp-Assisted Route")
-                        .distanceMeters(totalDistance)
-                        .durationSeconds(totalDuration)
-                        .mode(TravelMode.WHEELCHAIR)
-                        .geometry(combinedGeometry)
-                        .steps(combinedSteps)
-                        .hasObstacles(false)
-                        .build());
+                    bestWheelchair = RouteResponse.builder()
+                            .routeLabel("Ramp-Assisted Route")
+                            .distanceMeters(totalDistance)
+                            .durationSeconds(totalDuration)
+                            .mode(TravelMode.WHEELCHAIR)
+                            .geometry(PolylineEncoder.encode(combinedPath))
+                            .steps(combinedSteps)
+                            .hasObstacles(false)
+                            .build();
+                }
             } else {
-                log.warn("Ramp-assisted route skipped; leg 1 or leg 3 returned null.");
+                log.warn("Ramp-assisted route via ramp skipped; leg 1 or leg 3 returned null.");
             }
+        }
+
+        if (bestWheelchair != null) {
+            routes.add(bestWheelchair);
         }
 
         return routes;

--- a/frontend/src/components/CreateReportPanel.jsx
+++ b/frontend/src/components/CreateReportPanel.jsx
@@ -73,7 +73,7 @@ function CreateReportPanel({ position, onClose, onCreated }) {
       onCreated(mapped)
       onClose()
     } catch (err) {
-      setError('Failed to submit report. Please try again.')
+      setError(err.message || 'Failed to submit report. Please try again.')
     } finally {
       setSubmitting(false)
     }

--- a/frontend/src/components/CreateReportPanel.test.jsx
+++ b/frontend/src/components/CreateReportPanel.test.jsx
@@ -214,7 +214,7 @@ describe('CreateReportPanel', () => {
       await user.click(screen.getByRole('button', { name: /submit report/i }))
 
       await waitFor(() => {
-        expect(screen.getByText(/failed to submit report/i)).toBeInTheDocument()
+        expect(screen.getByText(/server error/i)).toBeInTheDocument()
       })
     })
   })


### PR DESCRIPTION
# 📝 Return shortest route between wheelchair and ramp-assisted routes

Fixes  #350 
ramp-assisted routing not using web-created ramp reports. Merges wheelchair and ramp-assisted routes into a single "Ramp-Assisted Route" that picks the shorter path by distance. Also improves error messaging when ramp report creation fails.

# 📊 Type of Change
- [x] Bug fix
- [x] Refactoring
- [ ] New feature
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [x] 5-15 min
- [ ] < 5 min
- [ ] > 15 min