### PR TITLE
[Backend] Implement Delete Report Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ build/
 .env
 application-local.properties
 .claude
+CLAUDE.md
+.claudeignore

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportController.java
@@ -50,11 +50,9 @@ public class ReportController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        if (reportService.delete(id)) {
-            return ResponseEntity.noContent().build();
-        }
-        return ResponseEntity.notFound().build();
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id, @AuthenticationPrincipal String email) {
+        reportService.delete(id, email);
     }
 
     @PostMapping("/{id}/verify")

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/Report.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/Report.java
@@ -49,6 +49,9 @@ public class Report {
     @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Media> mediaList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReportVerification> verifications = new ArrayList<>();
+
     public Report() {
     }
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -6,6 +6,8 @@ import com.bounswe2026group1.backend.model.Location;
 import com.bounswe2026group1.backend.model.Media;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.model.Report;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 import com.bounswe2026group1.backend.model.ReportVerification;
 import com.bounswe2026group1.backend.model.VoteType;
 import com.bounswe2026group1.backend.repository.MediaRepository;
@@ -36,6 +38,7 @@ public class ReportService {
     private final MediaRepository mediaRepository;
     private final ReportVerificationRepository verificationRepository;
     private final PublicSseService publicSseService;
+    private final S3MediaService s3MediaService;
 
     // Fetched from application.properties
     @Value("${app.report.verification.threshold:5}")
@@ -110,11 +113,24 @@ public class ReportService {
     }
 
     @Transactional
-    public boolean delete(Long id) {
-        if (!reportRepository.existsById(id)) return false;
-        reportRepository.deleteById(id);
+    public void delete(Long id, String email) {
+        Report report = reportRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Report not found with id: " + id));
+
+        RegisteredUser requester = registeredUserRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
+
+        if (!report.getCreatedBy().getId().equals(requester.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You are not the owner of this report");
+        }
+
+        List<String> mediaPaths = report.getMediaList().stream()
+                .map(Media::getFilePath)
+                .toList();
+        mediaPaths.forEach(s3MediaService::deleteFile);
+
+        reportRepository.delete(report);
         broadcastAfterCommit(() -> publicSseService.broadcastReportDeleted(id));
-        return true;
     }
 
     @Transactional

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/S3MediaService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/S3MediaService.java
@@ -1,10 +1,13 @@
 package com.bounswe2026group1.backend.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -14,8 +17,10 @@ import java.util.UUID;
 @Service
 public class S3MediaService {
 
-    private final S3Client s3Client;        // The object(bean) is in the AwsConfig
-    private final String bucketName;        // AWS S3 bucket name(injected from .env)
+    private static final Logger log = LoggerFactory.getLogger(S3MediaService.class);
+
+    private final S3Client s3Client;
+    private final String bucketName;
 
     private static final List<String> ALLOWED_CONTENT_TYPES = List.of(
             "image/jpeg", "image/png", "image/jpg", "video/mp4");
@@ -53,6 +58,17 @@ public class S3MediaService {
 
         } catch (IOException e) {
             throw new RuntimeException("Failed to upload to S3", e);
+        }
+    }
+
+    public void deleteFile(String fileUrl) {
+        String prefix = "https://" + bucketName + ".s3.amazonaws.com/";
+        if (fileUrl == null || !fileUrl.startsWith(prefix)) return;
+        String key = fileUrl.substring(prefix.length());
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(key).build());
+        } catch (Exception e) {
+            log.warn("Failed to delete S3 object '{}': {}", key, e.getMessage());
         }
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -14,7 +14,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -43,6 +45,9 @@ class ReportServiceTest {
     @Mock
     private PublicSseService publicSseService;
 
+    @Mock
+    private S3MediaService s3MediaService;
+
     @InjectMocks
     private ReportService reportService;
 
@@ -54,6 +59,7 @@ class ReportServiceTest {
     void setUp() {
         testUser = new RegisteredUser();
         testUser.setId(1L);
+        testUser.setEmail("owner@test.com");
 
         testReport = new Report(testUser, new Location(41.0, 29.0), "Broken ramp", Tag.MISSING_RAMP);
 
@@ -151,24 +157,55 @@ class ReportServiceTest {
     }
 
     @Test
-    void delete_existingId_returnsTrue() {
-        when(reportRepository.existsById(1L)).thenReturn(true);
+    void delete_ownerDeletesOwnReport_deletesAndBroadcasts() {
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("owner@test.com")).thenReturn(Optional.of(testUser));
 
-        boolean result = reportService.delete(1L);
+        reportService.delete(1L, "owner@test.com");
 
-        assertTrue(result);
-        verify(reportRepository).deleteById(1L);
+        verify(reportRepository).delete(testReport);
         verify(publicSseService).broadcastReportDeleted(1L);
     }
 
     @Test
-    void delete_nonExistingId_returnsFalse() {
-        when(reportRepository.existsById(99L)).thenReturn(false);
+    void delete_reportNotFound_throws404() {
+        when(reportRepository.findById(99L)).thenReturn(Optional.empty());
 
-        boolean result = reportService.delete(99L);
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> reportService.delete(99L, "owner@test.com"));
 
-        assertFalse(result);
-        verify(reportRepository, never()).deleteById(any());
+        assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
+        verify(reportRepository, never()).delete(any());
+    }
+
+    @Test
+    void delete_notOwner_throws403() {
+        RegisteredUser otherUser = new RegisteredUser();
+        otherUser.setId(2L);
+        otherUser.setEmail("other@test.com");
+
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("other@test.com")).thenReturn(Optional.of(otherUser));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> reportService.delete(1L, "other@test.com"));
+
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+        verify(reportRepository, never()).delete(any());
+    }
+
+    @Test
+    void delete_withMedia_callsS3DeleteForEachFile() {
+        Media media = new Media();
+        media.setFilePath("https://bucket.s3.amazonaws.com/file.jpg");
+        testReport.getMediaList().add(media);
+
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("owner@test.com")).thenReturn(Optional.of(testUser));
+
+        reportService.delete(1L, "owner@test.com");
+
+        verify(s3MediaService).deleteFile("https://bucket.s3.amazonaws.com/file.jpg");
     }
 
     @Test


### PR DESCRIPTION
# 📝 Description
Implements `DELETE /api/reports/{id}` endpoint with ownership validation and full cleanup of related resources. #175 

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
