### PR TITLE
[DevOps] Add restart policy to backend container so it auto-recovers after crash

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   db:
     image: postgres:15
     container_name: mapcess_db
+    restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
@@ -19,6 +20,7 @@ services:
   app:
     image: ghcr.io/bounswe/bounswe2026group1-backend:latest
     container_name: mapcess_backend
+    restart: unless-stopped
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
# 📝 Description
Fixes #381

Adds `restart: unless-stopped` to the `db` and `app` (backend) services in `backend/docker-compose.yml` so the production containers auto-recover after a crash.

**Context.** On 2026-04-17 the production backend container (`mapcess_backend`) was killed by the host kernel's OOM killer (exit code 137 with `OOMKilled=true`). Because the Compose service had no `restart` policy, the container stayed `Exited` for 13 days before anyone noticed, taking the public deployment offline. With `unless-stopped`, Docker brings the container back automatically on any non-manual exit. The `adminer` service already had this policy; this PR brings the other two services in line.

**Local-only compose untouched.** `docker-compose.local.yml` is intentionally left as-is — for local dev you usually want a crashed container to stay down so you notice and fix it.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas (n/a — config-only)
- [ ] I have added/updated tests (n/a — config-only)
- [x] All tests passed (no code changes)

# 📸 Screenshots / Recordings
n/a — config-only change. After deploy, verify with:

```
docker inspect mapcess_backend --format '{{.HostConfig.RestartPolicy.Name}}'
docker inspect mapcess_db      --format '{{.HostConfig.RestartPolicy.Name}}'
```

Both should print `unless-stopped`.

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
