### PR TITLE
[Backend] Report Refactor Foundation

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
@@ -57,7 +57,8 @@ public class SecurityConfig {
                     .permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET,
                                 "/api/reports", "/api/reports/**",
-                                "/api/comments", "/api/comments/**"
+                                "/api/comments", "/api/comments/**",
+                                "/api/categories", "/api/categories/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportCategoryController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportCategoryController.java
@@ -1,0 +1,29 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.dto.ReportCategoryResponse;
+import com.bounswe2026group1.backend.service.ReportCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+public class ReportCategoryController {
+
+    private final ReportCategoryService categoryService;
+
+    @GetMapping
+    public List<ReportCategoryResponse> getAll() {
+        return categoryService.getAllAsTree();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ReportCategoryResponse> getById(@PathVariable Long id) {
+        return categoryService.getById(id)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/MeasurementWarning.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/MeasurementWarning.java
@@ -1,0 +1,12 @@
+package com.bounswe2026group1.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MeasurementWarning {
+
+    private String field;
+    private String message;
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportCategoryResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportCategoryResponse.java
@@ -1,0 +1,50 @@
+package com.bounswe2026group1.backend.dto;
+
+import com.bounswe2026group1.backend.model.ReportCategory;
+import com.bounswe2026group1.backend.model.ReportType;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+public class ReportCategoryResponse {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Long id;
+    private final String name;
+    private final ReportType type;
+    private final List<String> affectedProfiles;
+    private final Object measurementSchema;
+    private final List<ReportCategoryResponse> children;
+
+    public ReportCategoryResponse(ReportCategory category, List<ReportCategoryResponse> children) {
+        this.id = category.getId();
+        this.name = category.getName();
+        this.type = category.getType();
+        this.affectedProfiles = parseProfiles(category.getAffectedProfiles());
+        this.measurementSchema = parseSchema(category.getMeasurementSchema());
+        this.children = children;
+    }
+
+    private static List<String> parseProfiles(String json) {
+        if (json == null) return Collections.emptyList();
+        try {
+            return MAPPER.readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    private static Object parseSchema(String json) {
+        if (json == null) return null;
+        try {
+            return MAPPER.readValue(json, Object.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/exception/GlobalExceptionHandlers.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/exception/GlobalExceptionHandlers.java
@@ -5,6 +5,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Map;
+
 @RestControllerAdvice
 public class GlobalExceptionHandlers {
 
@@ -12,5 +14,10 @@ public class GlobalExceptionHandlers {
     public ResponseEntity<RoutingErrorResponse> handleRouting(RoutingException ex) {
         return ResponseEntity.status(ex.getStatus())
                 .body(new RoutingErrorResponse("routing_error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(MeasurementValidationException.class)
+    public ResponseEntity<Map<String, String>> handleMeasurementValidation(MeasurementValidationException ex) {
+        return ResponseEntity.badRequest().body(Map.of("error", ex.getMessage()));
     }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/exception/MeasurementValidationException.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/exception/MeasurementValidationException.java
@@ -1,0 +1,8 @@
+package com.bounswe2026group1.backend.exception;
+
+public class MeasurementValidationException extends RuntimeException {
+
+    public MeasurementValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/ReportCategory.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/ReportCategory.java
@@ -1,0 +1,43 @@
+package com.bounswe2026group1.backend.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "report_categories")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReportCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private ReportCategory parent;
+
+    // Null on child nodes — inherited from top-level parent
+    @Enumerated(EnumType.STRING)
+    private ReportType type;
+
+    // JSON array: e.g. ["WHEELCHAIR","STROLLER"] — defined on leaf nodes
+    @Column(name = "affected_profiles", columnDefinition = "TEXT")
+    private String affectedProfiles;
+
+    // JSON object defining numeric measurement fields for this category — null if none
+    @Column(name = "measurement_schema", columnDefinition = "TEXT")
+    private String measurementSchema;
+
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
+    private List<ReportCategory> children = new ArrayList<>();
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/ReportEnvironment.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/ReportEnvironment.java
@@ -1,0 +1,6 @@
+package com.bounswe2026group1.backend.model;
+
+public enum ReportEnvironment {
+    INDOOR,
+    OUTDOOR
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/ReportType.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/ReportType.java
@@ -1,0 +1,6 @@
+package com.bounswe2026group1.backend.model;
+
+public enum ReportType {
+    OBSTACLE,
+    FEATURE
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportCategoryRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportCategoryRepository.java
@@ -1,0 +1,11 @@
+package com.bounswe2026group1.backend.repository;
+
+import com.bounswe2026group1.backend.model.ReportCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReportCategoryRepository extends JpaRepository<ReportCategory, Long> {
+
+    List<ReportCategory> findByParentIsNull();
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/MeasurementValidator.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/MeasurementValidator.java
@@ -1,0 +1,74 @@
+package com.bounswe2026group1.backend.service;
+
+import com.bounswe2026group1.backend.dto.MeasurementWarning;
+import com.bounswe2026group1.backend.exception.MeasurementValidationException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class MeasurementValidator {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Validates user-submitted measurements against the category's schema.
+     * Hard limits (min/max) throw MeasurementValidationException.
+     * Soft limits (accessible_min/accessible_max) return warnings.
+     */
+    public List<MeasurementWarning> validate(String measurementsJson, String schemaJson) {
+        if (measurementsJson == null || schemaJson == null) {
+            return List.of();
+        }
+
+        try {
+            Map<String, Number> measurements = MAPPER.readValue(
+                    measurementsJson, new TypeReference<>() {});
+            Map<String, Map<String, Double>> schema = MAPPER.readValue(
+                    schemaJson, new TypeReference<>() {});
+
+            List<MeasurementWarning> warnings = new ArrayList<>();
+
+            for (Map.Entry<String, Number> entry : measurements.entrySet()) {
+                String field = entry.getKey();
+                double value = entry.getValue().doubleValue();
+                Map<String, Double> fieldSchema = schema.get(field);
+
+                if (fieldSchema == null) continue;
+
+                Double min = fieldSchema.get("min");
+                Double max = fieldSchema.get("max");
+                Double accessibleMin = fieldSchema.get("accessible_min");
+                Double accessibleMax = fieldSchema.get("accessible_max");
+
+                if (min != null && value < min) {
+                    throw new MeasurementValidationException(
+                            "Field '" + field + "' value " + value + " is below minimum of " + min);
+                }
+                if (max != null && value > max) {
+                    throw new MeasurementValidationException(
+                            "Field '" + field + "' value " + value + " exceeds maximum of " + max);
+                }
+                if (accessibleMax != null && value > accessibleMax) {
+                    warnings.add(new MeasurementWarning(field,
+                            "Exceeds accessible limit of " + accessibleMax));
+                }
+                if (accessibleMin != null && value < accessibleMin) {
+                    warnings.add(new MeasurementWarning(field,
+                            "Below accessible minimum of " + accessibleMin));
+                }
+            }
+
+            return warnings;
+
+        } catch (MeasurementValidationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new MeasurementValidationException("Invalid measurements format: " + e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportCategoryService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportCategoryService.java
@@ -1,0 +1,54 @@
+package com.bounswe2026group1.backend.service;
+
+import com.bounswe2026group1.backend.dto.ReportCategoryResponse;
+import com.bounswe2026group1.backend.model.ReportCategory;
+import com.bounswe2026group1.backend.repository.ReportCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportCategoryService {
+
+    private final ReportCategoryRepository categoryRepository;
+
+    public List<ReportCategoryResponse> getAllAsTree() {
+        List<ReportCategory> all = categoryRepository.findAll();
+
+        Map<Long, List<ReportCategory>> byParent = all.stream()
+                .filter(c -> c.getParent() != null)
+                .collect(Collectors.groupingBy(c -> c.getParent().getId()));
+
+        return all.stream()
+                .filter(c -> c.getParent() == null)
+                .map(root -> toResponse(root, byParent))
+                .collect(Collectors.toList());
+    }
+
+    public Optional<ReportCategoryResponse> getById(Long id) {
+        return categoryRepository.findById(id)
+                .map(category -> {
+                    Map<Long, List<ReportCategory>> byParent = categoryRepository.findAll().stream()
+                            .filter(c -> c.getParent() != null)
+                            .collect(Collectors.groupingBy(c -> c.getParent().getId()));
+                    return toResponse(category, byParent);
+                });
+    }
+
+    private ReportCategoryResponse toResponse(ReportCategory category, Map<Long, List<ReportCategory>> byParent) {
+        List<ReportCategoryResponse> children = byParent
+                .getOrDefault(category.getId(), List.of())
+                .stream()
+                .map(child -> toResponse(child, byParent))
+                .collect(Collectors.toList());
+
+        return new ReportCategoryResponse(category, children);
+    }
+}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -26,6 +26,40 @@ INSERT INTO reports (user_id, latitude, longitude, description, tag, status, agr
 SELECT 1, 41.085693, 29.044523, 'There is actually a ramp in north campus.', 'RAMP', 'VERIFIED', 4, 0, NOW(), 41.085700, 29.044550, 41.085650, 29.044500
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'There is actually a ramp in north campus.');
 
+-- Categories: insert with explicit IDs for self-referencing foreign keys
+-- Parent categories first (no parent_id), then leaf categories
+INSERT INTO report_categories (id, name, type, parent_id, affected_profiles, measurement_schema) VALUES
+    -- OBSTACLE parents
+    (1,  'Ramp Issues',      'OBSTACLE', NULL, NULL, NULL),
+    (2,  'Elevator Issues',  'OBSTACLE', NULL, NULL, NULL),
+    (3,  'Sidewalk Issues',  'OBSTACLE', NULL, NULL, NULL),
+    -- OBSTACLE leaves (no parent)
+    (4,  'Other',            'OBSTACLE', NULL, '["WHEELCHAIR","VISUAL_IMPAIRED","STROLLER","ELDERLY"]', NULL),
+    -- OBSTACLE leaves under Ramp Issues
+    (5,  'Missing Ramp',     NULL, 1, '["WHEELCHAIR","STROLLER"]', NULL),
+    (6,  'Too Steep',        NULL, 1, '["WHEELCHAIR"]',            '{"slope_percent":{"min":0,"max":100,"accessible_max":8.33},"width_cm":{"min":0,"max":500,"accessible_min":90}}'),
+    (7,  'Too Narrow',       NULL, 1, '["WHEELCHAIR","STROLLER"]', '{"width_cm":{"min":0,"max":500,"accessible_min":90}}'),
+    (8,  'Damaged Surface',  NULL, 1, '["WHEELCHAIR","VISUAL_IMPAIRED"]', NULL),
+    -- OBSTACLE leaves under Elevator Issues
+    (9,  'Out of Service',   NULL, 2, '["WHEELCHAIR"]', NULL),
+    (10, 'Missing',          NULL, 2, '["WHEELCHAIR"]', NULL),
+    -- OBSTACLE leaves under Sidewalk Issues
+    (11, 'Blocked',          NULL, 3, '["WHEELCHAIR","VISUAL_IMPAIRED","STROLLER","ELDERLY"]', NULL),
+    (12, 'Uneven Surface',   NULL, 3, '["WHEELCHAIR","VISUAL_IMPAIRED"]', NULL),
+    (13, 'No Curb Cut',      NULL, 3, '["WHEELCHAIR","STROLLER"]', NULL),
+    -- FEATURE leaves (all top-level)
+    (14, 'Ramp',             'FEATURE', NULL, '["WHEELCHAIR","STROLLER"]',   '{"slope_percent":{"min":0,"max":100,"accessible_max":8.33},"width_cm":{"min":0,"max":500,"accessible_min":90},"height_cm":{"min":0,"max":300}}'),
+    (15, 'Elevator',         'FEATURE', NULL, '["WHEELCHAIR"]',              '{"width_cm":{"min":0,"max":500,"accessible_min":90}}'),
+    (16, 'Accessible Toilet','FEATURE', NULL, '["WHEELCHAIR"]',              NULL),
+    (17, 'Tactile Paving',   'FEATURE', NULL, '["VISUAL_IMPAIRED"]',         NULL),
+    (18, 'Audio Traffic Light','FEATURE',NULL,'["VISUAL_IMPAIRED"]',         NULL),
+    (19, 'Accessible Parking','FEATURE',NULL, '["WHEELCHAIR"]',              NULL),
+    (20, 'Other',            'FEATURE', NULL, '["WHEELCHAIR","VISUAL_IMPAIRED","STROLLER","ELDERLY"]', NULL)
+ON CONFLICT (id) DO NOTHING;
+
+-- Advance sequence past the explicitly inserted IDs
+SELECT setval('report_categories_id_seq', (SELECT MAX(id) FROM report_categories));
+
 -- Comments: guard with NOT EXISTS on content + report_id
 INSERT INTO comments (content, author_id, report_id, created_at)
 SELECT 'Yes, people also fall from this ramp', 2, 1, NOW()


### PR DESCRIPTION
# 📝 Description
Related to #369 

Introduces the foundational infrastructure for the report system redesign (SPECS.md).
This PR is additive-only — no existing behavior is changed.

Adds:
- `ReportCategory` entity with hierarchical parent-child structure
- `ReportType` (OBSTACLE/FEATURE) and `ReportEnvironment` (INDOOR/OUTDOOR) enums
- `MeasurementValidator` service with hard limit validation (400) and soft limit warnings
- `GET /api/categories` and `GET /api/categories/{id}` endpoints (public)
- 20 seed categories (OBSTACLE tree + FEATURE list) in `data.sql`

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A — backend only, no UI changes.
`GET /api/categories` returns the full category tree including measurement schemas.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min