### PR TITLE
[Backend] Accessibility Profiles and Constraint-Based Routing

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
@@ -6,12 +6,15 @@ import com.bounswe2026group1.backend.dto.routing.RouteResponse;
 import com.bounswe2026group1.backend.model.Location;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.model.Route;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
+import com.bounswe2026group1.backend.model.TravelMode;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.repository.RouteRepository;
 import com.bounswe2026group1.backend.service.RouteService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @RestController
@@ -35,8 +39,19 @@ public class RouteController {
 
     @PostMapping
     public ResponseEntity<List<RouteResponse>> getRouteOptions(@RequestBody RouteRequest request) {
-        List<RouteResponse> options = routeService.getRouteOptions(request);
-        recordPlannedRouteIfAuthenticated(request, options);
+        // Look up the caller once: we need their constraints + preferred mode for routing,
+        // and the user object again for recording the planned route. Anonymous → null.
+        RegisteredUser caller = currentUserOrNull();
+
+        Set<RoutingConstraint> constraints = caller != null && caller.getRoutingConstraints() != null
+                ? caller.getRoutingConstraints()
+                : Set.of();
+        TravelMode preferredMode = caller != null ? caller.getPreferredTravelMode() : null;
+
+        List<RouteResponse> options = routeService.getRouteOptions(request, constraints, preferredMode);
+        if (caller != null) {
+            recordPlannedRouteForUser(caller, request, options);
+        }
         return ResponseEntity.ok(options);
     }
 
@@ -48,17 +63,28 @@ public class RouteController {
     }
 
     /**
-     * Persist a single Route record so authenticated users can be credited with a "route planned"
-     * contribution stat (issue #302). Anonymous calls are not recorded.
+     * Resolve the authenticated caller's full {@link RegisteredUser} record so its
+     * routing-preference fields are available alongside the user's id. Returns null
+     * for anonymous callers and for tokens whose subject isn't in the DB.
      */
-    private void recordPlannedRouteIfAuthenticated(RouteRequest request, List<RouteResponse> options) {
-        if (options == null || options.isEmpty()) return;
-
+    private RegisteredUser currentUserOrNull() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !auth.isAuthenticated() || auth.getName() == null) return;
+        if (auth == null
+                || auth instanceof AnonymousAuthenticationToken
+                || !auth.isAuthenticated()
+                || auth.getName() == null) {
+            return null;
+        }
+        return registeredUserRepository.findByEmail(auth.getName()).orElse(null);
+    }
 
