### PR TITLE
[Backend] Add PATCH To CORS Allowed Methods

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
@@ -98,7 +98,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOriginPatterns(List.of(allowedOrigins));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 


### PR DESCRIPTION
# 📝 Add PATCH To CORS Allowed Methods

Fixes #421

\`SecurityConfig#corsConfigurationSource()\` was missing \`PATCH\` from the allowed methods list, causing the browser preflight to reject every PATCH request to the admin endpoints introduced in #412 (ban, unban, change role, change report status). One-line addition unblocks the web admin dashboard (#419) and any future PATCH endpoint.

# 📊 Type of Change
- [x] Bug fix

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests _(no existing CORS tests in the suite; a one-line config change to a method list doesn't warrant standing up MockMvc preflight infrastructure on its own)_
- [x] All tests passed (CI will verify)

# 📸 Screenshots / Recordings

Before the fix, every admin PATCH from \`http://localhost:5173\` failed with:
\`\`\`
Access to fetch at 'http://localhost:8080/api/admin/reports/6/status' from origin 'http://localhost:5173'
has been blocked by CORS policy: Response to preflight request doesn't pass access control check:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
\`\`\`

# ⏱️ Estimated Review Time
- [x] < 5 min