### PR TITLE
[Web] Add Profile Dropdown Menu to Navbar Avatar

### DIFF
--- a/frontend/src/components/CreateReportPanel.test.jsx
+++ b/frontend/src/components/CreateReportPanel.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from '../context/AuthContext.jsx'
 import CreateReportPanel from './CreateReportPanel.jsx'
 import * as api from '../services/api.js'
@@ -33,11 +34,14 @@ const FAKE_REPORT_RESPONSE = {
 
 function renderPanel({ token = FAKE_TOKEN, onClose = vi.fn(), onCreated = vi.fn(), position = null } = {}) {
   if (token) localStorage.setItem('token', token)
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <MemoryRouter>
-      <AuthProvider>
-        <CreateReportPanel position={position} onClose={onClose} onCreated={onCreated} />
-      </AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <CreateReportPanel position={position} onClose={onClose} onCreated={onCreated} />
+        </AuthProvider>
+      </QueryClientProvider>
     </MemoryRouter>
   )
 }

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -38,10 +38,10 @@ function Navbar() {
       }
     }
 
-    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('pointerdown', handlePointerDown)
     document.addEventListener('keydown', handleKeyDown)
     return () => {
-      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('pointerdown', handlePointerDown)
       document.removeEventListener('keydown', handleKeyDown)
     }
   }, [menuOpen])

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,10 +1,61 @@
-import { NavLink } from 'react-router-dom'
+import { useEffect, useRef, useState } from 'react'
+import { Link, NavLink, useNavigate } from 'react-router-dom'
 import SseStatusIndicator from './SseStatusIndicator.jsx'
 import logo from '../assets/mapcess-transparent.png'
 import { useAuth } from '../context/AuthContext.jsx'