-        RegisteredUser user = registeredUserRepository.findByEmail(auth.getName()).orElse(null);
-        if (user == null) return;
+    /**
+     * Persist a single Route record so authenticated users get credited with a "route planned"
+     * contribution stat (issue #302). Failures are logged, not propagated, so a flaky
+     * persistence layer can never fail a successful routing response.
+     */
+    private void recordPlannedRouteForUser(RegisteredUser user, RouteRequest request, List<RouteResponse> options) {
+        if (options == null || options.isEmpty()) return;
 
         try {
             RouteResponse first = options.get(0);
@@ -72,7 +98,6 @@ public class RouteController {
                     .build();
             routeRepository.save(record);
         } catch (Exception e) {
-            // Don't fail the routing response if persistence fails — just log it.
             log.warn("Failed to persist planned route for user {}: {}", user.getId(), e.getMessage());
         }
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RoutingPreferencesController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RoutingPreferencesController.java
@@ -1,0 +1,55 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.dto.routing.RoutingPreferencesResponse;
+import com.bounswe2026group1.backend.dto.routing.UpdateRoutingPreferencesRequest;
+import com.bounswe2026group1.backend.service.RoutingPreferencesService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users/me/routing-preferences")
+@RequiredArgsConstructor
+public class RoutingPreferencesController {
+
+    private final RoutingPreferencesService routingPreferencesService;
+
+    @GetMapping
+    public ResponseEntity<?> get() {
+        String email = currentUserEmailOrNull();
+        if (email == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Authentication required.");
+        }
+        RoutingPreferencesResponse response = routingPreferencesService.getForEmail(email);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping
+    public ResponseEntity<?> put(@RequestBody UpdateRoutingPreferencesRequest request) {
+        String email = currentUserEmailOrNull();
+        if (email == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Authentication required.");
+        }
+        RoutingPreferencesResponse response = routingPreferencesService.update(email, request);
+        return ResponseEntity.ok(response);
+    }
+
+    private String currentUserEmailOrNull() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null
+                || auth instanceof AnonymousAuthenticationToken
+                || !auth.isAuthenticated()
+                || auth.getName() == null) {
+            return null;
+        }
+        return auth.getName();
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RouteResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RouteResponse.java
@@ -23,4 +23,11 @@ public class RouteResponse {
     private List<RouteStep> steps;
     private boolean hasObstacles;
     private List<Location> nodeCoordinates;
+
+    /**
+     * True when this alternative matches the authenticated user's
+     * {@code preferredTravelMode}. Only one alternative is flagged per response.
+     * Always {@code false} for anonymous callers and users without a preference.
+     */
+    private boolean preferred;
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RoutingConstraintInfo.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RoutingConstraintInfo.java
@@ -1,0 +1,24 @@
+package com.bounswe2026group1.backend.dto.routing;
+
+import com.bounswe2026group1.backend.model.RoutingConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * One entry in the {@code availableConstraints} catalog returned by
+ * {@code GET /api/users/me/routing-preferences}. Lets the frontend render
+ * a self-describing settings page without hard-coding labels.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoutingConstraintInfo {
+    private String name;
+    private String label;
+    private String description;
+
+    public static RoutingConstraintInfo fromEnum(RoutingConstraint constraint) {
+        return new RoutingConstraintInfo(constraint.name(), constraint.getLabel(), constraint.getDescription());
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RoutingPreferencesResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RoutingPreferencesResponse.java
@@ -1,0 +1,37 @@
+package com.bounswe2026group1.backend.dto.routing;
+
+import com.bounswe2026group1.backend.model.RoutingPreset;
+import com.bounswe2026group1.backend.model.TravelMode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Returned by {@code GET /api/users/me/routing-preferences} and after every
+ * {@code PUT}. Self-describing: the catalog fields let the frontend render
+ * settings without hard-coding any preset or constraint metadata.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoutingPreferencesResponse {
+
+    /** Currently selected preset. Always present; defaults to {@link RoutingPreset#NONE}. */
+    private RoutingPreset preferredPreset;
+
+    /** The user's selected constraints, sorted by enum name for stable output. */
+    private List<String> constraints;
+
+    /** Optional travel-mode preference; null if unset. */
+    private TravelMode preferredTravelMode;
+
+    /** All preset values with their bundled constraints — stable across users. */
+    private List<RoutingPresetInfo> availablePresets;
+
+    /** All constraint values with labels and descriptions — stable across users. */
+    private List<RoutingConstraintInfo> availableConstraints;
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RoutingPresetInfo.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RoutingPresetInfo.java
@@ -1,0 +1,38 @@
+package com.bounswe2026group1.backend.dto.routing;
+
+import com.bounswe2026group1.backend.model.RoutingConstraint;
+import com.bounswe2026group1.backend.model.RoutingPreset;
+import com.bounswe2026group1.backend.model.TravelMode;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * One entry in the {@code availablePresets} catalog returned by
+ * {@code GET /api/users/me/routing-preferences}. The {@code constraints} field
+ * lets the frontend preview which constraints a preset will apply before the
+ * user commits to it.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoutingPresetInfo {
+    private String name;
+    private String label;
+    private List<String> constraints;
+    private TravelMode defaultTravelMode;
+
+    public static RoutingPresetInfo fromEnum(RoutingPreset preset) {
+        List<String> constraintNames = preset.getConstraints().stream()
+                .map(RoutingConstraint::name)
+                .sorted()
+                .toList();
+        return new RoutingPresetInfo(
+                preset.name(),
+                preset.getLabel(),
+                constraintNames,
+                preset.getDefaultTravelMode());
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/UpdateRoutingPreferencesRequest.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/UpdateRoutingPreferencesRequest.java
@@ -1,0 +1,33 @@
+package com.bounswe2026group1.backend.dto.routing;
+
+import com.bounswe2026group1.backend.model.RoutingConstraint;
+import com.bounswe2026group1.backend.model.RoutingPreset;
+import com.bounswe2026group1.backend.model.TravelMode;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+/**
+ * PUT body for {@code /api/users/me/routing-preferences}. All fields optional;
+ * the service interprets which combination the caller sent:
+ *
+ * <ul>
+ *   <li>Only {@code preferredPreset} → constraints + travelMode are filled
+ *       from the preset definition.</li>
+ *   <li>Only {@code constraints} → preset is auto-detected via
+ *       {@link RoutingPreset#detectFromConstraints(Set)}.</li>
+ *   <li>Both → constraints win; preset becomes whatever
+ *       {@code detectFromConstraints} returns.</li>
+ *   <li>Neither → no-op (returns current state).</li>
+ * </ul>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateRoutingPreferencesRequest {
+    private RoutingPreset preferredPreset;
+    private Set<RoutingConstraint> constraints;
+    private TravelMode preferredTravelMode;
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/IssueHazard.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/IssueHazard.java
@@ -1,0 +1,7 @@
+package com.bounswe2026group1.backend.model;
+
+/**
+ * A single (ObjectType, IssueType) tuple — the smallest unit a routing constraint
+ * cares about when deciding whether a report should become an avoidance polygon.
+ */
+public record IssueHazard(ObjectType objectType, IssueType issueType) {}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/RegisteredUser.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/RegisteredUser.java
@@ -10,6 +10,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "registered_users")
@@ -59,6 +61,36 @@ public class RegisteredUser {
     @Column(length = 1024)
     private String avatarUrl;
 
+    // ───── Routing preferences (issue #365) ──────────────────────────────────
+
+    /**
+     * Named bundle the user picked. Constraints are still the source of truth
+     * for filtering — this field exists so the UI can show the preset label
+     * without re-deriving the bundle.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "preferred_preset", length = 32, columnDefinition = "VARCHAR(32) DEFAULT 'NONE'")
+    private RoutingPreset preferredPreset = RoutingPreset.NONE;
+
+    /**
+     * The user's selected routing constraints. Source of truth for the avoid-
+     * polygon filter; consulted on every authenticated routing call.
+     */
+    @ElementCollection(fetch = FetchType.EAGER, targetClass = RoutingConstraint.class)
+    @CollectionTable(name = "user_routing_constraints",
+            joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "constraint_value", length = 64)
+    @Enumerated(EnumType.STRING)
+    private Set<RoutingConstraint> routingConstraints = new HashSet<>();
+
+    /**
+     * Optional travel-mode preference. When set, the matching alternative in
+     * the {@code POST /api/routes} response is flagged {@code preferred:true}.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "preferred_travel_mode", length = 16)
+    private TravelMode preferredTravelMode;
+
     @PrePersist
     protected void onCreate() {
         if (this.registeredAt == null) {
@@ -66,6 +98,12 @@ public class RegisteredUser {
         }
         if (this.status == null) {
             this.status = UserStatus.ACTIVE;
+        }
+        if (this.preferredPreset == null) {
+            this.preferredPreset = RoutingPreset.NONE;
+        }
+        if (this.routingConstraints == null) {
+            this.routingConstraints = new HashSet<>();
         }
     }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingConstraint.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingConstraint.java
@@ -1,0 +1,132 @@
+package com.bounswe2026group1.backend.model;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.bounswe2026group1.backend.model.IssueType.*;
+import static com.bounswe2026group1.backend.model.ObjectType.*;
+
+/**
+ * High-level user-facing routing constraints. Each value carries the set of
+ * (ObjectType, IssueType) hazard tuples it covers. The avoid-polygon builder
+ * unions hazards across the user's selected constraints to decide which
+ * VERIFIED reports become avoidance polygons.
+ *
+ * Constraints intentionally cover only path-segment hazards (sidewalks, ramps,
+ * stairs, low overhead clearance). Door and elevator issues are destination-level
+ * and stay informational — they don't generate avoid polygons.
+ */
+public enum RoutingConstraint {
+
+    AVOID_STAIRS(
+            "Avoid stairs entirely",
+            "Routes will avoid sidewalk segments containing reported stairways.",
+            Set.of(
+                    new IssueHazard(STAIR, MISSING_HANDRAIL),
+                    new IssueHazard(STAIR, NO_LANDING),
+                    new IssueHazard(STAIR, TOO_NARROW),
+                    new IssueHazard(STAIR, SLIPPERY_SURFACE),
+                    new IssueHazard(STAIR, RISER_TOO_HIGH),
+                    new IssueHazard(STAIR, TREAD_TOO_SHALLOW),
+                    new IssueHazard(STAIR, NO_ANTI_SLIP),
+                    new IssueHazard(STAIR, OPEN_RISERS))),
+
+    REQUIRE_RAMPS(
+            "Prefer routes with ramps over steps",
+            "Treats reports of missing ramps as obstacles to route around.",
+            Set.of(new IssueHazard(RAMP, MISSING))),
+
+    AVOID_UNSAFE_RAMPS(
+            "Avoid unsafe ramps",
+            "Routes will avoid ramps reported as too steep, too narrow, missing handrails, missing landings, or slippery.",
+            Set.of(
+                    new IssueHazard(RAMP, TOO_STEEP),
+                    new IssueHazard(RAMP, TOO_NARROW),
+                    new IssueHazard(RAMP, NO_LANDING),
+                    new IssueHazard(RAMP, SLIPPERY_SURFACE),
+                    new IssueHazard(RAMP, MISSING_HANDRAIL))),
+
+    AVOID_NARROW_SIDEWALKS(
+            "Avoid narrow sidewalks",
+            "Routes will avoid sidewalks reported as too narrow for accessible passage.",
+            Set.of(new IssueHazard(SIDEWALK, TOO_NARROW))),
+
+    AVOID_LOW_CLEARANCE(
+            "Avoid low overhead clearance",
+            "Routes will avoid sidewalk segments with low-hanging branches, signs, or other overhead obstructions.",
+            Set.of(new IssueHazard(SIDEWALK, INSUFFICIENT_CLEARANCE))),
+
+    AVOID_SLIPPERY_SURFACES(
+            "Avoid slippery surfaces",
+            "Routes will avoid ramps, sidewalks, and stairs reported as slippery or lacking anti-slip surfaces.",
+            Set.of(
+                    new IssueHazard(RAMP, SLIPPERY_SURFACE),
+                    new IssueHazard(SIDEWALK, SLIPPERY_SURFACE),
+                    new IssueHazard(STAIR, SLIPPERY_SURFACE),
+                    new IssueHazard(STAIR, NO_ANTI_SLIP))),
+
+    REQUIRE_HANDRAILS(
+            "Require handrails on stairs and ramps",
+            "Routes will avoid stairs and ramps reported as missing handrails.",
+            Set.of(
+                    new IssueHazard(RAMP, MISSING_HANDRAIL),
+                    new IssueHazard(STAIR, MISSING_HANDRAIL))),
+
+    AVOID_BLOCKED_OR_MISSING_SIDEWALKS(
+            "Avoid blocked or missing sidewalks",
+            "Routes will avoid sidewalk segments reported as blocked by obstacles or missing entirely.",
+            Set.of(
+                    new IssueHazard(SIDEWALK, BLOCKED),
+                    new IssueHazard(SIDEWALK, MISSING))),
+
+    AVOID_UNSAFE_STAIRS(
+            "Avoid unsafe stairs (when stairs are unavoidable)",
+            "Routes will avoid stairs reported with high risers, shallow treads, missing landings, or open risers.",
+            Set.of(
+                    new IssueHazard(STAIR, OPEN_RISERS),
+                    new IssueHazard(STAIR, RISER_TOO_HIGH),
+                    new IssueHazard(STAIR, TREAD_TOO_SHALLOW),
+                    new IssueHazard(STAIR, NO_LANDING))),
+
+    AVOID_DAMAGED_TACTILE_PAVING(
+            "Avoid damaged tactile paving",
+            "Routes will avoid sidewalks with reported tactile-paving issues that may misdirect visually impaired users.",
+            // Currently maps to NO_TACTILE_PAVING. The IssueType will be renamed to
+            // TACTILE_PAVING_DAMAGED in a follow-up; only this hazard set updates.
+            Set.of(new IssueHazard(SIDEWALK, NO_TACTILE_PAVING)));
+
+    private final String label;
+    private final String description;
+    private final Set<IssueHazard> hazards;
+
+    RoutingConstraint(String label, String description, Set<IssueHazard> hazards) {
+        this.label = label;
+        this.description = description;
+        this.hazards = hazards;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Set<IssueHazard> getHazards() {
+        return hazards;
+    }
+
+    /**
+     * Union the hazard sets of the given constraints. Empty / null input → empty set
+     * (caller falls back to baseline behaviour).
+     */
+    public static Set<IssueHazard> expand(Set<RoutingConstraint> constraints) {
+        if (constraints == null || constraints.isEmpty()) {
+            return Set.of();
+        }
+        return constraints.stream()
+                .flatMap(c -> c.hazards.stream())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingConstraint.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingConstraint.java
@@ -88,11 +88,9 @@ public enum RoutingConstraint {
                     new IssueHazard(STAIR, TREAD_TOO_SHALLOW),
                     new IssueHazard(STAIR, NO_LANDING))),
 
-    AVOID_DAMAGED_TACTILE_PAVING(
-            "Avoid damaged tactile paving",
-            "Routes will avoid sidewalks with reported tactile-paving issues that may misdirect visually impaired users.",
-            // Currently maps to NO_TACTILE_PAVING. The IssueType will be renamed to
-            // TACTILE_PAVING_DAMAGED in a follow-up; only this hazard set updates.
+    AVOID_MISSING_TACTILE_PAVING(
+            "Avoid sidewalks lacking tactile paving",
+            "Routes will avoid sidewalks reported as missing tactile guidance strips for visually impaired users.",
             Set.of(new IssueHazard(SIDEWALK, NO_TACTILE_PAVING)));
 
     private final String label;

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingPreset.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingPreset.java
@@ -34,7 +34,7 @@ public enum RoutingPreset {
             EnumSet.of(
                     AVOID_LOW_CLEARANCE,
                     AVOID_BLOCKED_OR_MISSING_SIDEWALKS,
-                    AVOID_DAMAGED_TACTILE_PAVING),
+                    AVOID_MISSING_TACTILE_PAVING),
             TravelMode.WALKING),
 
     MOBILITY_LIMITED("Mobility limited (cane, walker, elderly)",

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingPreset.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingPreset.java
@@ -1,0 +1,91 @@
+package com.bounswe2026group1.backend.model;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static com.bounswe2026group1.backend.model.RoutingConstraint.*;
+
+/**
+ * Named bundles of {@link RoutingConstraint} values that the user can pick
+ * with one tap. Constraints are stored on the user as the source of truth;
+ * the preset is metadata so the UI can show "you have the Wheelchair user
+ * preset selected" without re-deriving the bundle on every PUT.
+ *
+ * {@link #CUSTOM} is the sentinel returned when a user's constraint set
+ * doesn't exactly match any preset — and {@link #NONE} is the explicit
+ * empty bundle.
+ */
+public enum RoutingPreset {
+
+    NONE("No preferences",
+            EnumSet.noneOf(RoutingConstraint.class),
+            null),
+
+    WHEELCHAIR_USER("Wheelchair user",
+            EnumSet.of(
+                    AVOID_STAIRS,
+                    REQUIRE_RAMPS,
+                    AVOID_UNSAFE_RAMPS,
+                    AVOID_NARROW_SIDEWALKS,
+                    AVOID_BLOCKED_OR_MISSING_SIDEWALKS),
+            TravelMode.WHEELCHAIR),
+
+    BLIND_OR_LOW_VISION("Blind or low vision",
+            EnumSet.of(
+                    AVOID_LOW_CLEARANCE,
+                    AVOID_BLOCKED_OR_MISSING_SIDEWALKS,
+                    AVOID_DAMAGED_TACTILE_PAVING),
+            TravelMode.WALKING),
+
+    MOBILITY_LIMITED("Mobility limited (cane, walker, elderly)",
+            EnumSet.of(
+                    REQUIRE_RAMPS,
+                    AVOID_UNSAFE_RAMPS,
+                    AVOID_SLIPPERY_SURFACES,
+                    REQUIRE_HANDRAILS,
+                    AVOID_UNSAFE_STAIRS),
+            TravelMode.WALKING),
+
+    /** Sentinel: returned by {@link #detectFromConstraints} when no preset matches. */
+    CUSTOM("Custom", EnumSet.noneOf(RoutingConstraint.class), null);
+
+    private final String label;
+    private final Set<RoutingConstraint> constraints;
+    private final TravelMode defaultTravelMode;
+
+    RoutingPreset(String label, Set<RoutingConstraint> constraints, TravelMode defaultTravelMode) {
+        this.label = label;
+        this.constraints = constraints;
+        this.defaultTravelMode = defaultTravelMode;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public Set<RoutingConstraint> getConstraints() {
+        return constraints;
+    }
+
+    public TravelMode getDefaultTravelMode() {
+        return defaultTravelMode;
+    }
+
+    /**
+     * Return the preset whose constraint set exactly matches the input, otherwise
+     * {@link #CUSTOM}. Empty input returns {@link #NONE}. {@link #CUSTOM} itself
+     * is never auto-detected.
+     */
+    public static RoutingPreset detectFromConstraints(Set<RoutingConstraint> constraints) {
+        if (constraints == null || constraints.isEmpty()) {
+            return NONE;
+        }
+        for (RoutingPreset preset : values()) {
+            if (preset == NONE || preset == CUSTOM) continue;
+            if (preset.constraints.equals(constraints)) {
+                return preset;
+            }
+        }
+        return CUSTOM;
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
@@ -31,26 +31,40 @@ public interface ReportRepository extends JpaRepository<Report, Long>, JpaSpecif
 
     List<Report> findByStatus(ReportStatus status);
 
+    /**
+     * Routing-only query: restricted to {@code environment = OUTDOOR} because the
+     * route geometry comes from ORS foot-walking on outdoor pedestrian network.
+     * Indoor reports (broken elevators, heavy doors, etc.) stay in the report
+     * system as informational data; they don't generate avoid polygons because
+     * routing can't navigate to or around them.
+     */
     @Query("""
             SELECT r FROM Report r
             WHERE r.status IN :statuses
             AND r.reportType = :type
+            AND r.environment = com.bounswe2026group1.backend.model.ReportEnvironment.OUTDOOR
             """)
     List<Report> findByTypeAndStatusIn(
             @Param("type") ReportType type,
             @Param("statuses") Collection<ReportStatus> statuses);
 
     /**
-     * Native query — caller MUST pass status names (e.g.
-     * {@code ReportStatus.VERIFIED.name()}), not enum values. Hibernate binds
-     * {@code Collection<Enum>} as ordinals (smallint) in native queries, which
-     * collides with the varchar column produced by {@code @Enumerated(STRING)}.
-     * Same goes for {@code type}.
+     * Routing-only native query.
+     *
+     * <p>Caller MUST pass status names (e.g. {@code ReportStatus.VERIFIED.name()})
+     * and the type name, not enum values. Hibernate binds {@code Collection<Enum>}
+     * as ordinals (smallint) in native queries, which collides with the varchar
+     * columns produced by {@code @Enumerated(STRING)}.
+     *
+     * <p>Filtered to {@code environment = 'OUTDOOR'} because the route geometry
+     * comes from ORS foot-walking on the outdoor pedestrian network. Indoor
+     * reports stay in the report system as informational data.
      */
     @Query(value = """
             SELECT r.* FROM reports r
             WHERE r.status IN (:statuses)
             AND r.report_type = :type
+            AND r.environment = 'OUTDOOR'
             AND ST_Within(r.location, ST_MakeEnvelope(:minLon, :minLat, :maxLon, :maxLat, 4326))
             """,
             nativeQuery = true)
@@ -62,10 +76,11 @@ public interface ReportRepository extends JpaRepository<Report, Long>, JpaSpecif
             @Param("maxLon") double maxLon,
             @Param("statuses") Collection<String> statuses);
 
-    /** Native query — caller MUST pass status names. See sibling method above. */
+    /** Routing-only native query. See sibling method above for binding + environment caveats. */
     @Query(value = """
             SELECT r.* FROM reports r
             WHERE r.status IN (:statuses)
+            AND r.environment = 'OUTDOOR'
             AND ST_Within(r.location, ST_MakeEnvelope(:minLon, :minLat, :maxLon, :maxLat, 4326))
             """,
             nativeQuery = true)

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
@@ -40,6 +40,13 @@ public interface ReportRepository extends JpaRepository<Report, Long>, JpaSpecif
             @Param("type") ReportType type,
             @Param("statuses") Collection<ReportStatus> statuses);
 
+    /**
+     * Native query — caller MUST pass status names (e.g.
+     * {@code ReportStatus.VERIFIED.name()}), not enum values. Hibernate binds
+     * {@code Collection<Enum>} as ordinals (smallint) in native queries, which
+     * collides with the varchar column produced by {@code @Enumerated(STRING)}.
+     * Same goes for {@code type}.
+     */
     @Query(value = """
             SELECT r.* FROM reports r
             WHERE r.status IN (:statuses)
@@ -48,13 +55,14 @@ public interface ReportRepository extends JpaRepository<Report, Long>, JpaSpecif
             """,
             nativeQuery = true)
     List<Report> findByTypeInBoundingBoxWithStatuses(
-            @Param("type") ReportType type,
+            @Param("type") String type,
             @Param("minLat") double minLat,
             @Param("maxLat") double maxLat,
             @Param("minLon") double minLon,
             @Param("maxLon") double maxLon,
-            @Param("statuses") Collection<ReportStatus> statuses);
+            @Param("statuses") Collection<String> statuses);
 
+    /** Native query — caller MUST pass status names. See sibling method above. */
     @Query(value = """
             SELECT r.* FROM reports r
             WHERE r.status IN (:statuses)
@@ -66,5 +74,5 @@ public interface ReportRepository extends JpaRepository<Report, Long>, JpaSpecif
             @Param("maxLat") double maxLat,
             @Param("minLon") double minLon,
             @Param("maxLon") double maxLon,
-            @Param("statuses") Collection<ReportStatus> statuses);
+            @Param("statuses") Collection<String> statuses);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ObstacleService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ObstacleService.java
@@ -1,9 +1,13 @@
 package com.bounswe2026group1.backend.service;
 
+import com.bounswe2026group1.backend.model.IssueHazard;
+import com.bounswe2026group1.backend.model.IssueType;
 import com.bounswe2026group1.backend.model.Location;
 import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.model.ReportObject;
 import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.ReportType;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
 import com.bounswe2026group1.backend.repository.ReportRepository;
 import org.locationtech.jts.geom.Point;
 import tools.jackson.databind.ObjectMapper;
@@ -13,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -39,14 +44,43 @@ public class ObstacleService {
     // -------------------------------------------------------------------------
 
     /**
-     * @return a GeoJSON MultiPolygon node for all non-rejected obstacle reports,
-     *         or null if none exist
+     * Backwards-compatible no-arg overload — same as the empty-constraint case,
+     * which preserves the pre-#365 baseline (every VERIFIED obstacle becomes
+     * a polygon).
      */
     public ObjectNode buildAvoidPolygons() {
+        return buildAvoidPolygons(Set.of());
+    }
+
+    /**
+     * Build the GeoJSON MultiPolygon avoid set for routing.
+     *
+     * <p>When {@code constraints} is empty the baseline is preserved: every
+     * VERIFIED obstacle report becomes an avoid polygon (anonymous and
+     * NONE-preset users get the historical "Accessible Route" behaviour).
+     *
+     * <p>When {@code constraints} is non-empty, only VERIFIED obstacle reports
+     * whose objects expose at least one {@link IssueHazard} matching a hazard
+     * in the expanded constraint set become polygons. Constraints can only
+     * narrow the avoid set, never widen it past the baseline.
+     *
+     * @return a GeoJSON MultiPolygon node, or null if no reports survive the filter
+     */
+    public ObjectNode buildAvoidPolygons(Set<RoutingConstraint> constraints) {
         // Fetch only VERIFIED obstacle reports for route avoidance.
         List<Report> obstacles = reportRepository.findByTypeAndStatusIn(ReportType.OBSTACLE, ACTIVE_STATUSES);
         if (obstacles.isEmpty()) {
             return null;
+        }
+
+        Set<IssueHazard> hazards = RoutingConstraint.expand(constraints);
+        if (!hazards.isEmpty()) {
+            obstacles = obstacles.stream()
+                    .filter(r -> reportMatchesAnyHazard(r, hazards))
+                    .toList();
+            if (obstacles.isEmpty()) {
+                return null;
+            }
         }
 
         ArrayNode multiPolygonCoordinates = objectMapper.createArrayNode();
@@ -67,6 +101,20 @@ public class ObstacleService {
         avoidPolygons.put("type", "MultiPolygon");
         avoidPolygons.set("coordinates", multiPolygonCoordinates);
         return avoidPolygons;
+    }
+
+    private static boolean reportMatchesAnyHazard(Report report, Set<IssueHazard> hazards) {
+        List<ReportObject> objects = report.getObjects();
+        if (objects == null || objects.isEmpty()) return false;
+        for (ReportObject obj : objects) {
+            if (obj.getObjectType() == null || obj.getIssues() == null) continue;
+            for (IssueType issue : obj.getIssues()) {
+                if (hazards.contains(new IssueHazard(obj.getObjectType(), issue))) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     // -------------------------------------------------------------------------

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ObstacleService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ObstacleService.java
@@ -36,6 +36,14 @@ public class ObstacleService {
     /** Only verified reports are used for route calculations. */
     private static final List<ReportStatus> ACTIVE_STATUSES = List.of(ReportStatus.VERIFIED);
 
+    /**
+     * String form of {@link #ACTIVE_STATUSES} for native-query callers — Hibernate
+     * binds {@code Collection<Enum>} as smallint ordinals in native queries, which
+     * doesn't match the varchar column produced by {@code @Enumerated(STRING)}.
+     */
+    private static final List<String> ACTIVE_STATUS_NAMES =
+            ACTIVE_STATUSES.stream().map(Enum::name).toList();
+
     private final ReportRepository reportRepository;
     private final ObjectMapper objectMapper;
 
@@ -130,8 +138,9 @@ public class ObstacleService {
         double maxLon = Math.max(start.getLongitude(), end.getLongitude()) + bufferDeg;
 
         // Fetch only VERIFIED FEATURE reports with entry/exit points for wheelchair routing.
+        // Native query — pass status/type as strings (see method javadoc on the repo).
         List<Report> candidates = reportRepository.findByTypeInBoundingBoxWithStatuses(
-                ReportType.FEATURE, minLat, maxLat, minLon, maxLon, ACTIVE_STATUSES);
+                ReportType.FEATURE.name(), minLat, maxLat, minLon, maxLon, ACTIVE_STATUS_NAMES);
 
         Report bestRamp = null;
         double minTotalDistance = Double.MAX_VALUE;
@@ -197,8 +206,9 @@ public class ObstacleService {
         double maxLon = pathPoints.stream().mapToDouble(Location::getLongitude).max().orElseThrow() + bufferDeg;
 
         // Fetch only VERIFIED reports in the path bounding box for route calculations.
+        // Native query — pass statuses as strings (see method javadoc on the repo).
         List<Report> candidates = reportRepository.findReportsInBoundingBoxWithStatuses(
-                minLat, maxLat, minLon, maxLon, ACTIVE_STATUSES);
+                minLat, maxLat, minLon, maxLon, ACTIVE_STATUS_NAMES);
 
         return candidates.stream()
                 .filter(r -> r.getReportType() == ReportType.OBSTACLE)

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ObstacleService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ObstacleService.java
@@ -190,11 +190,28 @@ public class ObstacleService {
     // -------------------------------------------------------------------------
 
     /**
-     * Returns all active negative reports that lie within
-     * {@value PATH_BUFFER_METERS} m
-     * of any segment of the given decoded path.
+     * Backwards-compatible overload — same as the empty-constraint case.
+     * Used by callers that don't have a user identity (e.g. anonymous routing,
+     * existing tests that pre-date the constraint mechanism).
      */
     public List<Report> findObstaclesOnPath(List<Location> pathPoints) {
+        return findObstaclesOnPath(pathPoints, Set.of());
+    }
+
+    /**
+     * Return VERIFIED OUTDOOR obstacle reports that lie within
+     * {@value PATH_BUFFER_METERS} m of any segment of the given decoded path
+     * AND are relevant to the caller's accessibility constraints.
+     *
+     * <p>When {@code constraints} is empty the baseline applies: every nearby
+     * VERIFIED OUTDOOR obstacle is returned (anonymous and NONE-preset users
+     * get the full set). When non-empty, the result is filtered to obstacles
+     * whose objects expose at least one hazard the user actually cares about
+     * — same predicate that {@link #buildAvoidPolygons(Set)} uses, so the
+     * {@code hasObstacles} flag on a route response stays consistent with
+     * which polygons would have been avoided.
+     */
+    public List<Report> findObstaclesOnPath(List<Location> pathPoints, Set<RoutingConstraint> constraints) {
         if (pathPoints.size() < 2) {
             return List.of();
         }
@@ -210,9 +227,12 @@ public class ObstacleService {
         List<Report> candidates = reportRepository.findReportsInBoundingBoxWithStatuses(
                 minLat, maxLat, minLon, maxLon, ACTIVE_STATUS_NAMES);
 
+        Set<IssueHazard> hazards = RoutingConstraint.expand(constraints);
+
         return candidates.stream()
                 .filter(r -> r.getReportType() == ReportType.OBSTACLE)
                 .filter(r -> r.getLocation() != null)
+                .filter(r -> hazards.isEmpty() || reportMatchesAnyHazard(r, hazards))
                 .filter(r -> isWithinPathBuffer(r.getLocation(), pathPoints))
                 .toList();
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -64,7 +64,10 @@ public class RouteService {
 
         if (fastestResult != null) {
             List<Location> pathPoints = PolylineDecoder.decode(fastestResult.getGeometry());
-            hasObstacles = !obstacleService.findObstaclesOnPath(pathPoints).isEmpty();
+            // hasObstacles must respect the user's constraints — otherwise a
+            // ⭐ preferred Fastest Route can warn about an obstacle the user
+            // already declared they don't care about.
+            hasObstacles = !obstacleService.findObstaclesOnPath(pathPoints, constraints).isEmpty();
 
             routes.add(RouteResponse.builder()
                     .routeLabel("Fastest Route")

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -6,6 +6,7 @@ import com.bounswe2026group1.backend.dto.routing.RouteStep;
 import com.bounswe2026group1.backend.dto.routing.RoutingDirectionsResult;
 import com.bounswe2026group1.backend.model.Location;
 import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
 import com.bounswe2026group1.backend.model.TravelMode;
 import tools.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -23,12 +25,36 @@ public class RouteService {
     private final OrsRoutingClient orsRoutingClient;
     private final ObstacleService obstacleService;
 
+    /**
+     * Backwards-compatible signature — anonymous routing path. Equivalent to
+     * {@link #getRouteOptions(RouteRequest, Set, TravelMode)} with no
+     * constraints and no preferred mode (no alternative is flagged
+     * {@code preferred:true}).
+     */
     public List<RouteResponse> getRouteOptions(RouteRequest request) {
+        return getRouteOptions(request, Set.of(), null);
+    }
+
+    /**
+     * Build the route alternatives, optionally filtering avoid polygons by
+     * the caller's accessibility constraints (#365) and flagging the
+     * alternative whose mode matches their preferred travel mode.
+     *
+     * @param request           start/end coordinates from the controller
+     * @param constraints       caller's selected routing constraints; empty for anonymous / NONE preset
+     * @param preferredMode     caller's preferred travel mode; null for no preference
+     */
+    public List<RouteResponse> getRouteOptions(
+            RouteRequest request,
+            Set<RoutingConstraint> constraints,
+            TravelMode preferredMode) {
+
         Location start = new Location(request.getStartLat(), request.getStartLon());
         Location end = new Location(request.getEndLat(), request.getEndLon());
 
-        // Build avoid polygons once — reused for routes 2 and 3
-        ObjectNode avoidPolygons = obstacleService.buildAvoidPolygons();
+        // Build avoid polygons once — reused for routes 2 and 3.
+        // Empty constraints preserves the pre-#365 baseline (every VERIFIED obstacle becomes a polygon).
+        ObjectNode avoidPolygons = obstacleService.buildAvoidPolygons(constraints);
 
         List<RouteResponse> routes = new ArrayList<>();
 
@@ -135,7 +161,27 @@ public class RouteService {
             routes.add(bestWheelchair);
         }
 
+        markPreferred(routes, preferredMode);
         return routes;
+    }
+
+    /**
+     * Flag at most one alternative as the user's preferred route. When the
+     * preferred mode is {@code WALKING} and an "Accessible Route" exists, it
+     * wins over the "Fastest Route" (the loop overwrites earlier matches, and
+     * the accessible route is always appended after the fastest one).
+     */
+    private static void markPreferred(List<RouteResponse> routes, TravelMode preferredMode) {
+        if (preferredMode == null) return;
+        RouteResponse winner = null;
+        for (RouteResponse r : routes) {
+            if (r.getMode() == preferredMode) {
+                winner = r; // keep updating — last match wins
+            }
+        }
+        if (winner != null) {
+            winner.setPreferred(true);
+        }
     }
 
     private static double haversineMeters(Location a, Location b) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RoutingPreferencesService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RoutingPreferencesService.java
@@ -59,10 +59,14 @@ public class RoutingPreferencesService {
             // Constraints win when both fields are sent — see UpdateRoutingPreferencesRequest contract.
             resolvedConstraints = sanitize(request.getConstraints());
         } else if (request.getPreferredPreset() != null) {
-            resolvedConstraints = EnumSet.copyOf(
-                    request.getPreferredPreset() == RoutingPreset.CUSTOM
-                            ? user.getRoutingConstraints()
-                            : request.getPreferredPreset().getConstraints());
+            Set<RoutingConstraint> source = request.getPreferredPreset() == RoutingPreset.CUSTOM
+                    ? user.getRoutingConstraints()
+                    : request.getPreferredPreset().getConstraints();
+            // EnumSet.copyOf rejects empty non-EnumSet collections; a fresh user
+            // sending {"preferredPreset":"CUSTOM"} hits exactly that path.
+            resolvedConstraints = (source == null || source.isEmpty())
+                    ? EnumSet.noneOf(RoutingConstraint.class)
+                    : EnumSet.copyOf(source);
         } else {
             resolvedConstraints = user.getRoutingConstraints();
         }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RoutingPreferencesService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RoutingPreferencesService.java
@@ -1,0 +1,127 @@
+package com.bounswe2026group1.backend.service;
+
+import com.bounswe2026group1.backend.dto.routing.RoutingConstraintInfo;
+import com.bounswe2026group1.backend.dto.routing.RoutingPreferencesResponse;
+import com.bounswe2026group1.backend.dto.routing.RoutingPresetInfo;
+import com.bounswe2026group1.backend.dto.routing.UpdateRoutingPreferencesRequest;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
+import com.bounswe2026group1.backend.model.RoutingPreset;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RoutingPreferencesService {
+
+    private final RegisteredUserRepository registeredUserRepository;
+
+    private static final List<RoutingPresetInfo> PRESET_CATALOG =
+            Arrays.stream(RoutingPreset.values())
+                    .map(RoutingPresetInfo::fromEnum)
+                    .toList();
+
+    private static final List<RoutingConstraintInfo> CONSTRAINT_CATALOG =
+            Arrays.stream(RoutingConstraint.values())
+                    .map(RoutingConstraintInfo::fromEnum)
+                    .toList();
+
+    @Transactional(readOnly = true)
+    public RoutingPreferencesResponse getForEmail(String email) {
+        return toResponse(loadUser(email));
+    }
+
+    /**
+     * Apply the request to the user's stored preferences. Resolves preset vs
+     * constraints per the contract on
+     * {@link UpdateRoutingPreferencesRequest}.
+     */
+    @Transactional
+    public RoutingPreferencesResponse update(String email, UpdateRoutingPreferencesRequest request) {
+        RegisteredUser user = loadUser(email);
+        if (request == null) {
+            return toResponse(user);
+        }
+
+        Set<RoutingConstraint> resolvedConstraints;
+        if (request.getConstraints() != null) {
+            // Constraints win when both fields are sent — see UpdateRoutingPreferencesRequest contract.
+            resolvedConstraints = sanitize(request.getConstraints());
+        } else if (request.getPreferredPreset() != null) {
+            resolvedConstraints = EnumSet.copyOf(
+                    request.getPreferredPreset() == RoutingPreset.CUSTOM
+                            ? user.getRoutingConstraints()
+                            : request.getPreferredPreset().getConstraints());
+        } else {
+            resolvedConstraints = user.getRoutingConstraints();
+        }
+
+        // Always derive the preset from the resolved constraint set so the
+        // displayed preset stays consistent with what's actually applied.
+        RoutingPreset detected = RoutingPreset.detectFromConstraints(resolvedConstraints);
+
+        user.setRoutingConstraints(new HashSet<>(resolvedConstraints));
+        user.setPreferredPreset(detected);
+
+        if (request.getPreferredTravelMode() != null) {
+            user.setPreferredTravelMode(request.getPreferredTravelMode());
+        } else if (request.getPreferredPreset() != null
+                && request.getPreferredPreset().getDefaultTravelMode() != null
+                && request.getConstraints() == null) {
+            // Only auto-fill the travel mode when the caller explicitly picked a preset
+            // and didn't override constraints — preserves explicit nulls otherwise.
+            user.setPreferredTravelMode(request.getPreferredPreset().getDefaultTravelMode());
+        }
+
+        registeredUserRepository.save(user);
+        return toResponse(user);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private RegisteredUser loadUser(String email) {
+        if (email == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+        }
+        return registeredUserRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
+    }
+
+    private static Set<RoutingConstraint> sanitize(Set<RoutingConstraint> input) {
+        // Drop nulls and duplicates that could slip through Jackson deserialization.
+        return input.stream().filter(c -> c != null).collect(Collectors.toCollection(HashSet::new));
+    }
+
+    private RoutingPreferencesResponse toResponse(RegisteredUser user) {
+        Set<RoutingConstraint> stored = user.getRoutingConstraints() == null
+                ? Set.of()
+                : user.getRoutingConstraints();
+        List<String> constraintNames = stored.stream()
+                .map(RoutingConstraint::name)
+                .sorted()
+                .toList();
+        RoutingPreset preset = user.getPreferredPreset() == null
+                ? RoutingPreset.NONE
+                : user.getPreferredPreset();
+        return RoutingPreferencesResponse.builder()
+                .preferredPreset(preset)
+                .constraints(constraintNames)
+                .preferredTravelMode(user.getPreferredTravelMode())
+                .availablePresets(PRESET_CATALOG)
+                .availableConstraints(CONSTRAINT_CATALOG)
+                .build();
+    }
+}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -26,6 +26,13 @@ INSERT INTO reports (user_id, location, description, report_type, environment, s
 SELECT 1, ST_SetSRID(ST_MakePoint(29.044523, 41.085693), 4326), 'There is actually a ramp in north campus.', 'FEATURE', 'OUTDOOR', 'VERIFIED', 4, 0, NOW(), 41.085700, 29.044550, 41.085650, 29.044500
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'There is actually a ramp in north campus.');
 
+-- VERIFIED OUTDOOR obstacle so the routing pipeline has at least one polygon
+-- to demonstrate after the environment=OUTDOOR filter is applied.
+-- Location: 41°05'06.1"N 29°02'38.7"E  (Boğaziçi north-campus walkway corridor)
+INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 3, ST_SetSRID(ST_MakePoint(29.044083, 41.085028), 4326), 'Sidewalk blocked by construction debris', 'OBSTACLE', 'OUTDOOR', 'VERIFIED', 5, 0, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'Sidewalk blocked by construction debris');
+
 -- Report objects: resolve report_id by description so this is FK-safe on re-seed
 INSERT INTO report_objects (report_id, object_type, measurements)
 SELECT r.report_id, 'RAMP', '{"slope_percent": 15, "width_cm": 80}'
@@ -50,6 +57,12 @@ SELECT r.report_id, 'RAMP', '{"slope_percent": 6, "width_cm": 120}'
 FROM reports r
 WHERE r.description = 'There is actually a ramp in north campus.'
   AND NOT EXISTS (SELECT 1 FROM report_objects ro WHERE ro.report_id = r.report_id AND ro.object_type = 'RAMP');
+
+INSERT INTO report_objects (report_id, object_type, measurements)
+SELECT r.report_id, 'SIDEWALK', NULL
+FROM reports r
+WHERE r.description = 'Sidewalk blocked by construction debris'
+  AND NOT EXISTS (SELECT 1 FROM report_objects ro WHERE ro.report_id = r.report_id AND ro.object_type = 'SIDEWALK');
 
 -- Report object issues: resolve report_object_id via join on report description + object_type
 INSERT INTO report_object_issues (report_object_id, issue_type)
@@ -79,6 +92,13 @@ FROM report_objects ro
 JOIN reports r ON ro.report_id = r.report_id
 WHERE r.description = 'Narrow passage on the route to dormitories' AND ro.object_type = 'SIDEWALK'
   AND NOT EXISTS (SELECT 1 FROM report_object_issues i WHERE i.report_object_id = ro.id AND i.issue_type = 'TOO_NARROW');
+
+INSERT INTO report_object_issues (report_object_id, issue_type)
+SELECT ro.id, 'BLOCKED'
+FROM report_objects ro
+JOIN reports r ON ro.report_id = r.report_id
+WHERE r.description = 'Sidewalk blocked by construction debris' AND ro.object_type = 'SIDEWALK'
+  AND NOT EXISTS (SELECT 1 FROM report_object_issues i WHERE i.report_object_id = ro.id AND i.issue_type = 'BLOCKED');
 
 -- Comments: resolve report_id via the parent report's description so this stays
 -- FK-safe even if reports get deleted/re-inserted with new auto-generated ids.

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesIntegrationTest.java
@@ -1,0 +1,263 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
+import com.bounswe2026group1.backend.model.RoutingPreset;
+import com.bounswe2026group1.backend.model.TravelMode;
+import com.bounswe2026group1.backend.model.UserRole;
+import com.bounswe2026group1.backend.model.UserStatus;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Full-context integration test for the routing-preferences API.
+ *
+ * Boots the real Spring container, talks to the H2 PostgreSQL-mode test DB,
+ * and round-trips actual {@link RegisteredUser} rows. Auth is mocked via
+ * {@code with(user(...))} so we don't need a real JWT. The user record itself
+ * is persisted before each test so the controller's {@code findByEmail} lookup
+ * succeeds.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class RoutingPreferencesIntegrationTest {
+
+    private static final String EMAIL = "prefs-test@test.com";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private RegisteredUserRepository registeredUserRepository;
+    @Autowired private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        registeredUserRepository.findByEmail(EMAIL).ifPresent(registeredUserRepository::delete);
+        RegisteredUser u = new RegisteredUser();
+        u.setName("Prefs Tester");
+        u.setEmail(EMAIL);
+        u.setPassword("hashed-password-not-used-in-tests");
+        u.setRole(UserRole.USER);
+        u.setStatus(UserStatus.ACTIVE);
+        u.setRoutingConstraints(new HashSet<>());
+        u.setPreferredPreset(RoutingPreset.NONE);
+        registeredUserRepository.save(u);
+    }
+
+    // ── Anonymous → 401 ─────────────────────────────────────────────────────
+
+    @Test
+    void get_returns401_whenAnonymous() throws Exception {
+        mockMvc.perform(get("/api/users/me/routing-preferences"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void put_returns401_whenAnonymous() throws Exception {
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"preferredPreset\":\"WHEELCHAIR_USER\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── GET on a fresh user ─────────────────────────────────────────────────
+
+    @Test
+    void get_freshUser_returnsNonePresetAndFullCatalog() throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.preferredPreset").value("NONE"))
+                .andExpect(jsonPath("$.constraints").isArray())
+                .andExpect(jsonPath("$.constraints").isEmpty())
+                .andExpect(jsonPath("$.preferredTravelMode").doesNotExist())
+                .andExpect(jsonPath("$.availablePresets").isArray())
+                .andExpect(jsonPath("$.availableConstraints").isArray())
+                .andReturn();
+
+        // Catalog must list every preset and every constraint, with non-empty labels/descriptions.
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("availablePresets")).hasSize(RoutingPreset.values().length);
+        assertThat(body.get("availableConstraints")).hasSize(RoutingConstraint.values().length);
+        for (JsonNode entry : body.get("availableConstraints")) {
+            assertThat(entry.get("label").asString()).isNotBlank();
+            assertThat(entry.get("description").asString()).isNotBlank();
+        }
+    }
+
+    // ── PUT preset only → constraints + travel mode auto-fill ───────────────
+
+    @Test
+    void put_presetOnly_fillsConstraintsAndTravelMode_andPersists() throws Exception {
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("preferredPreset", "WHEELCHAIR_USER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.preferredPreset").value("WHEELCHAIR_USER"))
+                .andExpect(jsonPath("$.preferredTravelMode").value("WHEELCHAIR"))
+                .andExpect(jsonPath("$.constraints", hasSize(
+                        RoutingPreset.WHEELCHAIR_USER.getConstraints().size())));
+
+        // DB persisted the change — round-trip verification.
+        RegisteredUser stored = registeredUserRepository.findByEmail(EMAIL).orElseThrow();
+        assertThat(stored.getPreferredPreset()).isEqualTo(RoutingPreset.WHEELCHAIR_USER);
+        assertThat(stored.getRoutingConstraints())
+                .containsExactlyInAnyOrderElementsOf(RoutingPreset.WHEELCHAIR_USER.getConstraints());
+        assertThat(stored.getPreferredTravelMode()).isEqualTo(TravelMode.WHEELCHAIR);
+    }
+
+    // ── PUT constraints matching a preset → auto-detect ─────────────────────
+
+    @Test
+    void put_constraintsMatchingPreset_autoDetectsThePreset() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "constraints", RoutingPreset.MOBILITY_LIMITED.getConstraints().stream()
+                        .map(Enum::name).toList()));
+
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.preferredPreset").value("MOBILITY_LIMITED"));
+    }
+
+    // ── PUT arbitrary constraints → CUSTOM ──────────────────────────────────
+
+    @Test
+    void put_arbitraryConstraints_setsPresetCustom() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "constraints", java.util.List.of("AVOID_LOW_CLEARANCE", "REQUIRE_HANDRAILS")));
+
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.preferredPreset").value("CUSTOM"))
+                .andExpect(jsonPath("$.constraints", hasSize(2)));
+    }
+
+    // ── PUT both preset + constraints → constraints win ─────────────────────
+
+    @Test
+    void put_bothPresetAndArbitraryConstraints_constraintsWin_presetBecomesCustom() throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of(
+                "preferredPreset", "WHEELCHAIR_USER",
+                "constraints", java.util.List.of("AVOID_LOW_CLEARANCE")));
+
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.preferredPreset").value("CUSTOM"))
+                .andExpect(jsonPath("$.constraints", hasSize(1)))
+                .andExpect(jsonPath("$.constraints[0]").value("AVOID_LOW_CLEARANCE"));
+    }
+
+    // ── PUT then GET → DB round-trip ────────────────────────────────────────
+
+    @Test
+    void putThenGet_roundTripsThroughTheDatabase() throws Exception {
+        // Set BLIND_OR_LOW_VISION via PUT
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("preferredPreset", "BLIND_OR_LOW_VISION"))))
+                .andExpect(status().isOk());
+
+        // GET the same user — values come back identical
+        mockMvc.perform(get("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.preferredPreset").value("BLIND_OR_LOW_VISION"))
+                .andExpect(jsonPath("$.preferredTravelMode").value("WALKING"))
+                .andExpect(jsonPath("$.constraints", hasSize(
+                        RoutingPreset.BLIND_OR_LOW_VISION.getConstraints().size())));
+    }
+
+    // ── Empty body → no-op ──────────────────────────────────────────────────
+
+    @Test
+    void put_emptyBody_isNoOp_returnsCurrentState() throws Exception {
+        // Seed: user picked WHEELCHAIR_USER previously.
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("preferredPreset", "WHEELCHAIR_USER"))))
+                .andExpect(status().isOk());
+
+        // PUT empty body — should not clobber.
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.preferredPreset").value("WHEELCHAIR_USER"))
+                .andExpect(jsonPath("$.preferredTravelMode").value("WHEELCHAIR"));
+    }
+
+    // ── Toggle workflow (ergonomics) ────────────────────────────────────────
+
+    @Test
+    void toggleWorkflow_pickPresetEditConstraintRePickPresetSnapsBack() throws Exception {
+        // 1. Pick WHEELCHAIR_USER preset
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("preferredPreset", "WHEELCHAIR_USER"))))
+                .andExpect(status().isOk());
+
+        // 2. Drop one constraint — preset becomes CUSTOM
+        java.util.List<String> droppedOne = RoutingPreset.WHEELCHAIR_USER.getConstraints().stream()
+                .skip(1)
+                .map(Enum::name)
+                .toList();
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("constraints", droppedOne))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.preferredPreset").value("CUSTOM"));
+
+        // 3. Re-add the dropped constraint — preset auto-snaps back to WHEELCHAIR_USER
+        java.util.List<String> fullSet = RoutingPreset.WHEELCHAIR_USER.getConstraints().stream()
+                .map(Enum::name)
+                .toList();
+        mockMvc.perform(put("/api/users/me/routing-preferences")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("constraints", fullSet))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.preferredPreset").value("WHEELCHAIR_USER"));
+    }
+
+    private static org.hamcrest.Matcher<java.util.Collection<?>> hasSize(int expected) {
+        return org.hamcrest.Matchers.hasSize(expected);
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
@@ -1,0 +1,241 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.dto.routing.RoutingDirectionsResult;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
+import com.bounswe2026group1.backend.model.RoutingPreset;
+import com.bounswe2026group1.backend.model.TravelMode;
+import com.bounswe2026group1.backend.model.UserRole;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.service.ObstacleService;
+import com.bounswe2026group1.backend.service.OrsRoutingClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end test for the routing-prefs → /api/routes flow.
+ *
+ * Boots the full Spring container, persists a real {@link RegisteredUser} with
+ * routing preferences set, mocks {@link OrsRoutingClient} so we don't hit
+ * external HTTP, and asserts the response shape:
+ *
+ * <ul>
+ *   <li>Anonymous callers: no alternative is flagged {@code preferred:true}.</li>
+ *   <li>Authenticated user with {@code preferredTravelMode}: matching
+ *       alternative is flagged {@code preferred:true}.</li>
+ *   <li>Authenticated user with constraint set: the constraint set actually
+ *       reaches {@link ObstacleService#buildAvoidPolygons(java.util.Set)}.</li>
+ * </ul>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class RoutingPreferencesRouteIntegrationTest {
+
+    private static final String EMAIL = "route-int@test.com";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private RegisteredUserRepository registeredUserRepository;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private OrsRoutingClient orsRoutingClient;
+    @MockitoBean private ObstacleService obstacleService;
+
+    private RegisteredUser user;
+
+    @BeforeEach
+    void setUp() {
+        registeredUserRepository.findByEmail(EMAIL).ifPresent(registeredUserRepository::delete);
+
+        user = new RegisteredUser();
+        user.setName("Route Tester");
+        user.setEmail(EMAIL);
+        user.setPassword("hashed-password-stub");
+        user.setRole(UserRole.USER);
+        user.setRoutingConstraints(new HashSet<>());
+        user.setPreferredPreset(RoutingPreset.NONE);
+        user = registeredUserRepository.save(user);
+
+        // Canned ORS response for every fetchDirections call (any mode, any avoid arg).
+        RoutingDirectionsResult canned = RoutingDirectionsResult.builder()
+                .distanceMeters(500.0)
+                .durationSeconds(360.0)
+                .geometry("")
+                .steps(List.of())
+                .build();
+        when(orsRoutingClient.fetchDirections(any(), any(), any(), any())).thenReturn(canned);
+        when(obstacleService.findClosestRampInBoundingBox(any(), any())).thenReturn(null);
+        when(obstacleService.findObstaclesOnPath(any())).thenReturn(List.of());
+        when(obstacleService.buildAvoidPolygons(any())).thenReturn(null);
+    }
+
+    private static String routeRequestBody() {
+        return """
+                {
+                    "startLat": 41.0850,
+                    "startLon": 29.0451,
+                    "endLat":   41.0820,
+                    "endLon":   29.0500,
+                    "mode":     "WALKING"
+                }
+                """;
+    }
+
+    // ── Anonymous → no preferred flag ───────────────────────────────────────
+
+    @Test
+    void anonymous_routeResponse_hasNoPreferredAlternative() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/routes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        for (JsonNode alternative : body) {
+            assertThat(alternative.get("preferred").asBoolean()).isFalse();
+        }
+    }
+
+    // ── User with preferredTravelMode → matching alternative flagged ────────
+
+    @Test
+    void authenticated_withWheelchairPreference_flagsWheelchairAlternative() throws Exception {
+        user.setPreferredTravelMode(TravelMode.WHEELCHAIR);
+        registeredUserRepository.save(user);
+
+        MvcResult result = mockMvc.perform(post("/api/routes")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        long preferredCount = 0;
+        boolean wheelchairFlagged = false;
+        for (JsonNode alternative : body) {
+            if (alternative.get("preferred").asBoolean()) {
+                preferredCount++;
+                if ("WHEELCHAIR".equals(alternative.get("mode").asString())) {
+                    wheelchairFlagged = true;
+                }
+            }
+        }
+        assertThat(preferredCount).as("at most one alternative should be flagged").isEqualTo(1);
+        assertThat(wheelchairFlagged).as("the wheelchair alternative should be the flagged one").isTrue();
+    }
+
+    @Test
+    void authenticated_withWalkingPreference_flagsAccessibleWalkingOverFastest() throws Exception {
+        // Make avoid polygons non-null so the "Accessible Route" alternative is built.
+        when(obstacleService.buildAvoidPolygons(any())).thenReturn(objectMapper.createObjectNode());
+
+        user.setPreferredTravelMode(TravelMode.WALKING);
+        registeredUserRepository.save(user);
+
+        MvcResult result = mockMvc.perform(post("/api/routes")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        // The Accessible Route is appended after the Fastest Route, so it wins the
+        // last-match flag in markPreferred(). The Fastest Route must not be flagged.
+        for (JsonNode alternative : body) {
+            String label = alternative.get("routeLabel").asString();
+            boolean preferred = alternative.get("preferred").asBoolean();
+            if ("Accessible Route".equals(label)) {
+                assertThat(preferred).as("Accessible Route should be the preferred alternative").isTrue();
+            } else if ("Fastest Route".equals(label)) {
+                assertThat(preferred).as("Fastest Route must NOT be the preferred alternative").isFalse();
+            }
+        }
+    }
+
+    // ── User with constraints → constraints reach ObstacleService ───────────
+
+    @Test
+    void authenticated_withWheelchairUserPreset_passesConstraintsToObstacleService() throws Exception {
+        user.setPreferredPreset(RoutingPreset.WHEELCHAIR_USER);
+        user.setRoutingConstraints(new HashSet<>(RoutingPreset.WHEELCHAIR_USER.getConstraints()));
+        user.setPreferredTravelMode(TravelMode.WHEELCHAIR);
+        registeredUserRepository.save(user);
+
+        mockMvc.perform(post("/api/routes")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Set<RoutingConstraint>> captor = ArgumentCaptor.forClass(Set.class);
+        verify(obstacleService).buildAvoidPolygons(captor.capture());
+        assertThat(captor.getValue())
+                .as("constraint set passed to ObstacleService should match the user's stored set")
+                .containsExactlyInAnyOrderElementsOf(RoutingPreset.WHEELCHAIR_USER.getConstraints());
+    }
+
+    @Test
+    void anonymous_passesEmptyConstraintsToObstacleService() throws Exception {
+        mockMvc.perform(post("/api/routes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Set<RoutingConstraint>> captor = ArgumentCaptor.forClass(Set.class);
+        verify(obstacleService).buildAvoidPolygons(captor.capture());
+        assertThat(captor.getValue()).isEmpty();
+    }
+
+    // ── User without preferredTravelMode → no flag ──────────────────────────
+
+    @Test
+    void authenticated_withoutPreferredTravelMode_flagsNoAlternative() throws Exception {
+        user.setPreferredTravelMode(null);
+        registeredUserRepository.save(user);
+
+        MvcResult result = mockMvc.perform(post("/api/routes")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        for (JsonNode alternative : body) {
+            assertThat(alternative.get("preferred").asBoolean()).isFalse();
+        }
+
+        // ObstacleService should still receive an empty constraint set (NONE preset).
+        verify(obstacleService, atLeastOnce()).buildAvoidPolygons(eq(Set.of()));
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
@@ -90,7 +90,7 @@ class RoutingPreferencesRouteIntegrationTest {
                 .build();
         when(orsRoutingClient.fetchDirections(any(), any(), any(), any())).thenReturn(canned);
         when(obstacleService.findClosestRampInBoundingBox(any(), any())).thenReturn(null);
-        when(obstacleService.findObstaclesOnPath(any())).thenReturn(List.of());
+        when(obstacleService.findObstaclesOnPath(any(), any())).thenReturn(List.of());
         when(obstacleService.buildAvoidPolygons(any())).thenReturn(null);
     }
 

--- a/backend/src/test/java/com/bounswe2026group1/backend/model/RoutingConstraintTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/model/RoutingConstraintTest.java
@@ -1,0 +1,88 @@
+package com.bounswe2026group1.backend.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoutingConstraintTest {
+
+    @Test
+    void everyConstraint_carriesAtLeastOneHazard() {
+        for (RoutingConstraint c : RoutingConstraint.values()) {
+            assertNotNull(c.getHazards(), c.name() + " hazard set must not be null");
+            assertFalse(c.getHazards().isEmpty(), c.name() + " must have at least one hazard");
+            assertNotNull(c.getLabel(), c.name() + " must have a label");
+            assertNotNull(c.getDescription(), c.name() + " must have a description");
+        }
+    }
+
+    @Test
+    void hazardSets_areInternallyConsistent() {
+        // Every hazard's IssueType must be valid for its ObjectType — catches a typo
+        // in the constraint definition that would otherwise generate dead polygons.
+        for (RoutingConstraint c : RoutingConstraint.values()) {
+            for (IssueHazard h : c.getHazards()) {
+                assertTrue(h.issueType().isValidFor(h.objectType()),
+                        c.name() + " maps a hazard (" + h.objectType() + ", " + h.issueType()
+                                + ") that the IssueType.validFor catalog rejects.");
+            }
+        }
+    }
+
+    @Test
+    void expand_emptyOrNullInput_returnsEmptySet() {
+        assertTrue(RoutingConstraint.expand(null).isEmpty());
+        assertTrue(RoutingConstraint.expand(Set.of()).isEmpty());
+        assertTrue(RoutingConstraint.expand(EnumSet.noneOf(RoutingConstraint.class)).isEmpty());
+    }
+
+    @Test
+    void expand_singleConstraint_returnsItsHazards() {
+        Set<IssueHazard> result = RoutingConstraint.expand(EnumSet.of(RoutingConstraint.AVOID_LOW_CLEARANCE));
+        assertEquals(Set.of(new IssueHazard(ObjectType.SIDEWALK, IssueType.INSUFFICIENT_CLEARANCE)), result);
+    }
+
+    @Test
+    void expand_multipleConstraints_unionsHazardSets() {
+        Set<IssueHazard> result = RoutingConstraint.expand(EnumSet.of(
+                RoutingConstraint.REQUIRE_HANDRAILS,
+                RoutingConstraint.AVOID_LOW_CLEARANCE));
+        assertEquals(Set.of(
+                new IssueHazard(ObjectType.RAMP, IssueType.MISSING_HANDRAIL),
+                new IssueHazard(ObjectType.STAIR, IssueType.MISSING_HANDRAIL),
+                new IssueHazard(ObjectType.SIDEWALK, IssueType.INSUFFICIENT_CLEARANCE)),
+                result);
+    }
+
+    @Test
+    void expand_overlappingConstraints_dedupesHazards() {
+        // Both AVOID_UNSAFE_RAMPS and REQUIRE_HANDRAILS contain (RAMP, MISSING_HANDRAIL).
+        // The union must not duplicate it.
+        Set<IssueHazard> result = RoutingConstraint.expand(EnumSet.of(
+                RoutingConstraint.AVOID_UNSAFE_RAMPS,
+                RoutingConstraint.REQUIRE_HANDRAILS));
+        long handrailHazards = result.stream()
+                .filter(h -> h.objectType() == ObjectType.RAMP && h.issueType() == IssueType.MISSING_HANDRAIL)
+                .count();
+        assertEquals(1, handrailHazards, "Overlap between constraints must not duplicate hazards");
+    }
+
+    @Test
+    void avoidStairs_coversEveryStairIssue() {
+        // The AVOID_STAIRS constraint is meant to be a catch-all for any reported
+        // stair-related issue. If a new stair IssueType is added later, this test
+        // surfaces the gap so it gets explicitly added to the constraint.
+        Set<IssueHazard> hazards = RoutingConstraint.AVOID_STAIRS.getHazards();
+        Set<IssueType> stairIssues = Set.of(
+                IssueType.MISSING_HANDRAIL, IssueType.NO_LANDING, IssueType.TOO_NARROW,
+                IssueType.SLIPPERY_SURFACE, IssueType.RISER_TOO_HIGH, IssueType.TREAD_TOO_SHALLOW,
+                IssueType.NO_ANTI_SLIP, IssueType.OPEN_RISERS);
+        for (IssueType issue : stairIssues) {
+            assertTrue(hazards.contains(new IssueHazard(ObjectType.STAIR, issue)),
+                    "AVOID_STAIRS missing (STAIR, " + issue + ")");
+        }
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/model/RoutingPresetTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/model/RoutingPresetTest.java
@@ -1,0 +1,99 @@
+package com.bounswe2026group1.backend.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoutingPresetTest {
+
+    @Test
+    void detectFromConstraints_emptyOrNull_returnsNone() {
+        assertEquals(RoutingPreset.NONE, RoutingPreset.detectFromConstraints(null));
+        assertEquals(RoutingPreset.NONE, RoutingPreset.detectFromConstraints(Set.of()));
+        assertEquals(RoutingPreset.NONE,
+                RoutingPreset.detectFromConstraints(EnumSet.noneOf(RoutingConstraint.class)));
+    }
+
+    @Test
+    void detectFromConstraints_exactPresetMatch_returnsThatPreset() {
+        for (RoutingPreset preset : RoutingPreset.values()) {
+            if (preset == RoutingPreset.NONE || preset == RoutingPreset.CUSTOM) continue;
+            assertEquals(preset,
+                    RoutingPreset.detectFromConstraints(preset.getConstraints()),
+                    preset.name() + " should round-trip through detectFromConstraints");
+        }
+    }
+
+    @Test
+    void detectFromConstraints_arbitrarySet_returnsCustom() {
+        Set<RoutingConstraint> custom = EnumSet.of(
+                RoutingConstraint.AVOID_LOW_CLEARANCE,
+                RoutingConstraint.REQUIRE_HANDRAILS);
+        // The mix above doesn't match any preset bundle.
+        assertEquals(RoutingPreset.CUSTOM, RoutingPreset.detectFromConstraints(custom));
+    }
+
+    @Test
+    void detectFromConstraints_supersetOfPreset_returnsCustom() {
+        // WHEELCHAIR_USER plus an extra constraint → no longer matches any preset.
+        Set<RoutingConstraint> superset = new HashSet<>(RoutingPreset.WHEELCHAIR_USER.getConstraints());
+        superset.add(RoutingConstraint.AVOID_LOW_CLEARANCE);
+        assertEquals(RoutingPreset.CUSTOM, RoutingPreset.detectFromConstraints(superset));
+    }
+
+    @Test
+    void detectFromConstraints_subsetOfPreset_returnsCustom() {
+        // Drop one constraint from WHEELCHAIR_USER — should not be auto-detected as
+        // any preset because the bundle doesn't match exactly.
+        Set<RoutingConstraint> subset = new HashSet<>(RoutingPreset.WHEELCHAIR_USER.getConstraints());
+        subset.remove(subset.iterator().next());
+        assertEquals(RoutingPreset.CUSTOM, RoutingPreset.detectFromConstraints(subset));
+    }
+
+    @Test
+    void detectFromConstraints_neverReturnsCustomItself() {
+        // CUSTOM is a sentinel — its own (empty) constraint set must not auto-detect to itself,
+        // it should auto-detect to NONE.
+        assertEquals(RoutingPreset.NONE,
+                RoutingPreset.detectFromConstraints(RoutingPreset.CUSTOM.getConstraints()));
+    }
+
+    @Test
+    void presetConstraints_areAllPathLevel_noElevatorOrDoorTuples() {
+        // Path-level discipline check: presets should only bundle constraints that
+        // map to sidewalk/ramp/stair hazards. Door and elevator hazards are
+        // destination-level and live outside the routing-preference model.
+        for (RoutingPreset preset : RoutingPreset.values()) {
+            for (RoutingConstraint c : preset.getConstraints()) {
+                for (IssueHazard h : c.getHazards()) {
+                    assertNotEquals(ObjectType.DOOR, h.objectType(),
+                            preset.name() + " bundles " + c.name()
+                                    + " which contains a DOOR hazard — destination-level, not path-level");
+                    assertNotEquals(ObjectType.ELEVATOR, h.objectType(),
+                            preset.name() + " bundles " + c.name()
+                                    + " which contains an ELEVATOR hazard — destination-level, not path-level");
+                }
+            }
+        }
+    }
+
+    @Test
+    void wheelchairPreset_defaultsToWheelchairTravelMode() {
+        assertEquals(TravelMode.WHEELCHAIR, RoutingPreset.WHEELCHAIR_USER.getDefaultTravelMode());
+    }
+
+    @Test
+    void blindAndMobilityPresets_defaultToWalking() {
+        assertEquals(TravelMode.WALKING, RoutingPreset.BLIND_OR_LOW_VISION.getDefaultTravelMode());
+        assertEquals(TravelMode.WALKING, RoutingPreset.MOBILITY_LIMITED.getDefaultTravelMode());
+    }
+
+    @Test
+    void nonePreset_hasNoDefaultTravelMode() {
+        assertNull(RoutingPreset.NONE.getDefaultTravelMode());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/AdminUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/AdminUserServiceTest.java
@@ -44,9 +44,9 @@ class AdminUserServiceTest {
     @BeforeEach
     void setUp() {
         adminUser = new RegisteredUser(1L, "Admin", "admin@test.com", "hash", UserRole.ADMIN,
-                UserStatus.ACTIVE, null, 0, null, null);
+                UserStatus.ACTIVE, null, 0, null, null, null, null, null);
         regularUser = new RegisteredUser(2L, "User", "user@test.com", "hash", UserRole.USER,
-                UserStatus.ACTIVE, null, 0, null, null);
+                UserStatus.ACTIVE, null, 0, null, null, null, null, null);
     }
 
     // --- listUsers ---
@@ -170,7 +170,7 @@ class AdminUserServiceTest {
     @Test
     void changeRole_Fail_LastAdmin() {
         RegisteredUser anotherAdmin = new RegisteredUser(3L, "Admin2", "admin2@test.com", "hash", UserRole.ADMIN,
-                UserStatus.ACTIVE, null, 0, null, null);
+                UserStatus.ACTIVE, null, 0, null, null, null, null, null);
         when(userRepository.findById(3L)).thenReturn(Optional.of(anotherAdmin));
         when(userRepository.countByRole(UserRole.ADMIN)).thenReturn(1L);
 
@@ -190,7 +190,7 @@ class AdminUserServiceTest {
         when(userRepository.existsByEmail("new@test.com")).thenReturn(false);
         when(passwordEncoder.encode(any())).thenReturn("encoded");
         RegisteredUser saved = new RegisteredUser(5L, "New", "new@test.com", "encoded", UserRole.USER,
-                UserStatus.ACTIVE, null, 0, null, null);
+                UserStatus.ACTIVE, null, 0, null, null, null, null, null);
         when(userRepository.save(any())).thenReturn(saved);
 
         AdminCreateUserRequest req = new AdminCreateUserRequest();
@@ -249,7 +249,7 @@ class AdminUserServiceTest {
     @Test
     void deleteUser_Fail_LastAdmin() {
         RegisteredUser anotherAdmin = new RegisteredUser(3L, "Admin2", "admin2@test.com", "hash", UserRole.ADMIN,
-                UserStatus.ACTIVE, null, 0, null, null);
+                UserStatus.ACTIVE, null, 0, null, null, null, null, null);
         when(userRepository.findById(3L)).thenReturn(Optional.of(anotherAdmin));
         when(userRepository.countByRole(UserRole.ADMIN)).thenReturn(1L);
 

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceConstraintIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceConstraintIntegrationTest.java
@@ -185,6 +185,26 @@ class ObstacleServiceConstraintIntegrationTest extends AbstractPostgisIntegratio
         assertThat(polygons.get("coordinates")).hasSize(1);
     }
 
+    @Test
+    void buildAvoidPolygons_indoorObstacles_areFilteredOutOfTheBaselineToo() {
+        // Indoor obstacles (broken elevators, heavy doors) must never become avoid
+        // polygons — ORS foot-walking can't navigate inside buildings, so a polygon
+        // around an indoor point is geometrically meaningless.
+        Report indoorElevator = new Report(author, GeoUtils.point4326(41.0855, 29.0456),
+                "Indoor broken elevator", ReportType.OBSTACLE, ReportEnvironment.INDOOR);
+        indoorElevator.setStatus(ReportStatus.VERIFIED);
+        indoorElevator.getObjects().add(new ReportObject(indoorElevator,
+                ObjectType.ELEVATOR, EnumSet.of(IssueType.OUT_OF_SERVICE), null));
+        reportRepository.save(indoorElevator);
+
+        // Empty constraints → baseline behaviour (every VERIFIED OUTDOOR obstacle).
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(Set.of());
+
+        assertThat(polygons).isNotNull();
+        // Still 3 (the original seeded OUTDOOR obstacles) — the new INDOOR one is excluded.
+        assertThat(polygons.get("coordinates")).hasSize(3);
+    }
+
     private void persistObstacle(double lat, double lon, ObjectType objectType, IssueType issue) {
         Report r = new Report(author, GeoUtils.point4326(lat, lon),
                 objectType + " " + issue, ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceConstraintIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceConstraintIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.bounswe2026group1.backend.service;
 
 import com.bounswe2026group1.backend.model.IssueType;
+import com.bounswe2026group1.backend.model.Location;
 import com.bounswe2026group1.backend.model.ObjectType;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.model.Report;
@@ -132,6 +133,38 @@ class ObstacleServiceConstraintIntegrationTest extends AbstractPostgisIntegratio
                 EnumSet.of(RoutingConstraint.AVOID_DAMAGED_TACTILE_PAVING));
 
         assertThat(polygons).isNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // Regression: native-query enum binding (issue: prod /api/routes 500)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void findObstaclesOnPath_executesAgainstPostgisWithoutEnumBindingError() {
+        // findObstaclesOnPath() uses native query findReportsInBoundingBoxWithStatuses,
+        // which historically broke because Hibernate binds Collection<ReportStatus> as
+        // smallint ordinals in native queries (clashing with the varchar status column).
+        // The fix is to pass status names (strings); this test fails if anyone reverts.
+        Location p1 = new Location(41.0850, 29.0451);
+        Location p2 = new Location(41.0852, 29.0453);
+        List<Report> obstacles = obstacleService.findObstaclesOnPath(List.of(p1, p2));
+
+        // We don't assert a specific count — what matters is the call doesn't throw
+        // an InvalidDataAccessResourceUsageException ("operator does not exist:
+        // character varying = smallint"). Returning an empty list is fine; throwing isn't.
+        assertThat(obstacles).isNotNull();
+    }
+
+    @Test
+    void findClosestRampInBoundingBox_executesAgainstPostgisWithoutEnumBindingError() {
+        // findClosestRampInBoundingBox uses native query findByTypeInBoundingBoxWithStatuses,
+        // which has the same enum-binding pitfall on both the type and statuses params.
+        Location start = new Location(41.0840, 29.0440);
+        Location end = new Location(41.0860, 29.0470);
+        // Returning null is a valid outcome (no FEATURE-RAMP reports seeded).
+        // The test guards only against the SQL/Hibernate exception.
+        Report ramp = obstacleService.findClosestRampInBoundingBox(start, end);
+        assertThat(ramp).isNull();
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceConstraintIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceConstraintIntegrationTest.java
@@ -1,0 +1,164 @@
+package com.bounswe2026group1.backend.service;
+
+import com.bounswe2026group1.backend.model.IssueType;
+import com.bounswe2026group1.backend.model.ObjectType;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.model.ReportEnvironment;
+import com.bounswe2026group1.backend.model.ReportObject;
+import com.bounswe2026group1.backend.model.ReportStatus;
+import com.bounswe2026group1.backend.model.ReportType;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
+import com.bounswe2026group1.backend.model.RoutingPreset;
+import com.bounswe2026group1.backend.model.UserRole;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.repository.ReportRepository;
+import com.bounswe2026group1.backend.support.AbstractPostgisIntegrationTest;
+import com.bounswe2026group1.backend.util.GeoUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Full-stack test for the avoid-polygon filter — exercises ObstacleService
+ * against a real PostGIS-backed datasource, with real Reports persisted via
+ * the JPA repository. Proves the constraint→hazard mapping flows end-to-end
+ * through the persistence layer (not just the in-memory mock used by
+ * ObstacleServiceTest).
+ */
+@SpringBootTest
+class ObstacleServiceConstraintIntegrationTest extends AbstractPostgisIntegrationTest {
+
+    @Autowired private ObstacleService obstacleService;
+    @Autowired private ReportRepository reportRepository;
+    @Autowired private RegisteredUserRepository registeredUserRepository;
+
+    private RegisteredUser author;
+
+    @BeforeEach
+    @Transactional
+    void seedReports() {
+        // Tests share the singleton PostGIS container, so clean state by tag.
+        reportRepository.deleteAll();
+        registeredUserRepository.findByEmail("obstacle-int@test.com").ifPresent(registeredUserRepository::delete);
+
+        author = new RegisteredUser();
+        author.setName("Obstacle Tester");
+        author.setEmail("obstacle-int@test.com");
+        author.setPassword("hashed-password-stub");
+        author.setRole(UserRole.USER);
+        author = registeredUserRepository.save(author);
+
+        // Three VERIFIED OBSTACLE reports, each with a distinct hazard.
+        persistObstacle(41.0850, 29.0451, ObjectType.STAIR, IssueType.MISSING_HANDRAIL);
+        persistObstacle(41.0851, 29.0452, ObjectType.SIDEWALK, IssueType.BLOCKED);
+        persistObstacle(41.0852, 29.0453, ObjectType.RAMP, IssueType.TOO_STEEP);
+    }
+
+    @Test
+    void buildAvoidPolygons_emptyConstraints_includesAllVerifiedObstaclesFromDb() {
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(Set.of());
+
+        assertThat(polygons).isNotNull();
+        assertThat(polygons.get("coordinates")).hasSize(3);
+    }
+
+    @Test
+    void buildAvoidPolygons_avoidStairsOnly_keepsOnlyStairReport() {
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(EnumSet.of(RoutingConstraint.AVOID_STAIRS));
+
+        assertThat(polygons).isNotNull();
+        assertThat(polygons.get("coordinates")).hasSize(1);
+    }
+
+    @Test
+    void buildAvoidPolygons_avoidBlockedSidewalks_keepsOnlySidewalkReport() {
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(
+                EnumSet.of(RoutingConstraint.AVOID_BLOCKED_OR_MISSING_SIDEWALKS));
+
+        assertThat(polygons).isNotNull();
+        assertThat(polygons.get("coordinates")).hasSize(1);
+    }
+
+    @Test
+    void buildAvoidPolygons_avoidUnsafeRamps_keepsOnlyRampReport() {
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(
+                EnumSet.of(RoutingConstraint.AVOID_UNSAFE_RAMPS));
+
+        assertThat(polygons).isNotNull();
+        assertThat(polygons.get("coordinates")).hasSize(1);
+    }
+
+    @Test
+    void buildAvoidPolygons_wheelchairUserPreset_keepsRelevantReports() {
+        // WHEELCHAIR_USER bundles AVOID_STAIRS, REQUIRE_RAMPS, AVOID_UNSAFE_RAMPS,
+        // AVOID_NARROW_SIDEWALKS, AVOID_BLOCKED_OR_MISSING_SIDEWALKS.
+        // Of our seeded reports: stair (matches AVOID_STAIRS), blocked sidewalk
+        // (matches AVOID_BLOCKED), and ramp-too-steep (matches AVOID_UNSAFE_RAMPS) all match.
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(
+                RoutingPreset.WHEELCHAIR_USER.getConstraints());
+
+        assertThat(polygons).isNotNull();
+        assertThat(polygons.get("coordinates")).hasSize(3);
+    }
+
+    @Test
+    void buildAvoidPolygons_blindOrLowVisionPreset_filtersOutWheelchairOnlyReports() {
+        // BLIND_OR_LOW_VISION bundles AVOID_LOW_CLEARANCE, AVOID_BLOCKED_OR_MISSING_SIDEWALKS,
+        // AVOID_DAMAGED_TACTILE_PAVING. Only the blocked-sidewalk report matches; the
+        // wheelchair-relevant stair and ramp reports are filtered out.
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(
+                RoutingPreset.BLIND_OR_LOW_VISION.getConstraints());
+
+        assertThat(polygons).isNotNull();
+        assertThat(polygons.get("coordinates")).hasSize(1);
+    }
+
+    @Test
+    void buildAvoidPolygons_constraintWithNoMatches_returnsNull() {
+        // None of the seeded reports have NO_TACTILE_PAVING, so the constraint set is empty
+        // after filtering and the polygon set collapses to null.
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(
+                EnumSet.of(RoutingConstraint.AVOID_DAMAGED_TACTILE_PAVING));
+
+        assertThat(polygons).isNull();
+    }
+
+    @Test
+    void buildAvoidPolygons_pendingReportNeverFiltersIn_evenWithMatchingConstraint() {
+        // Add a PENDING report whose hazard matches a constraint — must not appear in polygons
+        // because only VERIFIED reports flow through.
+        Report pending = new Report(author, GeoUtils.point4326(41.0853, 29.0454),
+                "Pending stairs", ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        pending.setStatus(ReportStatus.PENDING);
+        ReportObject obj = new ReportObject(pending, ObjectType.STAIR, EnumSet.of(IssueType.MISSING_HANDRAIL), null);
+        pending.getObjects().add(obj);
+        reportRepository.save(pending);
+
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(EnumSet.of(RoutingConstraint.AVOID_STAIRS));
+
+        assertThat(polygons).isNotNull();
+        // Still 1 (the seeded VERIFIED stair report) — the PENDING one was rejected upstream.
+        assertThat(polygons.get("coordinates")).hasSize(1);
+    }
+
+    private void persistObstacle(double lat, double lon, ObjectType objectType, IssueType issue) {
+        Report r = new Report(author, GeoUtils.point4326(lat, lon),
+                objectType + " " + issue, ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        r.setStatus(ReportStatus.VERIFIED);
+        Report saved = reportRepository.save(r);
+        Set<IssueType> issues = new HashSet<>(List.of(issue));
+        saved.getObjects().add(new ReportObject(saved, objectType, issues, null));
+        reportRepository.save(saved);
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceConstraintIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceConstraintIntegrationTest.java
@@ -156,6 +156,47 @@ class ObstacleServiceConstraintIntegrationTest extends AbstractPostgisIntegratio
     }
 
     @Test
+    void findObstaclesOnPath_emptyConstraints_returnsEveryNearbyObstacle() {
+        // Path that brushes past all three seeded VERIFIED OUTDOOR obstacles
+        // (stair, sidewalk, ramp at 41.0850/0851/0852).
+        Location p1 = new Location(41.0850, 29.0450);
+        Location p2 = new Location(41.0853, 29.0454);
+
+        List<Report> obstacles = obstacleService.findObstaclesOnPath(List.of(p1, p2), Set.of());
+
+        assertThat(obstacles).hasSize(3);
+    }
+
+    @Test
+    void findObstaclesOnPath_withNonMatchingConstraint_filtersOutObstaclesUserDoesntCareAbout() {
+        // The user only cares about low overhead clearance — none of the seeded
+        // reports match that hazard. The fastest route may still graze them, but
+        // the response's hasObstacles flag should be false: warning the user about
+        // an obstacle they explicitly don't care about contradicts the prefs design.
+        Location p1 = new Location(41.0850, 29.0450);
+        Location p2 = new Location(41.0853, 29.0454);
+
+        List<Report> obstacles = obstacleService.findObstaclesOnPath(List.of(p1, p2),
+                EnumSet.of(RoutingConstraint.AVOID_LOW_CLEARANCE));
+
+        assertThat(obstacles).isEmpty();
+    }
+
+    @Test
+    void findObstaclesOnPath_withMatchingConstraint_keepsRelevantObstaclesOnly() {
+        // The user has AVOID_BLOCKED_OR_MISSING_SIDEWALKS — only the seeded
+        // sidewalk-blocked report should survive.
+        Location p1 = new Location(41.0850, 29.0450);
+        Location p2 = new Location(41.0853, 29.0454);
+
+        List<Report> obstacles = obstacleService.findObstaclesOnPath(List.of(p1, p2),
+                EnumSet.of(RoutingConstraint.AVOID_BLOCKED_OR_MISSING_SIDEWALKS));
+
+        assertThat(obstacles).hasSize(1);
+        assertThat(obstacles.get(0).getDescription()).contains("BLOCKED");
+    }
+
+    @Test
     void findClosestRampInBoundingBox_executesAgainstPostgisWithoutEnumBindingError() {
         // findClosestRampInBoundingBox uses native query findByTypeInBoundingBoxWithStatuses,
         // which has the same enum-binding pitfall on both the type and statuses params.

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceConstraintIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceConstraintIntegrationTest.java
@@ -116,7 +116,7 @@ class ObstacleServiceConstraintIntegrationTest extends AbstractPostgisIntegratio
     @Test
     void buildAvoidPolygons_blindOrLowVisionPreset_filtersOutWheelchairOnlyReports() {
         // BLIND_OR_LOW_VISION bundles AVOID_LOW_CLEARANCE, AVOID_BLOCKED_OR_MISSING_SIDEWALKS,
-        // AVOID_DAMAGED_TACTILE_PAVING. Only the blocked-sidewalk report matches; the
+        // AVOID_MISSING_TACTILE_PAVING. Only the blocked-sidewalk report matches; the
         // wheelchair-relevant stair and ramp reports are filtered out.
         ObjectNode polygons = obstacleService.buildAvoidPolygons(
                 RoutingPreset.BLIND_OR_LOW_VISION.getConstraints());
@@ -130,7 +130,7 @@ class ObstacleServiceConstraintIntegrationTest extends AbstractPostgisIntegratio
         // None of the seeded reports have NO_TACTILE_PAVING, so the constraint set is empty
         // after filtering and the polygon set collapses to null.
         ObjectNode polygons = obstacleService.buildAvoidPolygons(
-                EnumSet.of(RoutingConstraint.AVOID_DAMAGED_TACTILE_PAVING));
+                EnumSet.of(RoutingConstraint.AVOID_MISSING_TACTILE_PAVING));
 
         assertThat(polygons).isNull();
     }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceTest.java
@@ -51,7 +51,7 @@ class ObstacleServiceTest {
     @Test
     void findClosestRamp_returnsNull_whenNoCandidates() {
         when(reportRepository.findByTypeInBoundingBoxWithStatuses(
-                eq(ReportType.FEATURE),
+                eq(ReportType.FEATURE.name()),
                 anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyList()))
                 .thenReturn(List.of());
 
@@ -62,7 +62,7 @@ class ObstacleServiceTest {
     void findClosestRamp_returnsSingleRamp_whenOnlyOneCandidate() {
         Report ramp = rampNear(41.0840, 29.0460, 41.0838, 29.0465);
         when(reportRepository.findByTypeInBoundingBoxWithStatuses(
-                eq(ReportType.FEATURE),
+                eq(ReportType.FEATURE.name()),
                 anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyList()))
                 .thenReturn(List.of(ramp));
 
@@ -80,7 +80,7 @@ class ObstacleServiceTest {
                                 41.0821, 29.0499);  // exit ≈ 14 m from END
 
         when(reportRepository.findByTypeInBoundingBoxWithStatuses(
-                eq(ReportType.FEATURE),
+                eq(ReportType.FEATURE.name()),
                 anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyList()))
                 .thenReturn(List.of(rampA, rampB));
 
@@ -99,7 +99,7 @@ class ObstacleServiceTest {
         Report good = rampNear(41.0840, 29.0460, 41.0838, 29.0465);
 
         when(reportRepository.findByTypeInBoundingBoxWithStatuses(
-                eq(ReportType.FEATURE),
+                eq(ReportType.FEATURE.name()),
                 anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyList()))
                 .thenReturn(List.of(bad, good));
 
@@ -118,7 +118,7 @@ class ObstacleServiceTest {
         elevatorFeature.getObjects().add(new ReportObject(elevatorFeature, ObjectType.ELEVATOR, Set.of(), null));
 
         when(reportRepository.findByTypeInBoundingBoxWithStatuses(
-                eq(ReportType.FEATURE),
+                eq(ReportType.FEATURE.name()),
                 anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyList()))
                 .thenReturn(List.of(elevatorFeature, rampReport));
 

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceTest.java
@@ -1,12 +1,17 @@
 package com.bounswe2026group1.backend.service;
 
+import com.bounswe2026group1.backend.model.IssueType;
 import com.bounswe2026group1.backend.model.Location;
 import com.bounswe2026group1.backend.model.ObjectType;
 import com.bounswe2026group1.backend.model.Report;
 import com.bounswe2026group1.backend.model.ReportObject;
 import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.ReportType;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
 import com.bounswe2026group1.backend.repository.ReportRepository;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -132,6 +138,96 @@ class ObstacleServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // buildAvoidPolygons(constraints) — preference-aware filtering (#365)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void buildAvoidPolygons_emptyConstraints_includesEveryVerifiedObstacle() {
+        // Anonymous / NONE-preset baseline: all VERIFIED obstacles become polygons.
+        Report stairsReport = obstacleAt(41.0850, 29.0451, ObjectType.STAIR, IssueType.MISSING_HANDRAIL);
+        Report blockedSidewalk = obstacleAt(41.0851, 29.0452, ObjectType.SIDEWALK, IssueType.BLOCKED);
+        when(reportRepository.findByTypeAndStatusIn(eq(ReportType.OBSTACLE), anyList()))
+                .thenReturn(List.of(stairsReport, blockedSidewalk));
+
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(Set.of());
+
+        assertNotNull(polygons);
+        assertEquals(2, polygons.get("coordinates").size(),
+                "Empty constraints must preserve baseline (every VERIFIED obstacle becomes a polygon)");
+    }
+
+    @Test
+    void buildAvoidPolygons_withConstraintMatchingOnlyOneReport_filtersOutTheRest() {
+        Report stairsReport = obstacleAt(41.0850, 29.0451, ObjectType.STAIR, IssueType.MISSING_HANDRAIL);
+        Report blockedSidewalk = obstacleAt(41.0851, 29.0452, ObjectType.SIDEWALK, IssueType.BLOCKED);
+        when(reportRepository.findByTypeAndStatusIn(eq(ReportType.OBSTACLE), anyList()))
+                .thenReturn(List.of(stairsReport, blockedSidewalk));
+
+        // Only AVOID_BLOCKED_OR_MISSING_SIDEWALKS should match the blocked sidewalk; the stairs
+        // report's hazards aren't in this constraint's set.
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(
+                EnumSet.of(RoutingConstraint.AVOID_BLOCKED_OR_MISSING_SIDEWALKS));
+
+        assertNotNull(polygons);
+        assertEquals(1, polygons.get("coordinates").size(),
+                "Constraint should narrow the avoid set to reports whose objects match a hazard");
+    }
+
+    @Test
+    void buildAvoidPolygons_withConstraintMatchingNoReports_returnsNull() {
+        Report blockedSidewalk = obstacleAt(41.0851, 29.0452, ObjectType.SIDEWALK, IssueType.BLOCKED);
+        when(reportRepository.findByTypeAndStatusIn(eq(ReportType.OBSTACLE), anyList()))
+                .thenReturn(List.of(blockedSidewalk));
+
+        // REQUIRE_HANDRAILS only cares about (RAMP|STAIR, MISSING_HANDRAIL); blocked sidewalks
+        // don't match. With no surviving reports the polygon set should collapse to null
+        // (which lets ORS skip the avoidance call entirely).
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(
+                EnumSet.of(RoutingConstraint.REQUIRE_HANDRAILS));
+
+        assertNull(polygons);
+    }
+
+    @Test
+    void buildAvoidPolygons_withWheelchairUserPresetConstraints_filtersBlindOnlyHazardsOut() {
+        // A blind-user-relevant report: tactile paving missing
+        Report tactileReport = obstacleAt(41.0850, 29.0451, ObjectType.SIDEWALK, IssueType.NO_TACTILE_PAVING);
+        // A wheelchair-user-relevant report: missing ramp
+        Report rampReport = obstacleAt(41.0852, 29.0453, ObjectType.RAMP, IssueType.MISSING);
+        when(reportRepository.findByTypeAndStatusIn(eq(ReportType.OBSTACLE), anyList()))
+                .thenReturn(List.of(tactileReport, rampReport));
+
+        // Apply the WHEELCHAIR_USER preset's constraints. Only the ramp report should
+        // contribute a polygon — tactile paving isn't in this preset's hazard set.
+        ObjectNode polygons = obstacleService.buildAvoidPolygons(
+                com.bounswe2026group1.backend.model.RoutingPreset.WHEELCHAIR_USER.getConstraints());
+
+        assertNotNull(polygons);
+        assertEquals(1, polygons.get("coordinates").size());
+    }
+
+    @Test
+    void buildAvoidPolygons_constraintsCannotWidenSetPastBaseline() {
+        // The baseline includes every VERIFIED obstacle. Constraints can only narrow,
+        // never widen — so the count with constraints applied must always be ≤ baseline.
+        Report stairsReport = obstacleAt(41.0850, 29.0451, ObjectType.STAIR, IssueType.MISSING_HANDRAIL);
+        Report tactileReport = obstacleAt(41.0851, 29.0452, ObjectType.SIDEWALK, IssueType.NO_TACTILE_PAVING);
+        Report rampReport = obstacleAt(41.0852, 29.0453, ObjectType.RAMP, IssueType.TOO_STEEP);
+        when(reportRepository.findByTypeAndStatusIn(eq(ReportType.OBSTACLE), anyList()))
+                .thenReturn(List.of(stairsReport, tactileReport, rampReport));
+
+        int baseline = obstacleService.buildAvoidPolygons(Set.of()).get("coordinates").size();
+        int withConstraints = obstacleService.buildAvoidPolygons(
+                EnumSet.of(RoutingConstraint.AVOID_STAIRS)).get("coordinates").size();
+
+        assertEquals(3, baseline);
+        assertTrue(withConstraints <= baseline,
+                "Applying a constraint must never widen the avoid set past the baseline");
+        assertEquals(1, withConstraints,
+                "AVOID_STAIRS should match only the stair report");
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
@@ -143,6 +239,18 @@ class ObstacleServiceTest {
         r.setExitPoint(new Location(exitLat, exitLon));
         r.setStatus(ReportStatus.VERIFIED);
         r.getObjects().add(new ReportObject(r, ObjectType.RAMP, Set.of(), null));
+        return r;
+    }
+
+    private static final GeometryFactory GEOMETRY_FACTORY =
+            new GeometryFactory(new PrecisionModel(), 4326);
+
+    private static Report obstacleAt(double lat, double lon, ObjectType objectType, IssueType issue) {
+        Report r = new Report();
+        r.setReportType(ReportType.OBSTACLE);
+        r.setStatus(ReportStatus.VERIFIED);
+        r.setLocation(GEOMETRY_FACTORY.createPoint(new org.locationtech.jts.geom.Coordinate(lon, lat)));
+        r.getObjects().add(new ReportObject(r, objectType, EnumSet.of(issue), null));
         return r;
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
@@ -40,7 +40,7 @@ class RouteServiceTest {
         when(obstacleService.buildAvoidPolygons(any())).thenReturn(avoidPolygons);
 
         // But the fastest route happens not to cross any of them
-        when(obstacleService.findObstaclesOnPath(any())).thenReturn(List.of());
+        when(obstacleService.findObstaclesOnPath(any(), any())).thenReturn(List.of());
         when(obstacleService.findClosestRampInBoundingBox(any(), any())).thenReturn(null);
 
         RoutingDirectionsResult anyRoute = RoutingDirectionsResult.builder()

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
@@ -37,7 +37,7 @@ class RouteServiceTest {
     void accessibleRoute_isComputed_whenAvoidPolygonsExist_evenIfFastestRouteHasNoObstacles() {
         // Avoid polygons exist (some obstacles are reported in the area)
         ObjectNode avoidPolygons = JsonMapper.builder().build().createObjectNode();
-        when(obstacleService.buildAvoidPolygons()).thenReturn(avoidPolygons);
+        when(obstacleService.buildAvoidPolygons(any())).thenReturn(avoidPolygons);
 
         // But the fastest route happens not to cross any of them
         when(obstacleService.findObstaclesOnPath(any())).thenReturn(List.of());
@@ -71,7 +71,7 @@ class RouteServiceTest {
 
         // Avoid polygons exist so the WHEELCHAIR calls receive a non-null arg
         ObjectNode avoidPolygons = JsonMapper.builder().build().createObjectNode();
-        when(obstacleService.buildAvoidPolygons()).thenReturn(avoidPolygons);
+        when(obstacleService.buildAvoidPolygons(any())).thenReturn(avoidPolygons);
 
         // Direct wheelchair + leg1 + leg3 (all WHEELCHAIR) succeed
         RoutingDirectionsResult wheelchairRoute = RoutingDirectionsResult.builder()

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RoutingPreferencesServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RoutingPreferencesServiceTest.java
@@ -277,6 +277,27 @@ class RoutingPreferencesServiceTest {
     // ── CUSTOM preset semantics ──────────────────────────────────────────────
 
     @Test
+    void update_withCustomPresetOnly_freshUserNoConstraints_resolvesToNonePreset() {
+        // Regression for EnumSet.copyOf rejecting empty non-EnumSet collections.
+        // A fresh user's routingConstraints is an empty HashSet; sending
+        // {"preferredPreset":"CUSTOM"} used to throw IllegalArgumentException.
+        // The empty set then auto-detects as NONE (not CUSTOM) per detectFromConstraints.
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setPreferredPreset(RoutingPreset.CUSTOM);
+
+        RoutingPreferencesResponse resp = assertDoesNotThrow(
+                () -> service.update("user@test.com", req));
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        RegisteredUser saved = captor.getValue();
+        assertTrue(saved.getRoutingConstraints().isEmpty());
+        assertEquals(RoutingPreset.NONE, saved.getPreferredPreset());
+        assertEquals(RoutingPreset.NONE, resp.getPreferredPreset());
+    }
+
+    @Test
     void update_withCustomPresetOnly_keepsExistingConstraintsAndDetectsCustom() {
         // The user previously set CUSTOM with two arbitrary constraints. Sending
         // CUSTOM as the preset (and nothing else) should keep those constraints.

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RoutingPreferencesServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RoutingPreferencesServiceTest.java
@@ -1,0 +1,301 @@
+package com.bounswe2026group1.backend.service;
+
+import com.bounswe2026group1.backend.dto.routing.RoutingPreferencesResponse;
+import com.bounswe2026group1.backend.dto.routing.UpdateRoutingPreferencesRequest;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
+import com.bounswe2026group1.backend.model.RoutingPreset;
+import com.bounswe2026group1.backend.model.TravelMode;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RoutingPreferencesServiceTest {
+
+    @Mock private RegisteredUserRepository registeredUserRepository;
+
+    @InjectMocks
+    private RoutingPreferencesService service;
+
+    private RegisteredUser user;
+
+    @BeforeEach
+    void setUp() {
+        user = new RegisteredUser();
+        user.setId(1L);
+        user.setEmail("user@test.com");
+        user.setPreferredPreset(RoutingPreset.NONE);
+        user.setRoutingConstraints(new HashSet<>());
+    }
+
+    /**
+     * Stub the happy-path repository calls. Called from tests that actually exercise
+     * the load + save flow; tests asserting unauthorized paths skip this so Mockito
+     * strict-stubbing stays clean.
+     */
+    private void stubHappyPathRepo() {
+        when(registeredUserRepository.findByEmail("user@test.com")).thenReturn(Optional.of(user));
+        when(registeredUserRepository.save(any(RegisteredUser.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    // ── getForEmail ──────────────────────────────────────────────────────────
+
+    @Test
+    void getForEmail_withNullEmail_throwsUnauthorized() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.getForEmail(null));
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
+    }
+
+    @Test
+    void getForEmail_unknownEmail_throwsUnauthorized() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.getForEmail("ghost@test.com"));
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
+    }
+
+    @Test
+    void getForEmail_freshUser_returnsNonePresetAndFullCatalog() {
+        when(registeredUserRepository.findByEmail("user@test.com")).thenReturn(Optional.of(user));
+        RoutingPreferencesResponse response = service.getForEmail("user@test.com");
+
+        assertEquals(RoutingPreset.NONE, response.getPreferredPreset());
+        assertTrue(response.getConstraints().isEmpty());
+        assertNull(response.getPreferredTravelMode());
+        // Catalog should expose every preset and every constraint by name.
+        assertEquals(RoutingPreset.values().length, response.getAvailablePresets().size());
+        assertEquals(RoutingConstraint.values().length, response.getAvailableConstraints().size());
+    }
+
+    // ── update — preset only ────────────────────────────────────────────────
+
+    @Test
+    void update_withPresetOnly_fillsConstraintsAndTravelModeFromPreset() {
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setPreferredPreset(RoutingPreset.WHEELCHAIR_USER);
+
+        service.update("user@test.com", req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        RegisteredUser saved = captor.getValue();
+
+        assertEquals(RoutingPreset.WHEELCHAIR_USER, saved.getPreferredPreset());
+        assertEquals(RoutingPreset.WHEELCHAIR_USER.getConstraints(), saved.getRoutingConstraints());
+        assertEquals(TravelMode.WHEELCHAIR, saved.getPreferredTravelMode());
+    }
+
+    @Test
+    void update_withNonePresetOnly_clearsConstraintsButLeavesTravelModeUnset() {
+        // Seed the user with prior state to confirm clearing.
+        user.setRoutingConstraints(new HashSet<>(RoutingPreset.WHEELCHAIR_USER.getConstraints()));
+        user.setPreferredPreset(RoutingPreset.WHEELCHAIR_USER);
+        user.setPreferredTravelMode(TravelMode.WHEELCHAIR);
+
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setPreferredPreset(RoutingPreset.NONE);
+
+        service.update("user@test.com", req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        RegisteredUser saved = captor.getValue();
+
+        assertEquals(RoutingPreset.NONE, saved.getPreferredPreset());
+        assertTrue(saved.getRoutingConstraints().isEmpty());
+        // NONE has no defaultTravelMode, so the prior value is preserved (caller can override).
+        assertEquals(TravelMode.WHEELCHAIR, saved.getPreferredTravelMode());
+    }
+
+    // ── update — constraints only ───────────────────────────────────────────
+
+    @Test
+    void update_withConstraintsMatchingPreset_autoDetectsThePreset() {
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setConstraints(new HashSet<>(RoutingPreset.MOBILITY_LIMITED.getConstraints()));
+
+        service.update("user@test.com", req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        RegisteredUser saved = captor.getValue();
+
+        assertEquals(RoutingPreset.MOBILITY_LIMITED, saved.getPreferredPreset());
+        assertEquals(RoutingPreset.MOBILITY_LIMITED.getConstraints(), saved.getRoutingConstraints());
+    }
+
+    @Test
+    void update_withConstraintsNotMatchingAnyPreset_setsPresetToCustom() {
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setConstraints(EnumSet.of(
+                RoutingConstraint.AVOID_LOW_CLEARANCE,
+                RoutingConstraint.REQUIRE_HANDRAILS));
+
+        service.update("user@test.com", req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals(RoutingPreset.CUSTOM, captor.getValue().getPreferredPreset());
+    }
+
+    @Test
+    void update_withEmptyConstraintSet_setsPresetToNone() {
+        user.setPreferredPreset(RoutingPreset.WHEELCHAIR_USER);
+        user.setRoutingConstraints(new HashSet<>(RoutingPreset.WHEELCHAIR_USER.getConstraints()));
+
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setConstraints(new HashSet<>());
+
+        service.update("user@test.com", req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        RegisteredUser saved = captor.getValue();
+        assertEquals(RoutingPreset.NONE, saved.getPreferredPreset());
+        assertTrue(saved.getRoutingConstraints().isEmpty());
+    }
+
+    // ── update — both fields together ───────────────────────────────────────
+
+    @Test
+    void update_withBothPresetAndMatchingConstraints_constraintsWin_presetMatches() {
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setPreferredPreset(RoutingPreset.MOBILITY_LIMITED);          // claim
+        req.setConstraints(new HashSet<>(RoutingPreset.WHEELCHAIR_USER.getConstraints())); // reality
+
+        service.update("user@test.com", req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        RegisteredUser saved = captor.getValue();
+
+        // Constraints win → stored set is WHEELCHAIR_USER's; detected preset matches reality.
+        assertEquals(RoutingPreset.WHEELCHAIR_USER, saved.getPreferredPreset());
+        assertEquals(RoutingPreset.WHEELCHAIR_USER.getConstraints(), saved.getRoutingConstraints());
+    }
+
+    @Test
+    void update_withBothPresetAndArbitraryConstraints_setsCustom() {
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setPreferredPreset(RoutingPreset.WHEELCHAIR_USER);
+        req.setConstraints(EnumSet.of(RoutingConstraint.AVOID_LOW_CLEARANCE));
+
+        service.update("user@test.com", req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals(RoutingPreset.CUSTOM, captor.getValue().getPreferredPreset());
+    }
+
+    // ── update — travel mode handling ───────────────────────────────────────
+
+    @Test
+    void update_withExplicitTravelMode_overridesPresetDefault() {
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setPreferredPreset(RoutingPreset.WHEELCHAIR_USER); // default WHEELCHAIR
+        req.setPreferredTravelMode(TravelMode.WALKING);         // explicit override
+
+        service.update("user@test.com", req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals(TravelMode.WALKING, captor.getValue().getPreferredTravelMode());
+    }
+
+    @Test
+    void update_constraintsSentWithoutPreset_doesNotChangeTravelMode() {
+        user.setPreferredTravelMode(TravelMode.WALKING);
+
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setConstraints(EnumSet.of(RoutingConstraint.AVOID_LOW_CLEARANCE));
+
+        service.update("user@test.com", req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals(TravelMode.WALKING, captor.getValue().getPreferredTravelMode(),
+                "Sending only constraints must not silently change travelMode");
+    }
+
+    @Test
+    void update_emptyRequest_isNoOp_returnsCurrentState() {
+        user.setPreferredPreset(RoutingPreset.MOBILITY_LIMITED);
+        user.setRoutingConstraints(new HashSet<>(RoutingPreset.MOBILITY_LIMITED.getConstraints()));
+        user.setPreferredTravelMode(TravelMode.WALKING);
+
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        RoutingPreferencesResponse resp = service.update("user@test.com", req);
+
+        assertEquals(RoutingPreset.MOBILITY_LIMITED, resp.getPreferredPreset());
+        assertEquals(TravelMode.WALKING, resp.getPreferredTravelMode());
+        assertEquals(RoutingPreset.MOBILITY_LIMITED.getConstraints().size(), resp.getConstraints().size());
+    }
+
+    @Test
+    void update_returnedConstraintsAreSorted() {
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setConstraints(EnumSet.of(
+                RoutingConstraint.REQUIRE_HANDRAILS,
+                RoutingConstraint.AVOID_LOW_CLEARANCE,
+                RoutingConstraint.AVOID_STAIRS));
+
+        RoutingPreferencesResponse resp = service.update("user@test.com", req);
+
+        var sorted = resp.getConstraints().stream().sorted().toList();
+        assertEquals(sorted, resp.getConstraints(), "Returned constraints must be sorted by name for stable output");
+    }
+
+    // ── CUSTOM preset semantics ──────────────────────────────────────────────
+
+    @Test
+    void update_withCustomPresetOnly_keepsExistingConstraintsAndDetectsCustom() {
+        // The user previously set CUSTOM with two arbitrary constraints. Sending
+        // CUSTOM as the preset (and nothing else) should keep those constraints.
+        Set<RoutingConstraint> existing = EnumSet.of(
+                RoutingConstraint.AVOID_LOW_CLEARANCE,
+                RoutingConstraint.REQUIRE_HANDRAILS);
+        user.setRoutingConstraints(new HashSet<>(existing));
+        user.setPreferredPreset(RoutingPreset.CUSTOM);
+
+        stubHappyPathRepo();
+        UpdateRoutingPreferencesRequest req = new UpdateRoutingPreferencesRequest();
+        req.setPreferredPreset(RoutingPreset.CUSTOM);
+
+        service.update("user@test.com", req);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        RegisteredUser saved = captor.getValue();
+        assertEquals(existing, saved.getRoutingConstraints());
+        assertEquals(RoutingPreset.CUSTOM, saved.getPreferredPreset());
+    }
+}


### PR DESCRIPTION
# 📝 Accessibility Profiles and Constraint-Based Routing
Fixes #365

Adds backend infrastructure for stored user accessibility preferences and
threads those preferences through the routing pipeline. Users can pick a named
preset (`WHEELCHAIR_USER`, `BLIND_OR_LOW_VISION`, `MOBILITY_LIMITED`) or a
custom mix of 10 path-level constraints (`AVOID_STAIRS`, `REQUIRE_RAMPS`,
`AVOID_NARROW_SIDEWALKS`, `AVOID_DAMAGED_TACTILE_PAVING`, etc.); the avoid
polygons fed to OpenRouteService now include only obstacles whose hazard
tuples match the caller's constraint set, and the matching alternative on the
3-route response is flagged `preferred:true`. Anonymous and `NONE`-preset
callers see the existing baseline (every VERIFIED OUTDOOR obstacle becomes a
polygon).

The PR also fixes three pre-existing routing bugs surfaced by hands-on testing
of the feature:

1. **Native-query enum binding** — `findByTypeInBoundingBoxWithStatuses` and
   `findReportsInBoundingBoxWithStatuses` were 500-ing prod (`operator does
   not exist: character varying = smallint`) because Hibernate binds
   `Collection<Enum>` as ordinals in native queries. Switched the params to
   `Collection<String>` and the single caller (`ObstacleService`) now passes
   `ReportStatus.VERIFIED.name()`.
2. **INDOOR reports leaking into routing** — `buildAvoidPolygons` was
   generating polygons for indoor reports (e.g. broken elevators inside
   buildings) which ORS foot-walking can't navigate to anyway. Filtered all
   three routing repository queries to `environment = OUTDOOR`. Indoor
   reports stay in the report system as informational data.
3. **`hasObstacles` flag ignored constraints** — a `⭐ preferred` Fastest
   Route could warn about an obstacle the user had explicitly declared they
   don't care about. `findObstaclesOnPath` now applies the same
   constraint-filter predicate as `buildAvoidPolygons`.

# 📊 Type of Change
- [x] Bug fix (3 pre-existing bugs surfaced by testing the new feature)
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

## What's tested
- **44 new tests** across 7 files (313/313 in `mvnw clean verify`, 1 skipped live-ORS):
  - 17 unit tests on the enums (constraint→hazard mapping, preset round-trip)
  - 15 unit tests on `RoutingPreferencesService` (every PUT permutation)
  - 5 new unit tests on `ObstacleService` (constraint-aware avoid polygons)
  - 14 PostGIS-backed integration tests (`ObstacleServiceConstraintIntegrationTest`)
    including 2 native-query enum-binding regression guards, 1 INDOOR-filter
    guard, and 3 constraint-aware `findObstaclesOnPath` guards
  - 10 full HTTP integration tests on the prefs endpoints (`@SpringBootTest` +
    real DB) covering anonymous 401, fresh-user catalog, every PUT semantic,
    PUT-then-GET round-trip, toggle workflow with auto-detected preset
  - 6 end-to-end tests confirming user constraints flow into ObstacleService
    via `ArgumentCaptor` and the `preferred:true` flag is set on the right alt
- **Live smoke test** against the local Docker stack: PUT prefs through curl,
  verified DB persistence in Adminer, and confirmed `/api/routes` deflects the
  fastest path (270m → 535m) when the user's constraints match the seeded
  blocked-sidewalk obstacle, and stays unchanged when they don't.

# 📸 Screenshots / Recordings
N/A — backend-only changes.

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min