### PR TITLE
[Backend] Implement Report Feed Endpoint

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportController.java
@@ -1,6 +1,7 @@
 package com.bounswe2026group1.backend.controller;
 
 import com.bounswe2026group1.backend.dto.CreateReportRequest;
+import com.bounswe2026group1.backend.dto.ReportFeedQueryRequest;
 import com.bounswe2026group1.backend.dto.ReportResponse;
 import com.bounswe2026group1.backend.dto.UpdateReportRequest;
 import com.bounswe2026group1.backend.service.ReportService;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,6 +24,12 @@ public class ReportController {
     @GetMapping
     public List<ReportResponse> getAll(@AuthenticationPrincipal String email) {
         return reportService.getAll(email);
+    }
+
+    @GetMapping("/feed")
+    public Page<ReportResponse> getFeed(@ModelAttribute ReportFeedQueryRequest query,
+                                        @AuthenticationPrincipal String email) {
+        return reportService.getFeed(query, email);
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportFeedQueryRequest.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportFeedQueryRequest.java
@@ -1,0 +1,21 @@
+package com.bounswe2026group1.backend.dto;
+
+import com.bounswe2026group1.backend.model.ReportEnvironment;
+import com.bounswe2026group1.backend.model.ReportType;
+import lombok.Data;
+
+/**
+ * Query parameters for {@code GET /api/reports/feed}.
+ */
+@Data
+public class ReportFeedQueryRequest {
+
+    private Long categoryId;
+    private ReportType type;
+    private ReportEnvironment environment;
+    /** Filter by author user id */
+    private Long userId;
+
+    private int page = 0;
+    private int size = 20;
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
@@ -2,7 +2,10 @@ package com.bounswe2026group1.backend.dto;
 
 import com.bounswe2026group1.backend.model.Media;
 import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.model.ReportCategory;
+import com.bounswe2026group1.backend.model.ReportEnvironment;
 import com.bounswe2026group1.backend.model.ReportStatus;
+import com.bounswe2026group1.backend.model.ReportType;
 import com.bounswe2026group1.backend.model.Tag;
 import com.bounswe2026group1.backend.model.VoteType;
 import lombok.AllArgsConstructor;
@@ -29,6 +32,12 @@ public class ReportResponse {
     private List<String> mediaUrls;
     private VoteType userVote;
 
+    /** Populated when the report is linked to the redesigned category tree */
+    private Long categoryId;
+    private String categoryName;
+    private ReportType reportType;
+    private ReportEnvironment environment;
+
     public static ReportResponse fromEntity(Report report) {
         return fromEntity(report, null);
     }
@@ -51,6 +60,17 @@ public class ReportResponse {
                         .toList()
         );
         response.setUserVote(userVote);
+        ReportCategory category = report.getCategory();
+        if (category != null) {
+            response.setCategoryId(category.getId());
+            response.setCategoryName(category.getName());
+            ReportType effectiveType = category.getType();
+            if (effectiveType == null && category.getParent() != null) {
+                effectiveType = category.getParent().getType();
+            }
+            response.setReportType(effectiveType);
+        }
+        response.setEnvironment(report.getEnvironment());
         return response;
     }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/Report.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/Report.java
@@ -52,6 +52,13 @@ public class Report {
     @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReportVerification> verifications = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private ReportCategory category;
+
+    @Enumerated(EnumType.STRING)
+    private ReportEnvironment environment;
+
     public Report() {
     }
 
@@ -127,6 +134,22 @@ public class Report {
 
     public void setTag(Tag tag) {
         this.tag = tag;
+    }
+
+    public ReportCategory getCategory() {
+        return category;
+    }
+
+    public void setCategory(ReportCategory category) {
+        this.category = category;
+    }
+
+    public ReportEnvironment getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(ReportEnvironment environment) {
+        this.environment = environment;
     }
 
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
@@ -4,6 +4,7 @@ import com.bounswe2026group1.backend.model.Report;
 import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -12,7 +13,7 @@ import java.util.Collection;
 import java.util.List;
 
 @Repository
-public interface ReportRepository extends JpaRepository<Report, Long> {
+public interface ReportRepository extends JpaRepository<Report, Long>, JpaSpecificationExecutor<Report> {
 
     List<Report> findByCreatedById(Long userId);
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/spec/ReportSpecifications.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/spec/ReportSpecifications.java
@@ -1,0 +1,60 @@
+package com.bounswe2026group1.backend.repository.spec;
+
+import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.model.ReportCategory;
+import com.bounswe2026group1.backend.model.ReportEnvironment;
+import com.bounswe2026group1.backend.model.ReportType;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ReportSpecifications {
+
+    private ReportSpecifications() {
+    }
+
+    /**
+     * Optional filters for the chronological feed. Type matches either the leaf category's
+     * {@link ReportCategory#getType()} or, when null on the leaf, the parent category's type
+     * (one-level inheritance; sufficient for demo trees).
+     */
+    public static Specification<Report> feedFilters(
+            Long categoryId,
+            ReportType type,
+            ReportEnvironment environment,
+            Long userId) {
+
+        return (root, query, cb) -> {
+            if (query != null) {
+                query.distinct(true);
+            }
+            List<Predicate> predicates = new ArrayList<>();
+            if (userId != null) {
+                predicates.add(cb.equal(root.get("createdBy").get("id"), userId));
+            }
+            if (environment != null) {
+                predicates.add(cb.equal(root.get("environment"), environment));
+            }
+            boolean categoryJoinNeeded = categoryId != null || type != null;
+            if (categoryJoinNeeded) {
+                Join<Report, ReportCategory> cat = root.join("category", JoinType.INNER);
+                Join<ReportCategory, ReportCategory> parent = cat.join("parent", JoinType.LEFT);
+                if (categoryId != null) {
+                    predicates.add(cb.equal(cat.get("id"), categoryId));
+                }
+                if (type != null) {
+                    Predicate onLeaf = cb.equal(cat.get("type"), type);
+                    Predicate inheritedFromParent = cb.and(
+                            cb.isNull(cat.get("type")),
+                            cb.equal(parent.get("type"), type));
+                    predicates.add(cb.or(onLeaf, inheritedFromParent));
+                }
+            }
+            return predicates.isEmpty() ? cb.conjunction() : cb.and(predicates.toArray(Predicate[]::new));
+        };
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -1,6 +1,7 @@
 package com.bounswe2026group1.backend.service;
 
 import com.bounswe2026group1.backend.dto.CreateReportRequest;
+import com.bounswe2026group1.backend.dto.ReportFeedQueryRequest;
 import com.bounswe2026group1.backend.dto.ReportResponse;
 import com.bounswe2026group1.backend.dto.UpdateReportRequest;
 import com.bounswe2026group1.backend.model.Location;
@@ -15,7 +16,12 @@ import com.bounswe2026group1.backend.repository.MediaRepository;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.repository.ReportRepository;
 import com.bounswe2026group1.backend.repository.ReportVerificationRepository;
+import com.bounswe2026group1.backend.repository.spec.ReportSpecifications;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.beans.factory.annotation.Value;
@@ -64,6 +70,24 @@ public class ReportService {
         return reportRepository.findByCreatedById(userId).stream()
                 .map(ReportResponse::fromEntity)
                 .toList();
+    }
+
+    /**
+     * Paged chronological feed (newest first). Optional filters match the redesigned category/type/environment model.
+     */
+    @Transactional(readOnly = true)
+    public Page<ReportResponse> getFeed(ReportFeedQueryRequest filters, String email) {
+        Long viewerId = resolveUserId(email);
+        Specification<Report> spec = ReportSpecifications.feedFilters(
+                filters.getCategoryId(),
+                filters.getType(),
+                filters.getEnvironment(),
+                filters.getUserId());
+        Sort sort = Sort.by(Sort.Direction.DESC, "publishDate");
+        PageRequest pageable = PageRequest.of(filters.getPage(), filters.getSize(), sort);
+        Page<Report> page = reportRepository.findAll(spec, pageable);
+        Map<Long, VoteType> votesByReportId = resolveUserVotes(viewerId, page.getContent());
+        return page.map(r -> ReportResponse.fromEntity(r, votesByReportId.get(r.getReportId())));
     }
 
     private Long resolveUserId(String email) {

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -208,7 +208,7 @@ class ReportServiceTest {
                 () -> reportService.delete(99L, "owner@test.com"));
 
         assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
-        verify(reportRepository, never()).delete(any());
+        verify(reportRepository, never()).delete(any(Report.class));
     }
 
     @Test
@@ -224,7 +224,7 @@ class ReportServiceTest {
                 () -> reportService.delete(1L, "other@test.com"));
 
         assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
-        verify(reportRepository, never()).delete(any());
+        verify(reportRepository, never()).delete(any(Report.class));
     }
 
     @Test


### PR DESCRIPTION
# 📝 Description

Implements a simplified, paginated `GET /api/reports/feed` endpoint to list accessibility reports. This endpoint utilizes the newly introduced hierarchical `ReportCategory` and `ReportEnvironment` entities for optional filtering.

Fixes #319

# 📊 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings

# ⏱️ Estimated Review Time

- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min