+import { useCurrentUser } from '../hooks/useCurrentUser.js'
 
 function Navbar() {
-  const { isAdmin } = useAuth()
+  const { isAuthenticated, isAdmin, logout } = useAuth()
+  const { data: user } = useCurrentUser()
+  const navigate = useNavigate()
+
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [failedAvatarUrl, setFailedAvatarUrl] = useState(null)
+  const menuRef = useRef(null)
+  const buttonRef = useRef(null)
+
+  const avatarUrl = user?.avatarUrl
+  const showAvatarImage = !!avatarUrl && failedAvatarUrl !== avatarUrl
+
+  useEffect(() => {
+    if (!menuOpen) return
+
+    function handlePointerDown(event) {
+      if (
+        menuRef.current?.contains(event.target) ||
+        buttonRef.current?.contains(event.target)
+      ) {
+        return
+      }
+      setMenuOpen(false)
+    }
+
+    function handleKeyDown(event) {
+      if (event.key === 'Escape') {
+        setMenuOpen(false)
+        buttonRef.current?.focus()
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [menuOpen])
+
+  function handleProfileClick() {
+    setMenuOpen(false)
+    navigate('/profile')
+  }
+
+  function handleLogoutClick() {
+    setMenuOpen(false)
+    logout()
+    navigate('/')
+  }
 
   return (
     <header className="w-full sticky top-0 z-[1001] bg-white/80 backdrop-blur-md shadow-[0_4px_40px_-4px_rgba(45,47,47,0.08)] h-16 md:h-20 flex items-center justify-between px-4 sm:px-6 md:px-8 flex-shrink-0">
@@ -70,9 +121,80 @@ function Navbar() {
         >
           <span className="material-symbols-outlined text-on-surface-variant">settings</span>
         </button>
-        <div className="w-9 h-9 md:w-10 md:h-10 rounded-full bg-primary ml-1 sm:ml-2 flex items-center justify-center">
-          <span className="material-symbols-outlined text-white" style={{ fontSize: '20px' }}>person</span>
-        </div>
+
+        {isAuthenticated ? (
+          <div className="relative ml-1 sm:ml-2">
+            <button
+              ref={buttonRef}
+              type="button"
+              onClick={() => setMenuOpen((prev) => !prev)}
+              aria-label="Open profile menu"
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              className="w-9 h-9 md:w-10 md:h-10 rounded-full bg-primary flex items-center justify-center overflow-hidden cursor-pointer ring-offset-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              {showAvatarImage ? (
+                <img
+                  src={avatarUrl}
+                  alt={user?.name ? `${user.name}'s avatar` : 'User avatar'}
+                  className="w-full h-full object-cover"
+                  onError={() => setFailedAvatarUrl(avatarUrl)}
+                />
+              ) : (
+                <span className="material-symbols-outlined text-white" style={{ fontSize: '20px' }}>
+                  person
+                </span>
+              )}
+            </button>
+
+            {menuOpen && (
+              <div
+                ref={menuRef}
+                role="menu"
+                aria-label="Profile menu"
+                className="absolute right-0 mt-2 w-44 rounded-md bg-white shadow-lg ring-1 ring-black/5 py-1 z-[1100]"
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={handleProfileClick}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-on-surface hover:bg-surface-container text-left cursor-pointer"
+                >
+                  <span className="material-symbols-outlined text-on-surface-variant" style={{ fontSize: '20px' }}>
+                    person
+                  </span>
+                  Profile
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={handleLogoutClick}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-on-surface hover:bg-surface-container text-left cursor-pointer"
+                >
+                  <span className="material-symbols-outlined text-on-surface-variant" style={{ fontSize: '20px' }}>
+                    logout
+                  </span>
+                  Log Out
+                </button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 ml-1 sm:ml-2">
+            <Link
+              to="/login"
+              className="text-on-surface-variant hover:text-primary transition-colors font-medium text-sm sm:text-base"
+            >
+              Log In
+            </Link>
+            <Link
+              to="/signup"
+              className="bg-primary text-white rounded-full px-3 py-1.5 sm:px-4 sm:py-2 hover:bg-primary/90 transition-colors font-semibold text-sm sm:text-base"
+            >
+              Sign Up
+            </Link>
+          </div>
+        )}
       </div>
     </header>
   )

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -146,7 +146,7 @@ describe('Navbar', () => {
       await user.click(screen.getByRole('button', { name: /open profile menu/i }))
       expect(screen.getByRole('menu')).toBeInTheDocument()
 
-      fireEvent.mouseDown(screen.getByTestId('outside'))
+      fireEvent.pointerDown(screen.getByTestId('outside'))
 
       expect(screen.queryByRole('menu')).not.toBeInTheDocument()
     })

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -1,0 +1,177 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import Navbar from './Navbar.jsx'
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: vi.fn(),
+}))
+vi.mock('../hooks/useCurrentUser.js', () => ({
+  useCurrentUser: vi.fn(),
+}))
+vi.mock('./SseStatusIndicator.jsx', () => ({
+  default: () => <div data-testid="sse-status" />,
+}))
+
+import { useAuth } from '../context/AuthContext.jsx'
+import { useCurrentUser } from '../hooks/useCurrentUser.js'
+
+function renderNavbar(initialPath = '/somewhere') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/" element={<><Navbar /><div>home page</div></>} />
+        <Route path="/somewhere" element={<Navbar />} />
+        <Route path="/login" element={<div>login page</div>} />
+        <Route path="/signup" element={<div>signup page</div>} />
+        <Route path="/profile" element={<div>profile page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('Navbar', () => {
+  const logout = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuth.mockReturnValue({ isAuthenticated: true, isAdmin: false, logout })
+    useCurrentUser.mockReturnValue({ data: null })
+  })
+
+  describe('when unauthenticated', () => {
+    beforeEach(() => {
+      useAuth.mockReturnValue({ isAuthenticated: false, isAdmin: false, logout })
+    })
+
+    it('does not render the profile menu button', () => {
+      renderNavbar()
+      expect(screen.queryByRole('button', { name: /open profile menu/i })).not.toBeInTheDocument()
+    })
+
+    it('renders Log In and Sign Up links', () => {
+      renderNavbar()
+      expect(screen.getByRole('link', { name: /log in/i })).toHaveAttribute('href', '/login')
+      expect(screen.getByRole('link', { name: /sign up/i })).toHaveAttribute('href', '/signup')
+    })
+  })
+
+  describe('avatar rendering', () => {
+    it('shows the person icon when the user has no avatarUrl', () => {
+      useCurrentUser.mockReturnValue({ data: { id: 1, name: 'Ada', avatarUrl: null } })
+      renderNavbar()
+
+      const button = screen.getByRole('button', { name: /open profile menu/i })
+      expect(button).toBeInTheDocument()
+      expect(button.querySelector('img')).toBeNull()
+    })
+
+    it('renders the avatar image when avatarUrl is set', () => {
+      useCurrentUser.mockReturnValue({
+        data: { id: 1, name: 'Ada', avatarUrl: 'https://cdn.example.com/avatar.jpg' },
+      })
+      renderNavbar()
+
+      const img = screen.getByAltText(/ada's avatar/i)
+      expect(img).toHaveAttribute('src', 'https://cdn.example.com/avatar.jpg')
+    })
+
+    it('falls back to the icon when the avatar image fails to load', () => {
+      useCurrentUser.mockReturnValue({
+        data: { id: 1, name: 'Ada', avatarUrl: 'https://cdn.example.com/broken.jpg' },
+      })
+      renderNavbar()
+
+      const img = screen.getByAltText(/ada's avatar/i)
+      fireEvent.error(img)
+
+      expect(screen.queryByAltText(/ada's avatar/i)).not.toBeInTheDocument()
+      const button = screen.getByRole('button', { name: /open profile menu/i })
+      expect(button.querySelector('img')).toBeNull()
+    })
+  })
+
+  describe('dropdown menu', () => {
+    it('is closed by default', () => {
+      renderNavbar()
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /open profile menu/i }),
+      ).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('opens when the avatar button is clicked', async () => {
+      const user = userEvent.setup()
+      renderNavbar()
+
+      await user.click(screen.getByRole('button', { name: /open profile menu/i }))
+
+      expect(screen.getByRole('menu')).toBeInTheDocument()
+      expect(screen.getByRole('menuitem', { name: /profile/i })).toBeInTheDocument()
+      expect(screen.getByRole('menuitem', { name: /log out/i })).toBeInTheDocument()
+    })
+
+    it('toggles closed when the avatar button is clicked again', async () => {
+      const user = userEvent.setup()
+      renderNavbar()
+
+      const button = screen.getByRole('button', { name: /open profile menu/i })
+      await user.click(button)
+      await user.click(button)
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    })
+
+    it('closes when Escape is pressed', async () => {
+      const user = userEvent.setup()
+      renderNavbar()
+
+      await user.click(screen.getByRole('button', { name: /open profile menu/i }))
+      expect(screen.getByRole('menu')).toBeInTheDocument()
+
+      await user.keyboard('{Escape}')
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    })
+
+    it('closes when clicking outside the menu', async () => {
+      const user = userEvent.setup()
+      render(
+        <MemoryRouter>
+          <Navbar />
+          <div data-testid="outside">outside</div>
+        </MemoryRouter>,
+      )
+
+      await user.click(screen.getByRole('button', { name: /open profile menu/i }))
+      expect(screen.getByRole('menu')).toBeInTheDocument()
+
+      fireEvent.mouseDown(screen.getByTestId('outside'))
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('menu actions', () => {
+    it('navigates to /profile when Profile is clicked', async () => {
+      const user = userEvent.setup()
+      renderNavbar()
+
+      await user.click(screen.getByRole('button', { name: /open profile menu/i }))
+      await user.click(screen.getByRole('menuitem', { name: /profile/i }))
+
+      expect(screen.getByText('profile page')).toBeInTheDocument()
+    })
+
+    it('calls logout and redirects to / when Log Out is clicked', async () => {
+      const user = userEvent.setup()
+      renderNavbar()
+
+      await user.click(screen.getByRole('button', { name: /open profile menu/i }))
+      await user.click(screen.getByRole('menuitem', { name: /log out/i }))
+
+      expect(logout).toHaveBeenCalledTimes(1)
+      expect(screen.getByText('home page')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 
 const AuthContext = createContext(null)
 
@@ -22,6 +23,8 @@ function isTokenExpired(token) {
 }
 
 export function AuthProvider({ children }) {
+  const queryClient = useQueryClient()
+
   // Lazy initializer: read token from localStorage but discard it if already expired.
   const [token, setToken] = useState(() => {
     const stored = localStorage.getItem('token')
@@ -41,10 +44,11 @@ export function AuthProvider({ children }) {
     function handleExpired() {
       localStorage.removeItem('token')
       setToken(null)
+      queryClient.removeQueries({ queryKey: ['currentUser'] })
     }
     window.addEventListener('auth:expired', handleExpired)
     return () => window.removeEventListener('auth:expired', handleExpired)
-  }, [])
+  }, [queryClient])
 
   function login(newToken) {
     localStorage.setItem('token', newToken)
@@ -54,6 +58,7 @@ export function AuthProvider({ children }) {
   function logout() {
     localStorage.removeItem('token')
     setToken(null)
+    queryClient.removeQueries({ queryKey: ['currentUser'] })
   }
 
   return (

--- a/frontend/src/context/AuthContext.test.jsx
+++ b/frontend/src/context/AuthContext.test.jsx
@@ -1,7 +1,17 @@
 import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider, useAuth } from './AuthContext.jsx'
 
-const wrapper = ({ children }) => <AuthProvider>{children}</AuthProvider>
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+const wrapper = makeWrapper()
 
 describe('AuthContext', () => {
   beforeEach(() => {

--- a/frontend/src/hooks/useCurrentUser.js
+++ b/frontend/src/hooks/useCurrentUser.js
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import { useAuth } from '../context/AuthContext.jsx'
+import { getCurrentUser } from '../services/userService.js'
+
+export const currentUserKey = ['currentUser']
+
+export function useCurrentUser() {
+  const { token, isAuthenticated } = useAuth()
+  return useQuery({
+    queryKey: currentUserKey,
+    queryFn: () => getCurrentUser(token),
+    enabled: isAuthenticated,
+    staleTime: 60_000,
+  })
+}

--- a/frontend/src/pages/Login.test.jsx
+++ b/frontend/src/pages/Login.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from '../context/AuthContext.jsx'
 import Login from './Login.jsx'
 import * as authService from '../services/authService.js'
@@ -14,11 +15,14 @@ vi.mock('react-router-dom', async (importOriginal) => {
 })
 
 function renderLogin() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <MemoryRouter>
-      <AuthProvider>
-        <Login />
-      </AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <Login />
+        </AuthProvider>
+      </QueryClientProvider>
     </MemoryRouter>,
   )
 }

--- a/frontend/src/pages/Signup.test.jsx
+++ b/frontend/src/pages/Signup.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from '../context/AuthContext.jsx'
 import Signup from './Signup.jsx'
 import * as authService from '../services/authService.js'
@@ -14,11 +15,14 @@ vi.mock('react-router-dom', async (importOriginal) => {
 })
 
 function renderSignup() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <MemoryRouter>
-      <AuthProvider>
-        <Signup />
-      </AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <Signup />
+        </AuthProvider>
+      </QueryClientProvider>
     </MemoryRouter>,
   )
 }

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,0 +1,9 @@
+import { apiFetch } from './api.js'
+
+function authHeaders(token) {
+  return { Authorization: `Bearer ${token}` }
+}
+
+export async function getCurrentUser(token) {
+  return apiFetch('/api/users/me', { headers: authHeaders(token) })
+}


### PR DESCRIPTION
# 📝 Add Profile Dropdown Menu to Navbar Avatar

Fixes #424

The static navbar avatar is now an interactive button that opens a dropdown with **Profile** and **Log Out** items, and renders the logged-in users `avatarUrl` (with a graceful fallback to the existing `person` icon on missing or broken images). When unauthenticated, the avatar is replaced with **Log In** / **Sign Up** links.

Profile data is fetched from the existing `GET /api/users/me` endpoint via a new TanStack Query hook (`useCurrentUser`). Profile menu item links to `/profile` — that route is owned by #299 and will start working once that PR lands.

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
<img width="1920" height="341" alt="1" src="https://github.com/user-attachments/assets/5249e4a3-666f-4140-8ae9-857b71a94772" />
<img width="1920" height="332" alt="2" src="https://github.com/user-attachments/assets/5856e5f8-50a6-4e5f-aab5-0de521cb1670" />


# ⏱️ Estimated Review Time
- [x] 5-15 min
@