### PR TITLE
[Backend] Use Instant Instead Of LocalDateTime For API Timestamps

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/RampReportResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/RampReportResponse.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @NoArgsConstructor
@@ -18,7 +18,7 @@ public class RampReportResponse {
     private double longitude;
     private String description;
     private ReportStatus status;
-    private LocalDateTime publishDate;
+    private Instant publishDate;
     private double entryLatitude;
     private double entryLongitude;
     private double exitLatitude;

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
@@ -9,7 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Data
@@ -25,7 +25,7 @@ public class ReportResponse {
     private ReportStatus status;
     private int agrees;
     private int disagrees;
-    private LocalDateTime publishDate;
+    private Instant publishDate;
     private List<String> mediaUrls;
     private VoteType userVote;
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/Comment.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/Comment.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "comments")
@@ -29,11 +29,11 @@ public class Comment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "report_id")
     private Report report;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = Instant.now();
     }
 
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/Report.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/Report.java
@@ -3,7 +3,7 @@ package com.bounswe2026group1.backend.model;
 import jakarta.persistence.*;
 import org.hibernate.annotations.DiscriminatorFormula;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,7 +42,7 @@ public class Report {
     private int agrees = 0;
     private int disagrees = 0;
 
-    private LocalDateTime publishDate;
+    private Instant publishDate;
     @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
@@ -63,7 +63,7 @@ public class Report {
 
         // Report status defaults to PENDING on creation
         this.status = ReportStatus.PENDING;
-        this.publishDate = LocalDateTime.now();
+        this.publishDate = Instant.now();
     }
 
     public void incrementAgrees() { this.agrees++; }
@@ -105,7 +105,7 @@ public class Report {
         return disagrees;
     }
 
-    public LocalDateTime getPublishDate() {
+    public Instant getPublishDate() {
         return publishDate;
     }
 

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -1,0 +1,32 @@
+-- Migrate legacy timestamp columns to TIMESTAMPTZ so the API emits Z-suffixed
+-- timestamps via Jackson's Instant serializer. See issue #221.
+--
+-- Runs after Hibernate (spring.jpa.defer-datasource-initialization=true) and
+-- before data.sql. Idempotent: a no-op once the column is already TIMESTAMPTZ.
+-- Existing values are reinterpreted as UTC, which matches the production JVM
+-- timezone (containers run in UTC) so wall-clock instants are preserved.
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'reports'
+          AND column_name = 'publish_date'
+          AND data_type = 'timestamp without time zone'
+    ) THEN
+        ALTER TABLE reports
+            ALTER COLUMN publish_date TYPE TIMESTAMPTZ
+            USING publish_date AT TIME ZONE 'UTC';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'comments'
+          AND column_name = 'created_at'
+          AND data_type = 'timestamp without time zone'
+    ) THEN
+        ALTER TABLE comments
+            ALTER COLUMN created_at TYPE TIMESTAMPTZ
+            USING created_at AT TIME ZONE 'UTC';
+    END IF;
+END $$;


### PR DESCRIPTION
# 📝 Use Instant Instead Of LocalDateTime For API Timestamps
Fixes #221

Switches `Report.publishDate` and `Comment.createdAt` (and the matching DTOs) from `LocalDateTime` to `Instant` so Jackson emits Z-suffixed ISO-8601 timestamps. An idempotent `schema.sql` migrates existing `TIMESTAMP` columns to `TIMESTAMPTZ`, reinterpreting stored values as UTC to match the production JVM timezone.

# 📊 Type of Change
- [x] Bug fix
- [x] Refactoring

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A — wire-format change verified via Hibernate schema log: `publish_date timestamp(6) with time zone`, `created_at timestamp(6) with time zone`.

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min