### PR TITLE
[Backend] User Profile

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -92,6 +92,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>test</scope>

--- a/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
@@ -36,10 +36,13 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
-    /** Anonymous access: routing API and auth endpoints. */
+    /** Anonymous access: routing API, auth endpoints, and Spring Boot's error dispatcher.
+     *  /error must be public so validation/binding failures forward correctly and surface
+     *  as 400 instead of being masked as 401 by the security chain. */
     private static final String[] ROUTING_AND_AUTH_PUBLIC = {
             "/api/routes", "/api/routes/**",
             "/auth/register", "/auth/login",
+            "/error",
     };
 
     @Bean

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
@@ -32,9 +32,7 @@ public class RegisteredUserController {
 
     @GetMapping
     public List<UserProfileDTO> getAll() {
-        return registeredUserService.getAll().stream()
-                .map(u -> registeredUserService.getProfileById(u.getId()))
-                .toList();
+        return registeredUserService.getAllProfiles();
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -68,15 +69,6 @@ public class RegisteredUserController {
         }
         try {
             return ResponseEntity.ok(registeredUserService.getProfileByEmail(email));
-        } catch (NoSuchElementException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-        }
-    }
-
-    @GetMapping("/{id}/profile")
-    public ResponseEntity<?> getProfile(@PathVariable Long id) {
-        try {
-            return ResponseEntity.ok(registeredUserService.getProfileById(id));
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
@@ -156,7 +148,10 @@ public class RegisteredUserController {
 
     private String currentUserEmailOrNull() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !auth.isAuthenticated() || auth.getName() == null) return null;
+        // Spring's anonymous token reports isAuthenticated() == true with name "anonymousUser".
+        if (auth == null || auth instanceof AnonymousAuthenticationToken || !auth.isAuthenticated() || auth.getName() == null) {
+            return null;
+        }
         return auth.getName();
     }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
@@ -7,6 +7,7 @@ import com.bounswe2026group1.backend.service.RegisteredUserService;
 import com.bounswe2026group1.backend.service.S3MediaService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -110,6 +112,31 @@ public class RegisteredUserController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body("Avatar upload failed.");
+        }
+    }
+
+    @DeleteMapping("/{id}/profile/avatar")
+    public ResponseEntity<?> deleteAvatar(@PathVariable Long id) {
+        try {
+            requireOwner(id);
+            UserProfileDTO current = registeredUserService.getProfileById(id);
+            String oldUrl = current.getAvatarUrl();
+            registeredUserService.setAvatar(id, null);
+            // Clear DB first, then best-effort S3 delete. If S3 fails the object is orphaned
+            // but the user's avatar field is already cleared, which is what they asked for.
+            if (oldUrl != null && !oldUrl.isBlank()) {
+                try {
+                    s3MediaService.deleteFile(oldUrl);
+                } catch (Exception e) {
+                    log.warn("Failed to delete S3 object for user {} avatar ({}): {}",
+                            id, oldUrl, e.getMessage());
+                }
+            }
+            return ResponseEntity.noContent().build();
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
     }
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
@@ -1,12 +1,23 @@
 package com.bounswe2026group1.backend.controller;
 
+import com.bounswe2026group1.backend.dto.UpdateProfileRequest;
+import com.bounswe2026group1.backend.dto.UserProfileDTO;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.service.RegisteredUserService;
+import com.bounswe2026group1.backend.service.S3MediaService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 @RestController
 @RequestMapping("/api/users")
@@ -14,17 +25,22 @@ import java.util.List;
 public class RegisteredUserController {
 
     private final RegisteredUserService registeredUserService;
+    private final S3MediaService s3MediaService;
 
     @GetMapping
-    public List<RegisteredUser> getAll() {
-        return registeredUserService.getAll();
+    public List<UserProfileDTO> getAll() {
+        return registeredUserService.getAll().stream()
+                .map(u -> registeredUserService.getProfileById(u.getId()))
+                .toList();
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<RegisteredUser> getById(@PathVariable Long id) {
-        return registeredUserService.getById(id)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+    public ResponseEntity<UserProfileDTO> getById(@PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(registeredUserService.getProfileById(id));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.notFound().build();
+        }
     }
 
     @PostMapping
@@ -38,5 +54,82 @@ public class RegisteredUserController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.notFound().build();
+    }
+
+    // ───── Profile endpoints (issue #302) ───────────────────────────────────
+
+    @GetMapping("/me")
+    public ResponseEntity<?> me() {
+        String email = currentUserEmailOrNull();
+        if (email == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Authentication required.");
+        }
+        try {
+            return ResponseEntity.ok(registeredUserService.getProfileByEmail(email));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @GetMapping("/{id}/profile")
+    public ResponseEntity<?> getProfile(@PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(registeredUserService.getProfileById(id));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @PutMapping("/{id}/profile")
+    public ResponseEntity<?> updateProfile(@PathVariable Long id,
+                                           @RequestBody @Valid UpdateProfileRequest request) {
+        try {
+            requireOwner(id);
+            return ResponseEntity.ok(registeredUserService.updateProfile(id, request));
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/{id}/profile/avatar")
+    public ResponseEntity<?> uploadAvatar(@PathVariable Long id,
+                                          @RequestParam("file") MultipartFile file) {
+        try {
+            requireOwner(id);
+            String avatarUrl = s3MediaService.uploadFile(file);
+            UserProfileDTO updated = registeredUserService.setAvatar(id, avatarUrl);
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(Map.of("avatarUrl", updated.getAvatarUrl()));
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body("Avatar upload failed.");
+        }
+    }
+
+    /**
+     * Throws 403 unless the path id matches the authenticated user. Throws 401 if no auth.
+     */
+    private void requireOwner(Long pathId) {
+        String email = currentUserEmailOrNull();
+        if (email == null) {
+            throw new AccessDeniedException("Authentication required.");
+        }
+        UserProfileDTO me = registeredUserService.getProfileByEmail(email);
+        if (!me.getId().equals(pathId)) {
+            throw new AccessDeniedException("You can only modify your own profile.");
+        }
+    }
+
+    private String currentUserEmailOrNull() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth.getName() == null) return null;
+        return auth.getName();
     }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
@@ -2,9 +2,17 @@ package com.bounswe2026group1.backend.controller;
 
 import com.bounswe2026group1.backend.dto.routing.RouteRequest;
 import com.bounswe2026group1.backend.dto.routing.RouteResponse;
+import com.bounswe2026group1.backend.model.Location;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.Route;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.repository.RouteRepository;
 import com.bounswe2026group1.backend.service.RouteService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,15 +20,50 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/routes")
 @RequiredArgsConstructor
 public class RouteController {
 
     private final RouteService routeService;
+    private final RouteRepository routeRepository;
+    private final RegisteredUserRepository registeredUserRepository;
 
     @PostMapping
     public ResponseEntity<List<RouteResponse>> getRouteOptions(@RequestBody RouteRequest request) {
-        return ResponseEntity.ok(routeService.getRouteOptions(request));
+        List<RouteResponse> options = routeService.getRouteOptions(request);
+        recordPlannedRouteIfAuthenticated(request, options);
+        return ResponseEntity.ok(options);
+    }
+
+    /**
+     * Persist a single Route record so authenticated users can be credited with a "route planned"
+     * contribution stat (issue #302). Anonymous calls are not recorded.
+     */
+    private void recordPlannedRouteIfAuthenticated(RouteRequest request, List<RouteResponse> options) {
+        if (options == null || options.isEmpty()) return;
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth.getName() == null) return;
+
+        RegisteredUser user = registeredUserRepository.findByEmail(auth.getName()).orElse(null);
+        if (user == null) return;
+
+        try {
+            RouteResponse first = options.get(0);
+            Route record = Route.builder()
+                    .startLocation(new Location(request.getStartLat(), request.getStartLon()))
+                    .endLocation(new Location(request.getEndLat(), request.getEndLon()))
+                    .distance((int) Math.round(first.getDistanceMeters()))
+                    .duration((int) Math.round(first.getDurationSeconds()))
+                    .travelMode(first.getMode())
+                    .createdBy(user)
+                    .build();
+            routeRepository.save(record);
+        } catch (Exception e) {
+            // Don't fail the routing response if persistence fails — just log it.
+            log.warn("Failed to persist planned route for user {}: {}", user.getId(), e.getMessage());
+        }
     }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.controller;
 
+import com.bounswe2026group1.backend.dto.RouteSummaryDTO;
 import com.bounswe2026group1.backend.dto.routing.RouteRequest;
 import com.bounswe2026group1.backend.dto.routing.RouteResponse;
 import com.bounswe2026group1.backend.model.Location;
@@ -13,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,6 +38,13 @@ public class RouteController {
         List<RouteResponse> options = routeService.getRouteOptions(request);
         recordPlannedRouteIfAuthenticated(request, options);
         return ResponseEntity.ok(options);
+    }
+
+    @GetMapping("/user/{userId}")
+    public List<RouteSummaryDTO> getByUserId(@PathVariable Long userId) {
+        return routeRepository.findByCreatedByIdOrderByIdDesc(userId).stream()
+                .map(RouteSummaryDTO::from)
+                .toList();
     }
 
     /**

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/LoginResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/LoginResponse.java
@@ -2,9 +2,12 @@ package com.bounswe2026group1.backend.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class LoginResponse {
     private String token;
+    private UserProfileDTO profile;
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/RouteSummaryDTO.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/RouteSummaryDTO.java
@@ -1,0 +1,36 @@
+package com.bounswe2026group1.backend.dto;
+
+import com.bounswe2026group1.backend.model.Location;
+import com.bounswe2026group1.backend.model.Route;
+import com.bounswe2026group1.backend.model.TravelMode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RouteSummaryDTO {
+
+    private Long id;
+    private Location startLocation;
+    private Location endLocation;
+    private int distance;
+    private int duration;
+    private TravelMode travelMode;
+    private Long createdById;
+
+    public static RouteSummaryDTO from(Route r) {
+        return RouteSummaryDTO.builder()
+                .id(r.getId())
+                .startLocation(r.getStartLocation())
+                .endLocation(r.getEndLocation())
+                .distance(r.getDistance())
+                .duration(r.getDuration())
+                .travelMode(r.getTravelMode())
+                .createdById(r.getCreatedBy() != null ? r.getCreatedBy().getId() : null)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/UpdateProfileRequest.java
@@ -1,0 +1,18 @@
+package com.bounswe2026group1.backend.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProfileRequest {
+
+    @Size(min = 2, max = 50, message = "Name must be between 2 and 50 characters")
+    private String name;
+
+    @Size(max = 500, message = "Bio must be at most 500 characters")
+    private String bio;
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/UserProfileDTO.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/UserProfileDTO.java
@@ -1,0 +1,30 @@
+package com.bounswe2026group1.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileDTO {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String bio;
+    private String avatarUrl;
+    private String role;
+    private ContributionStatsDTO contributionStats;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ContributionStatsDTO {
+        private long reportsSubmitted;
+        private long routesPlanned;
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/RegisteredUser.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/RegisteredUser.java
@@ -37,4 +37,11 @@ public class RegisteredUser {
     @NotBlank(message = "Role cannot be blank")
     @Column(nullable = false)
     private String role;
+
+    @Size(max = 500, message = "Bio must be at most 500 characters")
+    @Column(length = 500)
+    private String bio;
+
+    @Column(length = 1024)
+    private String avatarUrl;
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/Route.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/Route.java
@@ -7,9 +7,12 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -51,4 +54,8 @@ public class Route {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 32)
     private TravelMode travelMode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private RegisteredUser createdBy;
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
@@ -18,6 +18,15 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     long countByCreatedById(Long userId);
 
+    /** Batch variant of {@link #countByCreatedById}: one query, grouped by user.
+     *  Returns rows of {@code [userId, count]}; absent users mean zero. */
+    @Query("""
+            SELECT r.createdBy.id, COUNT(r) FROM Report r
+            WHERE r.createdBy.id IN :userIds
+            GROUP BY r.createdBy.id
+            """)
+    List<Object[]> countByCreatedByIdIn(@Param("userIds") Collection<Long> userIds);
+
     List<Report> findByStatus(ReportStatus status);
 
     /**

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
@@ -16,6 +16,8 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     List<Report> findByCreatedById(Long userId);
 
+    long countByCreatedById(Long userId);
+
     List<Report> findByStatus(ReportStatus status);
 
     /**

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/RouteRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/RouteRepository.java
@@ -2,14 +2,26 @@ package com.bounswe2026group1.backend.repository;
 
 import com.bounswe2026group1.backend.model.Route;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface RouteRepository extends JpaRepository<Route, Long> {
 
     long countByCreatedById(Long userId);
+
+    /** Batch variant of {@link #countByCreatedById}: one query, grouped by user.
+     *  Returns rows of {@code [userId, count]}; absent users mean zero. */
+    @Query("""
+            SELECT r.createdBy.id, COUNT(r) FROM Route r
+            WHERE r.createdBy.id IN :userIds
+            GROUP BY r.createdBy.id
+            """)
+    List<Object[]> countByCreatedByIdIn(@Param("userIds") Collection<Long> userIds);
 
     List<Route> findByCreatedByIdOrderByIdDesc(Long userId);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/RouteRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/RouteRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RouteRepository extends JpaRepository<Route, Long> {
+
+    long countByCreatedById(Long userId);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/RouteRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/RouteRepository.java
@@ -4,8 +4,12 @@ import com.bounswe2026group1.backend.model.Route;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RouteRepository extends JpaRepository<Route, Long> {
 
     long countByCreatedById(Long userId);
+
+    List<Route> findByCreatedByIdOrderByIdDesc(Long userId);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
@@ -4,8 +4,12 @@ import com.bounswe2026group1.backend.dto.LoginRequest;
 import com.bounswe2026group1.backend.dto.LoginResponse;
 import com.bounswe2026group1.backend.dto.RegisterRequest;
 import com.bounswe2026group1.backend.dto.RegisterResponse;
+import com.bounswe2026group1.backend.dto.UpdateProfileRequest;
+import com.bounswe2026group1.backend.dto.UserProfileDTO;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.repository.ReportRepository;
+import com.bounswe2026group1.backend.repository.RouteRepository;
 import com.bounswe2026group1.backend.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -13,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
@@ -21,6 +26,8 @@ public class RegisteredUserService {
 
 
     private final RegisteredUserRepository registeredUserRepository;
+    private final ReportRepository reportRepository;
+    private final RouteRepository routeRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
 
@@ -71,8 +78,8 @@ public class RegisteredUserService {
         // 3. Generate JWT token
         String token = jwtUtil.generateToken(user.getId(), user.getEmail(), user.getRole());
 
-        // 4. Return token in response
-        return new LoginResponse(token);
+        // 4. Return token + profile in response
+        return new LoginResponse(token, toProfileDTO(user));
     }
 
     public List<RegisteredUser> getAll() {
@@ -91,5 +98,59 @@ public class RegisteredUserService {
         if (!registeredUserRepository.existsById(id)) return false;
         registeredUserRepository.deleteById(id);
         return true;
+    }
+
+    // ───── Profile (issue #302) ─────────────────────────────────────────────
+
+    public UserProfileDTO getProfileById(Long id) {
+        RegisteredUser user = registeredUserRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("User not found with id: " + id));
+        return toProfileDTO(user);
+    }
+
+    public UserProfileDTO getProfileByEmail(String email) {
+        RegisteredUser user = registeredUserRepository.findByEmail(email)
+                .orElseThrow(() -> new NoSuchElementException("User not found with email: " + email));
+        return toProfileDTO(user);
+    }
+
+    public UserProfileDTO updateProfile(Long id, UpdateProfileRequest request) {
+        RegisteredUser user = registeredUserRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("User not found with id: " + id));
+
+        if (request.getName() != null) {
+            user.setName(request.getName());
+        }
+        if (request.getBio() != null) {
+            user.setBio(request.getBio());
+        }
+
+        RegisteredUser saved = registeredUserRepository.save(user);
+        return toProfileDTO(saved);
+    }
+
+    public UserProfileDTO setAvatar(Long id, String avatarUrl) {
+        RegisteredUser user = registeredUserRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("User not found with id: " + id));
+        user.setAvatarUrl(avatarUrl);
+        RegisteredUser saved = registeredUserRepository.save(user);
+        return toProfileDTO(saved);
+    }
+
+    private UserProfileDTO toProfileDTO(RegisteredUser user) {
+        long reports = reportRepository.countByCreatedById(user.getId());
+        long routes = routeRepository.countByCreatedById(user.getId());
+        return UserProfileDTO.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .bio(user.getBio())
+                .avatarUrl(user.getAvatarUrl())
+                .role(user.getRole())
+                .contributionStats(UserProfileDTO.ContributionStatsDTO.builder()
+                        .reportsSubmitted(reports)
+                        .routesPlanned(routes)
+                        .build())
+                .build();
     }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
@@ -79,7 +79,7 @@ public class RegisteredUserService {
         String token = jwtUtil.generateToken(user.getId(), user.getEmail(), user.getRole());
 
         // 4. Return token + profile in response
-        return new LoginResponse(token, toProfileDTO(user));
+        return new LoginResponse(token, toProfileDTO(user, true));
     }
 
     public List<RegisteredUser> getAll() {
@@ -105,13 +105,13 @@ public class RegisteredUserService {
     public UserProfileDTO getProfileById(Long id) {
         RegisteredUser user = registeredUserRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("User not found with id: " + id));
-        return toProfileDTO(user);
+        return toProfileDTO(user, false);
     }
 
     public UserProfileDTO getProfileByEmail(String email) {
         RegisteredUser user = registeredUserRepository.findByEmail(email)
                 .orElseThrow(() -> new NoSuchElementException("User not found with email: " + email));
-        return toProfileDTO(user);
+        return toProfileDTO(user, true);
     }
 
     public UserProfileDTO updateProfile(Long id, UpdateProfileRequest request) {
@@ -126,7 +126,7 @@ public class RegisteredUserService {
         }
 
         RegisteredUser saved = registeredUserRepository.save(user);
-        return toProfileDTO(saved);
+        return toProfileDTO(saved, true);
     }
 
     public UserProfileDTO setAvatar(Long id, String avatarUrl) {
@@ -134,16 +134,18 @@ public class RegisteredUserService {
                 .orElseThrow(() -> new NoSuchElementException("User not found with id: " + id));
         user.setAvatarUrl(avatarUrl);
         RegisteredUser saved = registeredUserRepository.save(user);
-        return toProfileDTO(saved);
+        return toProfileDTO(saved, true);
     }
 
-    private UserProfileDTO toProfileDTO(RegisteredUser user) {
+    // includeEmail=true is reserved for self-views (/me, login, owner-only mutations).
+    // Public lookups must pass false to avoid leaking another user's email.
+    private UserProfileDTO toProfileDTO(RegisteredUser user, boolean includeEmail) {
         long reports = reportRepository.countByCreatedById(user.getId());
         long routes = routeRepository.countByCreatedById(user.getId());
         return UserProfileDTO.builder()
                 .id(user.getId())
                 .name(user.getName())
-                .email(user.getEmail())
+                .email(includeEmail ? user.getEmail() : null)
                 .bio(user.getBio())
                 .avatarUrl(user.getAvatarUrl())
                 .role(user.getRole())

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
@@ -16,7 +16,9 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -102,6 +104,31 @@ public class RegisteredUserService {
 
     // ───── Profile (issue #302) ─────────────────────────────────────────────
 
+    /** Public listing — uses batched count queries so this stays at 3 queries
+     *  total regardless of user count, instead of 1 + 3N. */
+    public List<UserProfileDTO> getAllProfiles() {
+        List<RegisteredUser> users = registeredUserRepository.findAll();
+        if (users.isEmpty()) return List.of();
+
+        List<Long> ids = users.stream().map(RegisteredUser::getId).toList();
+        Map<Long, Long> reportCounts = toCountMap(reportRepository.countByCreatedByIdIn(ids));
+        Map<Long, Long> routeCounts = toCountMap(routeRepository.countByCreatedByIdIn(ids));
+
+        return users.stream()
+                .map(u -> buildDTO(u, false,
+                        reportCounts.getOrDefault(u.getId(), 0L),
+                        routeCounts.getOrDefault(u.getId(), 0L)))
+                .toList();
+    }
+
+    private static Map<Long, Long> toCountMap(List<Object[]> rows) {
+        Map<Long, Long> map = new HashMap<>(rows.size());
+        for (Object[] row : rows) {
+            map.put((Long) row[0], (Long) row[1]);
+        }
+        return map;
+    }
+
     public UserProfileDTO getProfileById(Long id) {
         RegisteredUser user = registeredUserRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("User not found with id: " + id));
@@ -142,6 +169,10 @@ public class RegisteredUserService {
     private UserProfileDTO toProfileDTO(RegisteredUser user, boolean includeEmail) {
         long reports = reportRepository.countByCreatedById(user.getId());
         long routes = routeRepository.countByCreatedById(user.getId());
+        return buildDTO(user, includeEmail, reports, routes);
+    }
+
+    private UserProfileDTO buildDTO(RegisteredUser user, boolean includeEmail, long reports, long routes) {
         return UserProfileDTO.builder()
                 .id(user.getId())
                 .name(user.getName())

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/S3MediaService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/S3MediaService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -54,5 +55,28 @@ public class S3MediaService {
         } catch (IOException e) {
             throw new RuntimeException("Failed to upload to S3", e);
         }
+    }
+
+    /**
+     * Deletes the S3 object referenced by {@code url}. The URL must point to this service's
+     * configured bucket; URLs from other buckets are rejected so a malicious caller can't
+     * trick the app into deleting arbitrary objects.
+     */
+    public void deleteFile(String url) {
+        if (url == null || url.isBlank()) return;
+
+        String prefix = "https://" + bucketName + ".s3.amazonaws.com/";
+        if (!url.startsWith(prefix)) {
+            throw new IllegalArgumentException("URL does not belong to this bucket: " + url);
+        }
+        String key = url.substring(prefix.length());
+        if (key.isBlank()) {
+            throw new IllegalArgumentException("URL has no S3 key");
+        }
+
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build());
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/AuthControllerTest.java
@@ -4,6 +4,7 @@ import com.bounswe2026group1.backend.dto.LoginRequest;
 import com.bounswe2026group1.backend.dto.LoginResponse;
 import com.bounswe2026group1.backend.dto.RegisterRequest;
 import com.bounswe2026group1.backend.dto.RegisterResponse;
+import com.bounswe2026group1.backend.dto.UserProfileDTO;
 import com.bounswe2026group1.backend.service.RegisteredUserService;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import com.bounswe2026group1.backend.util.JwtUtil;
@@ -116,7 +117,15 @@ class AuthControllerTest {
 
     @Test
     void login_Returns200_OnSuccess() throws Exception {
-        LoginResponse expectedResponse = new LoginResponse("mocked.jwt.token");
+        UserProfileDTO profile = UserProfileDTO.builder()
+                .id(1L)
+                .name("Test")
+                .email("test@test.com")
+                .role("USER")
+                .contributionStats(UserProfileDTO.ContributionStatsDTO.builder()
+                        .reportsSubmitted(0).routesPlanned(0).build())
+                .build();
+        LoginResponse expectedResponse = new LoginResponse("mocked.jwt.token", profile);
         Mockito.when(registeredUserService.loginUser(any(LoginRequest.class))).thenReturn(expectedResponse);
 
         mockMvc.perform(post("/auth/login")
@@ -124,7 +133,10 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(validLoginRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.token").value("mocked.jwt.token"));
+                .andExpect(jsonPath("$.token").value("mocked.jwt.token"))
+                .andExpect(jsonPath("$.profile.id").value(1))
+                .andExpect(jsonPath("$.profile.email").value("test@test.com"))
+                .andExpect(jsonPath("$.profile.contributionStats.reportsSubmitted").value(0));
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RegisteredUserControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RegisteredUserControllerTest.java
@@ -81,27 +81,27 @@ class RegisteredUserControllerTest {
                 .andExpect(status().isUnauthorized());
     }
 
-    // ───── GET /{id}/profile ─────────────────────────────────────────────────
+    // ───── GET /{id} ─────────────────────────────────────────────────────────
 
     @Test
     @WithMockUser(username = OWNER_EMAIL)
-    @DisplayName("GET /{id}/profile returns 200")
-    void getProfile_returns200() throws Exception {
+    @DisplayName("GET /{id} returns 200")
+    void getById_returns200() throws Exception {
         when(registeredUserService.getProfileById(OWNER_ID)).thenReturn(ownerProfile);
 
-        mockMvc.perform(get("/api/users/{id}/profile", OWNER_ID).header("Mapcess-Key", validApiKey))
+        mockMvc.perform(get("/api/users/{id}", OWNER_ID).header("Mapcess-Key", validApiKey))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(OWNER_ID));
     }
 
     @Test
     @WithMockUser(username = OWNER_EMAIL)
-    @DisplayName("GET /{id}/profile returns 404 when user missing")
-    void getProfile_returns404() throws Exception {
+    @DisplayName("GET /{id} returns 404 when user missing")
+    void getById_returns404() throws Exception {
         when(registeredUserService.getProfileById(99L))
                 .thenThrow(new NoSuchElementException("User not found with id: 99"));
 
-        mockMvc.perform(get("/api/users/{id}/profile", 99L).header("Mapcess-Key", validApiKey))
+        mockMvc.perform(get("/api/users/{id}", 99L).header("Mapcess-Key", validApiKey))
                 .andExpect(status().isNotFound());
     }
 

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RegisteredUserControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RegisteredUserControllerTest.java
@@ -228,4 +228,76 @@ class RegisteredUserControllerTest {
                         .header("Mapcess-Key", validApiKey))
                 .andExpect(status().isInternalServerError());
     }
+
+    // ───── DELETE /{id}/profile/avatar ───────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("DELETE /{id}/profile/avatar by owner returns 204 and clears DB + S3")
+    void deleteAvatar_owner_returns204() throws Exception {
+        String existing = "https://bucket.s3.amazonaws.com/uuid_pic.jpg";
+        UserProfileDTO withAvatar = UserProfileDTO.builder()
+                .id(OWNER_ID).name("Owner").email(OWNER_EMAIL).avatarUrl(existing).role("USER")
+                .contributionStats(UserProfileDTO.ContributionStatsDTO.builder().build())
+                .build();
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        when(registeredUserService.getProfileById(OWNER_ID)).thenReturn(withAvatar);
+
+        mockMvc.perform(delete("/api/users/{id}/profile/avatar", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNoContent());
+
+        verify(registeredUserService).setAvatar(OWNER_ID, null);
+        verify(s3MediaService).deleteFile(existing);
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("DELETE /{id}/profile/avatar with no existing avatar still returns 204 (no S3 call)")
+    void deleteAvatar_noExistingAvatar_skipsS3() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        when(registeredUserService.getProfileById(OWNER_ID)).thenReturn(ownerProfile); // avatarUrl null
+
+        mockMvc.perform(delete("/api/users/{id}/profile/avatar", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNoContent());
+
+        verify(registeredUserService).setAvatar(OWNER_ID, null);
+        verify(s3MediaService, never()).deleteFile(any());
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("DELETE /{id}/profile/avatar still returns 204 even when S3 delete fails")
+    void deleteAvatar_s3Failure_stillReturns204() throws Exception {
+        String existing = "https://bucket.s3.amazonaws.com/uuid_pic.jpg";
+        UserProfileDTO withAvatar = UserProfileDTO.builder()
+                .id(OWNER_ID).name("Owner").email(OWNER_EMAIL).avatarUrl(existing).role("USER")
+                .contributionStats(UserProfileDTO.ContributionStatsDTO.builder().build())
+                .build();
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        when(registeredUserService.getProfileById(OWNER_ID)).thenReturn(withAvatar);
+        doThrow(new RuntimeException("S3 down")).when(s3MediaService).deleteFile(existing);
+
+        mockMvc.perform(delete("/api/users/{id}/profile/avatar", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNoContent());
+
+        // DB clear must have happened before S3 call
+        verify(registeredUserService).setAvatar(OWNER_ID, null);
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("DELETE /{id}/profile/avatar by non-owner returns 403")
+    void deleteAvatar_nonOwner_returns403() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+
+        mockMvc.perform(delete("/api/users/{id}/profile/avatar", OTHER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isForbidden());
+
+        verify(registeredUserService, never()).setAvatar(any(), any());
+        verify(s3MediaService, never()).deleteFile(any());
+    }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RegisteredUserControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RegisteredUserControllerTest.java
@@ -1,0 +1,231 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.dto.UpdateProfileRequest;
+import com.bounswe2026group1.backend.dto.UserProfileDTO;
+import com.bounswe2026group1.backend.service.RegisteredUserService;
+import com.bounswe2026group1.backend.service.S3MediaService;
+import com.bounswe2026group1.backend.util.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.NoSuchElementException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = RegisteredUserController.class)
+class RegisteredUserControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private RegisteredUserService registeredUserService;
+    @MockitoBean private S3MediaService s3MediaService;
+    @MockitoBean private JwtUtil jwtUtil;
+
+    @Value("${app.api.key}")
+    private String validApiKey;
+
+    private static final String OWNER_EMAIL = "owner@test.com";
+    private static final long OWNER_ID = 1L;
+    private static final long OTHER_ID = 2L;
+
+    private UserProfileDTO ownerProfile;
+
+    @BeforeEach
+    void setUp() {
+        ownerProfile = UserProfileDTO.builder()
+                .id(OWNER_ID)
+                .name("Owner")
+                .email(OWNER_EMAIL)
+                .bio("hello")
+                .role("USER")
+                .contributionStats(UserProfileDTO.ContributionStatsDTO.builder()
+                        .reportsSubmitted(2).routesPlanned(1).build())
+                .build();
+    }
+
+    // ───── GET /me ───────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("GET /me returns 200 with profile when authenticated")
+    void me_authenticated_returns200() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+
+        mockMvc.perform(get("/api/users/me").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(OWNER_ID))
+                .andExpect(jsonPath("$.email").value(OWNER_EMAIL))
+                .andExpect(jsonPath("$.contributionStats.reportsSubmitted").value(2))
+                .andExpect(jsonPath("$.contributionStats.routesPlanned").value(1));
+    }
+
+    @Test
+    @DisplayName("GET /me returns 401 when no auth")
+    void me_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(get("/api/users/me").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ───── GET /{id}/profile ─────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("GET /{id}/profile returns 200")
+    void getProfile_returns200() throws Exception {
+        when(registeredUserService.getProfileById(OWNER_ID)).thenReturn(ownerProfile);
+
+        mockMvc.perform(get("/api/users/{id}/profile", OWNER_ID).header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(OWNER_ID));
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("GET /{id}/profile returns 404 when user missing")
+    void getProfile_returns404() throws Exception {
+        when(registeredUserService.getProfileById(99L))
+                .thenThrow(new NoSuchElementException("User not found with id: 99"));
+
+        mockMvc.perform(get("/api/users/{id}/profile", 99L).header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNotFound());
+    }
+
+    // ───── PUT /{id}/profile ─────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("PUT /{id}/profile by owner returns 200")
+    void updateProfile_owner_returns200() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        UpdateProfileRequest req = new UpdateProfileRequest(null, "new bio");
+        UserProfileDTO updated = UserProfileDTO.builder()
+                .id(OWNER_ID).name("Owner").email(OWNER_EMAIL).bio("new bio").role("USER")
+                .contributionStats(UserProfileDTO.ContributionStatsDTO.builder().build())
+                .build();
+        when(registeredUserService.updateProfile(eq(OWNER_ID), any(UpdateProfileRequest.class)))
+                .thenReturn(updated);
+
+        mockMvc.perform(put("/api/users/{id}/profile", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bio").value("new bio"));
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("PUT /{id}/profile by non-owner returns 403")
+    void updateProfile_nonOwner_returns403() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        UpdateProfileRequest req = new UpdateProfileRequest(null, "new bio");
+
+        mockMvc.perform(put("/api/users/{id}/profile", OTHER_ID)
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden());
+
+        verify(registeredUserService, never()).updateProfile(any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("PUT /{id}/profile rejects bio over 500 chars with 400")
+    void updateProfile_invalidBio_returns400() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        UpdateProfileRequest req = new UpdateProfileRequest(null, "x".repeat(501));
+
+        mockMvc.perform(put("/api/users/{id}/profile", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ───── POST /{id}/profile/avatar ─────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("POST /{id}/profile/avatar by owner returns 201 with avatarUrl")
+    void uploadAvatar_owner_returns201() throws Exception {
+        String avatarUrl = "https://bucket.s3.amazonaws.com/uuid_pic.jpg";
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        when(s3MediaService.uploadFile(any())).thenReturn(avatarUrl);
+        UserProfileDTO updated = UserProfileDTO.builder()
+                .id(OWNER_ID).name("Owner").email(OWNER_EMAIL).avatarUrl(avatarUrl).role("USER")
+                .contributionStats(UserProfileDTO.ContributionStatsDTO.builder().build())
+                .build();
+        when(registeredUserService.setAvatar(eq(OWNER_ID), eq(avatarUrl))).thenReturn(updated);
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "pic.jpg", "image/jpeg", "bytes".getBytes());
+
+        mockMvc.perform(multipart("/api/users/{id}/profile/avatar", OWNER_ID).file(file)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.avatarUrl").value(avatarUrl));
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("POST /{id}/profile/avatar by non-owner returns 403")
+    void uploadAvatar_nonOwner_returns403() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "pic.jpg", "image/jpeg", "bytes".getBytes());
+
+        mockMvc.perform(multipart("/api/users/{id}/profile/avatar", OTHER_ID).file(file)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isForbidden());
+
+        verify(s3MediaService, never()).uploadFile(any());
+        verify(registeredUserService, never()).setAvatar(any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("POST /{id}/profile/avatar with unsupported file type returns 400")
+    void uploadAvatar_invalidType_returns400() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        when(s3MediaService.uploadFile(any())).thenThrow(new IllegalArgumentException("Invalid file type."));
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "doc.pdf", "application/pdf", "bytes".getBytes());
+
+        mockMvc.perform(multipart("/api/users/{id}/profile/avatar", OWNER_ID).file(file)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("POST /{id}/profile/avatar with S3 failure returns 500")
+    void uploadAvatar_s3Failure_returns500() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        when(s3MediaService.uploadFile(any())).thenThrow(new RuntimeException("S3 down"));
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "pic.jpg", "image/jpeg", "bytes".getBytes());
+
+        mockMvc.perform(multipart("/api/users/{id}/profile/avatar", OWNER_ID).file(file)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isInternalServerError());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RouteControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RouteControllerTest.java
@@ -1,0 +1,88 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.model.Location;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.Route;
+import com.bounswe2026group1.backend.model.TravelMode;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.repository.RouteRepository;
+import com.bounswe2026group1.backend.service.RouteService;
+import com.bounswe2026group1.backend.util.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = RouteController.class)
+class RouteControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private RouteService routeService;
+    @MockitoBean private RouteRepository routeRepository;
+    @MockitoBean private RegisteredUserRepository registeredUserRepository;
+    @MockitoBean private JwtUtil jwtUtil;
+
+    @Value("${app.api.key}")
+    private String validApiKey;
+
+    @Test
+    @DisplayName("GET /api/routes/user/{userId}: returns RouteSummaryDTOs for that user")
+    void getByUserId_returnsRoutes() throws Exception {
+        RegisteredUser ada = new RegisteredUser();
+        ada.setId(7L);
+        ada.setEmail("ada@test.com");
+
+        Route r1 = Route.builder()
+                .id(101L)
+                .startLocation(new Location(41.0, 28.9))
+                .endLocation(new Location(41.01, 28.95))
+                .distance(500)
+                .duration(600)
+                .travelMode(TravelMode.WALKING)
+                .createdBy(ada)
+                .build();
+        Route r2 = Route.builder()
+                .id(100L)
+                .startLocation(new Location(41.05, 29.00))
+                .endLocation(new Location(41.06, 29.01))
+                .distance(200)
+                .duration(240)
+                .travelMode(TravelMode.WHEELCHAIR)
+                .createdBy(ada)
+                .build();
+
+        when(routeRepository.findByCreatedByIdOrderByIdDesc(7L)).thenReturn(List.of(r1, r2));
+
+        mockMvc.perform(get("/api/routes/user/{userId}", 7L)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(101))
+                .andExpect(jsonPath("$[0].distance").value(500))
+                .andExpect(jsonPath("$[0].travelMode").value("WALKING"))
+                .andExpect(jsonPath("$[0].createdById").value(7))
+                .andExpect(jsonPath("$[1].id").value(100))
+                .andExpect(jsonPath("$[1].travelMode").value("WHEELCHAIR"));
+    }
+
+    @Test
+    @DisplayName("GET /api/routes/user/{userId}: empty list for user with no routes")
+    void getByUserId_empty() throws Exception {
+        when(routeRepository.findByCreatedByIdOrderByIdDesc(99L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/routes/user/{userId}", 99L)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/repository/RouteRepositoryTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/repository/RouteRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.bounswe2026group1.backend.repository;
 
 import com.bounswe2026group1.backend.model.Location;
+import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.model.Route;
 import com.bounswe2026group1.backend.model.TravelMode;
 import org.junit.jupiter.api.Test;
@@ -8,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +21,9 @@ class RouteRepositoryTest {
 
     @Autowired
     private RouteRepository routeRepository;
+
+    @Autowired
+    private RegisteredUserRepository registeredUserRepository;
 
     @Test
     void saveAndFindById_persistsEmbeddedLocationsAndEnums() {
@@ -47,5 +52,50 @@ class RouteRepositoryTest {
         assertEquals(850, found.getDistance());
         assertEquals(620, found.getDuration());
         assertEquals(TravelMode.WHEELCHAIR, found.getTravelMode());
+    }
+
+    @Test
+    void findByCreatedByIdOrderByIdDesc_returnsOnlyUsersRoutes_newestFirst() {
+        RegisteredUser ada = persistUser("ada@test.com");
+        RegisteredUser bob = persistUser("bob@test.com");
+
+        Route adaFirst  = persistRoute(ada, 100);
+        Route adaSecond = persistRoute(ada, 200);
+        Route bobOnly   = persistRoute(bob, 300);
+
+        List<Route> adaRoutes = routeRepository.findByCreatedByIdOrderByIdDesc(ada.getId());
+        assertEquals(2, adaRoutes.size());
+        assertTrue(adaRoutes.get(0).getId() > adaRoutes.get(1).getId(), "results must be newest-first");
+        assertEquals(adaSecond.getId(), adaRoutes.get(0).getId());
+        assertEquals(adaFirst.getId(), adaRoutes.get(1).getId());
+
+        List<Route> bobRoutes = routeRepository.findByCreatedByIdOrderByIdDesc(bob.getId());
+        assertEquals(1, bobRoutes.size());
+        assertEquals(bobOnly.getId(), bobRoutes.get(0).getId());
+
+        // unrelated user gets an empty list, not the whole table
+        List<Route> ghost = routeRepository.findByCreatedByIdOrderByIdDesc(9_999L);
+        assertTrue(ghost.isEmpty());
+    }
+
+    private RegisteredUser persistUser(String email) {
+        RegisteredUser u = new RegisteredUser();
+        u.setName("Test");
+        u.setEmail(email);
+        u.setPassword("hashedPassword");
+        u.setRole("USER");
+        return registeredUserRepository.save(u);
+    }
+
+    private Route persistRoute(RegisteredUser user, int distance) {
+        Route r = Route.builder()
+                .startLocation(new Location(41.0, 28.9))
+                .endLocation(new Location(41.01, 28.95))
+                .distance(distance)
+                .duration(distance * 2)
+                .travelMode(TravelMode.WALKING)
+                .createdBy(user)
+                .build();
+        return routeRepository.save(r);
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/repository/RouteRepositoryTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/repository/RouteRepositoryTest.java
@@ -55,6 +55,28 @@ class RouteRepositoryTest {
     }
 
     @Test
+    void countByCreatedByIdIn_groupsCountsPerUser_omittingUsersWithNoRoutes() {
+        RegisteredUser ada = persistUser("ada-batch@test.com");
+        RegisteredUser bob = persistUser("bob-batch@test.com");
+        RegisteredUser cleo = persistUser("cleo-batch@test.com"); // no routes
+        persistRoute(ada, 100);
+        persistRoute(ada, 200);
+        persistRoute(bob, 300);
+
+        List<Object[]> rows = routeRepository.countByCreatedByIdIn(
+                List.of(ada.getId(), bob.getId(), cleo.getId()));
+
+        assertEquals(2, rows.size(), "users with zero routes should not appear in the result");
+        for (Object[] row : rows) {
+            Long userId = (Long) row[0];
+            Long count = (Long) row[1];
+            if (userId.equals(ada.getId())) assertEquals(2L, count);
+            else if (userId.equals(bob.getId())) assertEquals(1L, count);
+            else throw new AssertionError("unexpected userId in result: " + userId);
+        }
+    }
+
+    @Test
     void findByCreatedByIdOrderByIdDesc_returnsOnlyUsersRoutes_newestFirst() {
         RegisteredUser ada = persistUser("ada@test.com");
         RegisteredUser bob = persistUser("bob@test.com");

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -153,7 +153,7 @@ class RegisteredUserServiceTest {
     // ───── PROFILE TESTS (issue #302) ────────────────────────────────────────
 
     @Test
-    void getProfileById_returnsAllFieldsAndStats() {
+    void getProfileById_returnsPublicFieldsAndStats_withoutEmail() {
         when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
         when(reportRepository.countByCreatedById(1L)).thenReturn(3L);
         when(routeRepository.countByCreatedById(1L)).thenReturn(2L);
@@ -162,7 +162,8 @@ class RegisteredUserServiceTest {
 
         assertEquals(1L, dto.getId());
         assertEquals("Test User", dto.getName());
-        assertEquals("test@test.com", dto.getEmail());
+        // Public lookup must NOT expose email — it's PII and only owner-views may include it.
+        assertNull(dto.getEmail());
         assertEquals("hello", dto.getBio());
         assertEquals("https://cdn/old.jpg", dto.getAvatarUrl());
         assertEquals("USER", dto.getRole());

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -4,18 +4,25 @@ import com.bounswe2026group1.backend.dto.LoginRequest;
 import com.bounswe2026group1.backend.dto.LoginResponse;
 import com.bounswe2026group1.backend.dto.RegisterRequest;
 import com.bounswe2026group1.backend.dto.RegisterResponse;
+import com.bounswe2026group1.backend.dto.UpdateProfileRequest;
+import com.bounswe2026group1.backend.dto.UserProfileDTO;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.repository.ReportRepository;
+import com.bounswe2026group1.backend.repository.RouteRepository;
 import com.bounswe2026group1.backend.util.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.lang.reflect.Field;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -25,14 +32,11 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class RegisteredUserServiceTest {
 
-    @Mock
-    private RegisteredUserRepository registeredUserRepository;
-
-    @Mock
-    private PasswordEncoder passwordEncoder;
-
-    @Mock
-    private JwtUtil jwtUtil;
+    @Mock private RegisteredUserRepository registeredUserRepository;
+    @Mock private ReportRepository reportRepository;
+    @Mock private RouteRepository routeRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtUtil jwtUtil;
 
     @InjectMocks
     private RegisteredUserService registeredUserService;
@@ -48,7 +52,14 @@ class RegisteredUserServiceTest {
         validRegisterRequest.setEmail("test@test.com");
         validRegisterRequest.setPassword("StrongP@ss1");
 
-        mockUser = new RegisteredUser(1L, "Test User", "test@test.com", "hashedPassword", "USER");
+        mockUser = new RegisteredUser();
+        mockUser.setId(1L);
+        mockUser.setName("Test User");
+        mockUser.setEmail("test@test.com");
+        mockUser.setPassword("hashedPassword");
+        mockUser.setRole("USER");
+        mockUser.setBio("hello");
+        mockUser.setAvatarUrl("https://cdn/old.jpg");
 
         validLoginRequest = new LoginRequest();
         validLoginRequest.setEmail("test@test.com");
@@ -109,11 +120,15 @@ class RegisteredUserServiceTest {
         when(registeredUserRepository.findByEmail(validLoginRequest.getEmail())).thenReturn(Optional.of(mockUser));
         when(passwordEncoder.matches(validLoginRequest.getPassword(), mockUser.getPassword())).thenReturn(true);
         when(jwtUtil.generateToken(mockUser.getId(), mockUser.getEmail(), mockUser.getRole())).thenReturn("mockJwtToken");
+        when(reportRepository.countByCreatedById(1L)).thenReturn(0L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
 
         LoginResponse response = registeredUserService.loginUser(validLoginRequest);
 
         assertNotNull(response);
         assertEquals("mockJwtToken", response.getToken());
+        assertNotNull(response.getProfile());
+        assertEquals(1L, response.getProfile().getId());
     }
 
     @Test
@@ -133,5 +148,250 @@ class RegisteredUserServiceTest {
         assertThrows(BadCredentialsException.class, () -> {
             registeredUserService.loginUser(validLoginRequest);
         });
+    }
+
+    // ───── PROFILE TESTS (issue #302) ────────────────────────────────────────
+
+    @Test
+    void getProfileById_returnsAllFieldsAndStats() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(reportRepository.countByCreatedById(1L)).thenReturn(3L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(2L);
+
+        UserProfileDTO dto = registeredUserService.getProfileById(1L);
+
+        assertEquals(1L, dto.getId());
+        assertEquals("Test User", dto.getName());
+        assertEquals("test@test.com", dto.getEmail());
+        assertEquals("hello", dto.getBio());
+        assertEquals("https://cdn/old.jpg", dto.getAvatarUrl());
+        assertEquals("USER", dto.getRole());
+        assertEquals(3L, dto.getContributionStats().getReportsSubmitted());
+        assertEquals(2L, dto.getContributionStats().getRoutesPlanned());
+        verify(reportRepository, times(1)).countByCreatedById(1L);
+        verify(routeRepository, times(1)).countByCreatedById(1L);
+    }
+
+    @Test
+    void getProfileById_throwsAndSkipsCounts_whenUserMissing() {
+        when(registeredUserRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class, () -> registeredUserService.getProfileById(99L));
+
+        verifyNoInteractions(reportRepository);
+        verifyNoInteractions(routeRepository);
+    }
+
+    @Test
+    void getProfileById_statsDefaultToZero_noNpe() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(reportRepository.countByCreatedById(1L)).thenReturn(0L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
+
+        UserProfileDTO dto = registeredUserService.getProfileById(1L);
+
+        assertEquals(0L, dto.getContributionStats().getReportsSubmitted());
+        assertEquals(0L, dto.getContributionStats().getRoutesPlanned());
+    }
+
+    @Test
+    void getProfileById_doesNotLeakPassword() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(reportRepository.countByCreatedById(1L)).thenReturn(0L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
+
+        UserProfileDTO dto = registeredUserService.getProfileById(1L);
+
+        // Regression guard: UserProfileDTO must not expose a password field at all.
+        for (Field f : dto.getClass().getDeclaredFields()) {
+            assertNotEquals("password", f.getName(), "UserProfileDTO must not expose a password field");
+        }
+    }
+
+    @Test
+    void getProfileByEmail_resolvesSameShape() {
+        when(registeredUserRepository.findByEmail("test@test.com")).thenReturn(Optional.of(mockUser));
+        when(reportRepository.countByCreatedById(1L)).thenReturn(1L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
+
+        UserProfileDTO dto = registeredUserService.getProfileByEmail("test@test.com");
+
+        assertEquals(1L, dto.getId());
+        assertEquals("test@test.com", dto.getEmail());
+        assertEquals(1L, dto.getContributionStats().getReportsSubmitted());
+    }
+
+    @Test
+    void getProfileByEmail_throwsWhenUnknown() {
+        when(registeredUserRepository.findByEmail("ghost@example.com")).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class,
+                () -> registeredUserService.getProfileByEmail("ghost@example.com"));
+    }
+
+    @Test
+    void updateProfile_bioOnly_leavesNameUntouched() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(reportRepository.countByCreatedById(1L)).thenReturn(0L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
+
+        UpdateProfileRequest req = new UpdateProfileRequest(null, "new bio");
+        UserProfileDTO dto = registeredUserService.updateProfile(1L, req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals("Test User", captor.getValue().getName(), "name must be untouched");
+        assertEquals("new bio", captor.getValue().getBio());
+        assertEquals("new bio", dto.getBio());
+    }
+
+    @Test
+    void updateProfile_nameOnly_leavesBioUntouched() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(reportRepository.countByCreatedById(1L)).thenReturn(0L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
+
+        UpdateProfileRequest req = new UpdateProfileRequest("Lovelace", null);
+        registeredUserService.updateProfile(1L, req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals("Lovelace", captor.getValue().getName());
+        assertEquals("hello", captor.getValue().getBio(), "bio must be untouched");
+    }
+
+    @Test
+    void updateProfile_bothFields_persistsBoth() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(reportRepository.countByCreatedById(1L)).thenReturn(0L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
+
+        UpdateProfileRequest req = new UpdateProfileRequest("Lovelace", "new bio");
+        registeredUserService.updateProfile(1L, req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals("Lovelace", captor.getValue().getName());
+        assertEquals("new bio", captor.getValue().getBio());
+    }
+
+    @Test
+    void updateProfile_emptyBio_clearsBio() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(reportRepository.countByCreatedById(1L)).thenReturn(0L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
+
+        UpdateProfileRequest req = new UpdateProfileRequest(null, "");
+        registeredUserService.updateProfile(1L, req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals("", captor.getValue().getBio());
+    }
+
+    @Test
+    void updateProfile_returnsPostSaveDto() {
+        RegisteredUser persisted = new RegisteredUser();
+        persisted.setId(1L);
+        persisted.setName("Persisted-Name");
+        persisted.setEmail("test@test.com");
+        persisted.setBio("persisted-bio");
+        persisted.setRole("USER");
+
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenReturn(persisted);
+        when(reportRepository.countByCreatedById(1L)).thenReturn(0L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
+
+        UpdateProfileRequest req = new UpdateProfileRequest("ignored-by-mock", "ignored-by-mock");
+        UserProfileDTO dto = registeredUserService.updateProfile(1L, req);
+
+        assertEquals("Persisted-Name", dto.getName());
+        assertEquals("persisted-bio", dto.getBio());
+    }
+
+    @Test
+    void updateProfile_userMissing_throwsAndDoesNotSave() {
+        when(registeredUserRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class,
+                () -> registeredUserService.updateProfile(99L, new UpdateProfileRequest("X", "Y")));
+
+        verify(registeredUserRepository, never()).save(any());
+    }
+
+    @Test
+    void setAvatar_persistsAndReturnsNewUrl() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(reportRepository.countByCreatedById(1L)).thenReturn(0L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
+
+        UserProfileDTO dto = registeredUserService.setAvatar(1L, "https://cdn/new.jpg");
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals("https://cdn/new.jpg", captor.getValue().getAvatarUrl());
+        assertEquals("https://cdn/new.jpg", dto.getAvatarUrl());
+    }
+
+    @Test
+    void setAvatar_replacesOldValue_doesNotConcatenate() {
+        // mockUser starts with "https://cdn/old.jpg"
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(reportRepository.countByCreatedById(1L)).thenReturn(0L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(0L);
+
+        registeredUserService.setAvatar(1L, "https://cdn/new.jpg");
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals("https://cdn/new.jpg", captor.getValue().getAvatarUrl());
+        assertFalse(captor.getValue().getAvatarUrl().contains("old.jpg"));
+    }
+
+    @Test
+    void setAvatar_userMissing_throws() {
+        when(registeredUserRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class,
+                () -> registeredUserService.setAvatar(99L, "https://cdn/new.jpg"));
+
+        verify(registeredUserRepository, never()).save(any());
+    }
+
+    @Test
+    void loginUser_includesProfileWithStats() {
+        when(registeredUserRepository.findByEmail(validLoginRequest.getEmail())).thenReturn(Optional.of(mockUser));
+        when(passwordEncoder.matches(validLoginRequest.getPassword(), mockUser.getPassword())).thenReturn(true);
+        when(jwtUtil.generateToken(1L, "test@test.com", "USER")).thenReturn("jwt-token");
+        when(reportRepository.countByCreatedById(1L)).thenReturn(4L);
+        when(routeRepository.countByCreatedById(1L)).thenReturn(1L);
+
+        LoginResponse resp = registeredUserService.loginUser(validLoginRequest);
+
+        assertEquals("jwt-token", resp.getToken());
+        assertNotNull(resp.getProfile());
+        assertEquals(1L, resp.getProfile().getId());
+        assertEquals("test@test.com", resp.getProfile().getEmail());
+        assertEquals(4L, resp.getProfile().getContributionStats().getReportsSubmitted());
+        assertEquals(1L, resp.getProfile().getContributionStats().getRoutesPlanned());
+    }
+
+    @Test
+    void loginUser_badCredentials_skipsProfile() {
+        when(registeredUserRepository.findByEmail(validLoginRequest.getEmail())).thenReturn(Optional.of(mockUser));
+        when(passwordEncoder.matches(validLoginRequest.getPassword(), mockUser.getPassword())).thenReturn(false);
+
+        assertThrows(BadCredentialsException.class, () -> registeredUserService.loginUser(validLoginRequest));
+
+        verify(reportRepository, never()).countByCreatedById(any());
+        verify(routeRepository, never()).countByCreatedById(any());
+        verify(jwtUtil, never()).generateToken(any(), any(), any());
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -22,11 +22,13 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -151,6 +153,52 @@ class RegisteredUserServiceTest {
     }
 
     // ───── PROFILE TESTS (issue #302) ────────────────────────────────────────
+
+    @Test
+    void getAllProfiles_usesBatchQueries_noPerUserCounts() {
+        RegisteredUser other = new RegisteredUser();
+        other.setId(2L);
+        other.setName("Other");
+        other.setEmail("other@test.com");
+        other.setRole("USER");
+
+        when(registeredUserRepository.findAll()).thenReturn(List.of(mockUser, other));
+        // mockUser=1L has 3 reports & 2 routes; user 2L has zero of either (absent rows)
+        when(reportRepository.countByCreatedByIdIn(List.of(1L, 2L)))
+                .thenReturn(List.<Object[]>of(new Object[]{1L, 3L}));
+        when(routeRepository.countByCreatedByIdIn(List.of(1L, 2L)))
+                .thenReturn(List.<Object[]>of(new Object[]{1L, 2L}));
+
+        List<UserProfileDTO> profiles = registeredUserService.getAllProfiles();
+
+        assertEquals(2, profiles.size());
+        UserProfileDTO ada = profiles.stream().filter(p -> p.getId() == 1L).findFirst().orElseThrow();
+        UserProfileDTO bob = profiles.stream().filter(p -> p.getId() == 2L).findFirst().orElseThrow();
+        assertEquals(3L, ada.getContributionStats().getReportsSubmitted());
+        assertEquals(2L, ada.getContributionStats().getRoutesPlanned());
+        assertEquals(0L, bob.getContributionStats().getReportsSubmitted());
+        assertEquals(0L, bob.getContributionStats().getRoutesPlanned());
+        // Public listing must not leak email
+        assertNull(ada.getEmail());
+        assertNull(bob.getEmail());
+
+        // Each batch query fires exactly once; per-user count queries are never used.
+        verify(reportRepository, times(1)).countByCreatedByIdIn(anyCollection());
+        verify(routeRepository, times(1)).countByCreatedByIdIn(anyCollection());
+        verify(reportRepository, never()).countByCreatedById(any());
+        verify(routeRepository, never()).countByCreatedById(any());
+    }
+
+    @Test
+    void getAllProfiles_emptyUsers_skipsCountQueries() {
+        when(registeredUserRepository.findAll()).thenReturn(List.of());
+
+        List<UserProfileDTO> profiles = registeredUserService.getAllProfiles();
+
+        assertTrue(profiles.isEmpty());
+        verifyNoInteractions(reportRepository);
+        verifyNoInteractions(routeRepository);
+    }
 
     @Test
     void getProfileById_returnsPublicFieldsAndStats_withoutEmail() {

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/S3MediaServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/S3MediaServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
@@ -145,6 +146,49 @@ class S3MediaServiceTest {
                 "file", "empty.jpg", "image/jpeg", new byte[0]);
 
         assertThrows(IllegalArgumentException.class, () -> s3MediaService.uploadFile(file));
+        verifyNoInteractions(s3Client);
+    }
+
+    // ── Deletes ───────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("deleteFile: extracts key and calls S3 deleteObject")
+    void deleteFile_callsS3WithCorrectKey() {
+        String url = "https://" + BUCKET_NAME + ".s3.amazonaws.com/abc-uuid_photo.jpg";
+
+        s3MediaService.deleteFile(url);
+
+        org.mockito.ArgumentCaptor<DeleteObjectRequest> captor =
+                org.mockito.ArgumentCaptor.forClass(DeleteObjectRequest.class);
+        verify(s3Client, times(1)).deleteObject(captor.capture());
+        assertEquals(BUCKET_NAME, captor.getValue().bucket());
+        assertEquals("abc-uuid_photo.jpg", captor.getValue().key());
+    }
+
+    @Test
+    @DisplayName("deleteFile: null and blank URLs are no-ops")
+    void deleteFile_nullOrBlank_noop() {
+        s3MediaService.deleteFile(null);
+        s3MediaService.deleteFile("");
+        s3MediaService.deleteFile("   ");
+        verifyNoInteractions(s3Client);
+    }
+
+    @Test
+    @DisplayName("deleteFile: rejects URLs from a different bucket")
+    void deleteFile_wrongBucket_throws() {
+        String url = "https://other-bucket.s3.amazonaws.com/some-file.jpg";
+
+        assertThrows(IllegalArgumentException.class, () -> s3MediaService.deleteFile(url));
+        verifyNoInteractions(s3Client);
+    }
+
+    @Test
+    @DisplayName("deleteFile: rejects URL with empty key")
+    void deleteFile_emptyKey_throws() {
+        String url = "https://" + BUCKET_NAME + ".s3.amazonaws.com/";
+
+        assertThrows(IllegalArgumentException.class, () -> s3MediaService.deleteFile(url));
         verifyNoInteractions(s3Client);
     }
 }


### PR DESCRIPTION
# 📝 [Backend] User Profile
Fixes #302

Adds the backend API for the User Profile feature.

- New endpoints: `GET /api/users/me`, `GET/PUT /api/users/{id}/profile`, `POST/DELETE /api/users/{id}/profile/avatar`.
- `LoginResponse` embeds a `UserProfileDTO` so clients have the full profile in the login response.
- `Route` gets a `createdBy` owner; `RouteController` records a row per `/api/routes` call from authenticated users so the `routesPlanned` contribution stat is real.
- New `GET /api/routes/user/{userId}` returns the user's routes (mirrors `GET /api/reports/user/{userId}`), so the frontend can render a user's route history. Reports are already covered by `ReportController`.
- `S3MediaService.deleteFile(url)` is reused by `DELETE /profile/avatar` to remove the underlying S3 object alongside the URL.
- Fixes a pre-existing config bug: `/error` was missing from `SecurityConfig` permitAll, so `@Valid` 400s got masked as 401 in real Tomcat (slice tests with MockMvc didn't catch it).

Drive-by: existing `GET /api/users` and `GET /api/users/{id}` now return `UserProfileDTO` instead of the raw `RegisteredUser`, closing a password-hash leak.

**Out of scope (separate tickets):** avatar replace-cleanup (orphans on re-upload), public-vs-private profile flag, username/handle field, pagination on `GET /api/routes/user/{userId}`, backfilling `routes.created_by` for existing anonymous routes.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
<!-- N/A — backend-only PR. Verified manually with curl: register → login (profile embedded), /me, GET /{id}/profile, PUT happy path (200), PUT short name (400), PUT cross-user (403), POST avatar (201 with real S3 URL), POST avatar wrong MIME (400), DELETE avatar (204, S3 object actually removed), DELETE cross-user (403), routesPlanned increments after a routing call. Swagger at /swagger-ui shows the new endpoints with bearer-auth locks. -->

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min