### PR TITLE
[Backend] Replace Comment Entity With Request And Response DTOs

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/CommentController.java
@@ -1,7 +1,9 @@
 package com.bounswe2026group1.backend.controller;
 
+import com.bounswe2026group1.backend.dto.CreateCommentRequest;
 import com.bounswe2026group1.backend.model.Comment;
 import com.bounswe2026group1.backend.service.CommentService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,8 +40,8 @@ public class CommentController {
     }
 
     @PostMapping
-    public Comment create(@RequestBody Comment comment) {
-        return commentService.create(comment);
+    public Comment create(@RequestBody @Valid CreateCommentRequest req) {
+        return commentService.create(req);
     }
 
     @PutMapping("/{id}")

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/CommentController.java
@@ -2,7 +2,7 @@ package com.bounswe2026group1.backend.controller;
 
 import com.bounswe2026group1.backend.dto.CommentResponse;
 import com.bounswe2026group1.backend.dto.CreateCommentRequest;
-import com.bounswe2026group1.backend.model.Comment;
+import com.bounswe2026group1.backend.dto.UpdateCommentRequest;
 import com.bounswe2026group1.backend.service.CommentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -46,8 +46,8 @@ public class CommentController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<CommentResponse> update(@PathVariable Long id, @RequestBody Comment comment) {
-        return commentService.update(id, comment)
+    public ResponseEntity<CommentResponse> update(@PathVariable Long id, @RequestBody @Valid UpdateCommentRequest req) {
+        return commentService.update(id, req)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.controller;
 
+import com.bounswe2026group1.backend.dto.CommentResponse;
 import com.bounswe2026group1.backend.dto.CreateCommentRequest;
 import com.bounswe2026group1.backend.model.Comment;
 import com.bounswe2026group1.backend.service.CommentService;
@@ -18,34 +19,34 @@ public class CommentController {
     private final CommentService commentService;
 
     @GetMapping
-    public List<Comment> getAll() {
+    public List<CommentResponse> getAll() {
         return commentService.getAll();
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Comment> getById(@PathVariable Long id) {
+    public ResponseEntity<CommentResponse> getById(@PathVariable Long id) {
         return commentService.getById(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @GetMapping("/author/{authorId}")
-    public List<Comment> getByAuthor(@PathVariable Long authorId) {
+    public List<CommentResponse> getByAuthor(@PathVariable Long authorId) {
         return commentService.getByAuthor(authorId);
     }
 
     @GetMapping("/report/{reportId}")
-    public List<Comment> getByReport(@PathVariable Long reportId) {
+    public List<CommentResponse> getByReport(@PathVariable Long reportId) {
         return commentService.getByReport(reportId);
     }
 
     @PostMapping
-    public Comment create(@RequestBody @Valid CreateCommentRequest req) {
+    public CommentResponse create(@RequestBody @Valid CreateCommentRequest req) {
         return commentService.create(req);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Comment> update(@PathVariable Long id, @RequestBody Comment comment) {
+    public ResponseEntity<CommentResponse> update(@PathVariable Long id, @RequestBody Comment comment) {
         return commentService.update(id, comment)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/CommentResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/CommentResponse.java
@@ -1,0 +1,24 @@
+package com.bounswe2026group1.backend.dto;
+
+import com.bounswe2026group1.backend.model.Comment;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+
+import java.time.Instant;
+
+// Replaces the raw Comment entity on the response side. Returning the entity
+// directly leaked the author's BCrypt password hash, email, role, and Hibernate
+// proxy state on every comment endpoint — see issue #435.
+public record CommentResponse(
+        Long id,
+        String content,
+        Instant createdAt,
+        AuthorRef author
+) {
+    public record AuthorRef(Long id, String name, String avatarUrl) {}
+
+    public static CommentResponse fromEntity(Comment c) {
+        RegisteredUser a = c.getAuthor();
+        AuthorRef author = a == null ? null : new AuthorRef(a.getId(), a.getName(), a.getAvatarUrl());
+        return new CommentResponse(c.getId(), c.getContent(), c.getCreatedAt(), author);
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/CreateCommentRequest.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/CreateCommentRequest.java
@@ -1,0 +1,18 @@
+package com.bounswe2026group1.backend.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+// Records sidestep the Lombok @AllArgsConstructor + primitive-int pitfall
+// that Jackson 3 (Spring Boot 4) hits when binding the JPA Comment entity
+// directly as @RequestBody — see issue #433.
+public record CreateCommentRequest(
+        @NotBlank @Size(max = 1000) String content,
+        @NotNull @Valid AuthorRef author,
+        @NotNull @Valid ReportRef report
+) {
+    public record AuthorRef(@NotNull Long id) {}
+    public record ReportRef(@NotNull Long reportId) {}
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/UpdateCommentRequest.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/UpdateCommentRequest.java
@@ -1,0 +1,10 @@
+package com.bounswe2026group1.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// Same Jackson 3 / primitive-int pitfall as CreateCommentRequest — see issue #433.
+// Only `content` is mutable on update; author and report are fixed at creation time.
+public record UpdateCommentRequest(
+        @NotBlank @Size(max = 1000) String content
+) {}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/CommentService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/CommentService.java
@@ -2,6 +2,7 @@ package com.bounswe2026group1.backend.service;
 
 import com.bounswe2026group1.backend.dto.CommentResponse;
 import com.bounswe2026group1.backend.dto.CreateCommentRequest;
+import com.bounswe2026group1.backend.dto.UpdateCommentRequest;
 import com.bounswe2026group1.backend.model.Comment;
 import com.bounswe2026group1.backend.repository.CommentRepository;
 import com.bounswe2026group1.backend.repository.ReportRepository;
@@ -49,9 +50,10 @@ public class CommentService {
         return CommentResponse.fromEntity(saved);
     }
 
-    public Optional<CommentResponse> update(Long id, Comment updated) {
+    @Transactional
+    public Optional<CommentResponse> update(Long id, UpdateCommentRequest req) {
         return commentRepository.findById(id).map(existing -> {
-            existing.setContent(updated.getContent());
+            existing.setContent(req.content());
             return CommentResponse.fromEntity(commentRepository.save(existing));
         });
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/CommentService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.service;
 
+import com.bounswe2026group1.backend.dto.CommentResponse;
 import com.bounswe2026group1.backend.dto.CreateCommentRequest;
 import com.bounswe2026group1.backend.model.Comment;
 import com.bounswe2026group1.backend.repository.CommentRepository;
@@ -21,37 +22,37 @@ public class CommentService {
     private final RegisteredUserRepository registeredUserRepository;
     private final NotificationService notificationService;
 
-    public List<Comment> getAll() {
-        return commentRepository.findAll();
+    public List<CommentResponse> getAll() {
+        return commentRepository.findAll().stream().map(CommentResponse::fromEntity).toList();
     }
 
-    public Optional<Comment> getById(Long id) {
-        return commentRepository.findById(id);
+    public Optional<CommentResponse> getById(Long id) {
+        return commentRepository.findById(id).map(CommentResponse::fromEntity);
     }
 
-    public List<Comment> getByAuthor(Long id) {
-        return commentRepository.findByAuthorId(id);
+    public List<CommentResponse> getByAuthor(Long id) {
+        return commentRepository.findByAuthorId(id).stream().map(CommentResponse::fromEntity).toList();
     }
 
-    public List<Comment> getByReport(Long reportId) {
-        return commentRepository.findByReportReportId(reportId);
+    public List<CommentResponse> getByReport(Long reportId) {
+        return commentRepository.findByReportReportId(reportId).stream().map(CommentResponse::fromEntity).toList();
     }
 
     @Transactional
-    public Comment create(CreateCommentRequest req) {
+    public CommentResponse create(CreateCommentRequest req) {
         Comment comment = new Comment();
         comment.setContent(req.content());
         comment.setReport(reportRepository.getReferenceById(req.report().reportId()));
         comment.setAuthor(registeredUserRepository.getReferenceById(req.author().id()));
         Comment saved = commentRepository.save(comment);
         notificationService.notifyNewComment(saved);
-        return saved;
+        return CommentResponse.fromEntity(saved);
     }
 
-    public Optional<Comment> update(Long id, Comment updated) {
+    public Optional<CommentResponse> update(Long id, Comment updated) {
         return commentRepository.findById(id).map(existing -> {
             existing.setContent(updated.getContent());
-            return commentRepository.save(existing);
+            return CommentResponse.fromEntity(commentRepository.save(existing));
         });
     }
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/CommentService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.service;
 
+import com.bounswe2026group1.backend.dto.CreateCommentRequest;
 import com.bounswe2026group1.backend.model.Comment;
 import com.bounswe2026group1.backend.repository.CommentRepository;
 import com.bounswe2026group1.backend.repository.ReportRepository;
@@ -37,13 +38,11 @@ public class CommentService {
     }
 
     @Transactional
-    public Comment create(Comment comment) {
-        if (comment.getReport() != null && comment.getReport().getReportId() != null) {
-            comment.setReport(reportRepository.getReferenceById(comment.getReport().getReportId()));
-        }
-        if (comment.getAuthor() != null && comment.getAuthor().getId() != null) {
-            comment.setAuthor(registeredUserRepository.getReferenceById(comment.getAuthor().getId()));
-        }
+    public Comment create(CreateCommentRequest req) {
+        Comment comment = new Comment();
+        comment.setContent(req.content());
+        comment.setReport(reportRepository.getReferenceById(req.report().reportId()));
+        comment.setAuthor(registeredUserRepository.getReferenceById(req.author().id()));
         Comment saved = commentRepository.save(comment);
         notificationService.notifyNewComment(saved);
         return saved;

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/CommentControllerTest.java
@@ -1,9 +1,7 @@
 package com.bounswe2026group1.backend.controller;
 
+import com.bounswe2026group1.backend.dto.CommentResponse;
 import com.bounswe2026group1.backend.dto.CreateCommentRequest;
-import com.bounswe2026group1.backend.model.Comment;
-import com.bounswe2026group1.backend.model.RegisteredUser;
-import com.bounswe2026group1.backend.model.Report;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.service.CommentService;
 import com.bounswe2026group1.backend.util.JwtUtil;
@@ -17,12 +15,16 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -46,19 +48,12 @@ class CommentControllerTest {
             { "content": "looks good", "author": { "id": 3 }, "report": { "reportId": 18 } }
             """;
 
-    private Comment savedCommentStub() {
-        RegisteredUser author = new RegisteredUser();
-        author.setId(3L);
-        Report report = new Report();
-        report.setReportId(18L);
-
-        Comment c = new Comment();
-        c.setId(99L);
-        c.setContent("looks good");
-        c.setAuthor(author);
-        c.setReport(report);
-        c.setCreatedAt(Instant.parse("2026-05-08T20:00:00Z"));
-        return c;
+    private CommentResponse savedCommentStub() {
+        return new CommentResponse(
+                99L,
+                "looks good",
+                Instant.parse("2026-05-08T20:00:00Z"),
+                new CommentResponse.AuthorRef(3L, "Alice", null));
     }
 
     // ───── Happy path ────────────────────────────────────────────────────────
@@ -75,7 +70,65 @@ class CommentControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(99))
                 .andExpect(jsonPath("$.content").value("looks good"))
-                .andExpect(jsonPath("$.author.id").value(3));
+                .andExpect(jsonPath("$.author.id").value(3))
+                .andExpect(jsonPath("$.author.name").value("Alice"));
+    }
+
+    // ───── Response leak regression (issue #435) ────────────────────────────
+
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void create_responseDoesNotLeakAuthFields() throws Exception {
+        when(commentService.create(any(CreateCommentRequest.class))).thenReturn(savedCommentStub());
+
+        String body = mockMvc.perform(post("/api/comments")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.author.password").doesNotExist())
+                .andExpect(jsonPath("$.author.email").doesNotExist())
+                .andExpect(jsonPath("$.author.role").doesNotExist())
+                .andExpect(jsonPath("$.author.status").doesNotExist())
+                .andExpect(jsonPath("$.author.points").doesNotExist())
+                .andExpect(jsonPath("$.author.registeredAt").doesNotExist())
+                .andExpect(jsonPath("$.author.bio").doesNotExist())
+                .andExpect(jsonPath("$.author.hibernateLazyInitializer").doesNotExist())
+                .andReturn().getResponse().getContentAsString();
+
+        // Belt-and-suspenders: BCrypt hashes always start with $2a$, $2b$, or $2y$.
+        // If any leaks back in, this catches it regardless of the field name.
+        if (body.matches("(?s).*\\$2[aby]\\$\\d{2}\\$.*")) {
+            throw new AssertionError("Response leaks a BCrypt-shaped string: " + body);
+        }
+    }
+
+    @Test
+    void getByReport_responseDoesNotLeakAuthFields() throws Exception {
+        when(commentService.getByReport(eq(18L))).thenReturn(java.util.List.of(savedCommentStub()));
+
+        mockMvc.perform(get("/api/comments/report/18")
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(99))
+                .andExpect(jsonPath("$[0].author.id").value(3))
+                .andExpect(jsonPath("$[0].author.name").value("Alice"))
+                .andExpect(jsonPath("$[0].author.password").doesNotExist())
+                .andExpect(jsonPath("$[0].author.email").doesNotExist())
+                .andExpect(jsonPath("$[0].author.hibernateLazyInitializer").doesNotExist());
+    }
+
+    @Test
+    void getById_responseDoesNotLeakAuthFields() throws Exception {
+        when(commentService.getById(eq(99L))).thenReturn(Optional.of(savedCommentStub()));
+
+        mockMvc.perform(get("/api/comments/99")
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.author.password").doesNotExist())
+                .andExpect(jsonPath("$.author.email").doesNotExist())
+                .andExpect(jsonPath("$.author.hibernateLazyInitializer").doesNotExist())
+                .andExpect(content().string(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("$2a$"))));
     }
 
     // ───── Validation ────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/CommentControllerTest.java
@@ -1,0 +1,125 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.dto.CreateCommentRequest;
+import com.bounswe2026group1.backend.model.Comment;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.service.CommentService;
+import com.bounswe2026group1.backend.util.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CommentController.class)
+class CommentControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private CommentService commentService;
+    @MockitoBean private JwtUtil jwtUtil;
+    @MockitoBean private RegisteredUserRepository registeredUserRepository;
+
+    @Value("${app.api.key}")
+    private String validApiKey;
+
+    private static final String AUTHOR_EMAIL = "alice@example.com";
+
+    // Pinned wire contract — the exact shape the deployed web and mobile clients
+    // already send. If this body ever stops deserializing, this test fails first.
+    private static final String VALID_BODY = """
+            { "content": "looks good", "author": { "id": 3 }, "report": { "reportId": 18 } }
+            """;
+
+    private Comment savedCommentStub() {
+        RegisteredUser author = new RegisteredUser();
+        author.setId(3L);
+        Report report = new Report();
+        report.setReportId(18L);
+
+        Comment c = new Comment();
+        c.setId(99L);
+        c.setContent("looks good");
+        c.setAuthor(author);
+        c.setReport(report);
+        c.setCreatedAt(Instant.parse("2026-05-08T20:00:00Z"));
+        return c;
+    }
+
+    // ───── Happy path ────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void create_acceptsLegacyNestedWireShape_andPersists() throws Exception {
+        when(commentService.create(any(CreateCommentRequest.class))).thenReturn(savedCommentStub());
+
+        mockMvc.perform(post("/api/comments")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(99))
+                .andExpect(jsonPath("$.content").value("looks good"))
+                .andExpect(jsonPath("$.author.id").value(3));
+    }
+
+    // ───── Validation ────────────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void create_rejectsBlankContent_with400() throws Exception {
+        mockMvc.perform(post("/api/comments")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "content": "", "author": { "id": 3 }, "report": { "reportId": 18 } }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verify(commentService, never()).create(any(CreateCommentRequest.class));
+    }
+
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void create_rejectsMissingAuthorId_with400() throws Exception {
+        mockMvc.perform(post("/api/comments")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "content": "x", "author": {}, "report": { "reportId": 18 } }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verify(commentService, never()).create(any(CreateCommentRequest.class));
+    }
+
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void create_rejectsMissingReportId_with400() throws Exception {
+        mockMvc.perform(post("/api/comments")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "content": "x", "author": { "id": 3 }, "report": {} }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verify(commentService, never()).create(any(CreateCommentRequest.class));
+    }
+
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/CommentControllerTest.java
@@ -2,6 +2,7 @@ package com.bounswe2026group1.backend.controller;
 
 import com.bounswe2026group1.backend.dto.CommentResponse;
 import com.bounswe2026group1.backend.dto.CreateCommentRequest;
+import com.bounswe2026group1.backend.dto.UpdateCommentRequest;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.service.CommentService;
 import com.bounswe2026group1.backend.util.JwtUtil;
@@ -24,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -173,6 +175,76 @@ class CommentControllerTest {
                 .andExpect(status().isBadRequest());
 
         verify(commentService, never()).create(any(CreateCommentRequest.class));
+    }
+
+    // ───── PUT /api/comments/{id} ────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void update_acceptsContentOnlyBody_andReturnsSlimResponse() throws Exception {
+        when(commentService.update(eq(99L), any(UpdateCommentRequest.class)))
+                .thenReturn(Optional.of(savedCommentStub()));
+
+        mockMvc.perform(put("/api/comments/99")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "content": "edited" }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(99))
+                .andExpect(jsonPath("$.author.id").value(3))
+                .andExpect(jsonPath("$.author.password").doesNotExist())
+                .andExpect(jsonPath("$.author.email").doesNotExist())
+                .andExpect(jsonPath("$.author.hibernateLazyInitializer").doesNotExist());
+    }
+
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void update_returns404WhenMissing() throws Exception {
+        when(commentService.update(eq(404L), any(UpdateCommentRequest.class)))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(put("/api/comments/404")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "content": "edited" }
+                                """))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void update_rejectsBlankContent_with400() throws Exception {
+        mockMvc.perform(put("/api/comments/99")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "content": "" }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verify(commentService, never()).update(any(Long.class), any(UpdateCommentRequest.class));
+    }
+
+    // The original prod-failure body for POST contained nested `author` and `report`
+    // objects that triggered Jackson 3's primitive-int blow-up. Make sure the PUT
+    // endpoint is no longer reachable through that legacy entity-shaped body — it
+    // should fail validation cleanly (no 5xx, no leaked fields) since the new DTO
+    // only declares `content`.
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void update_rejectsLegacyEntityBody_with400() throws Exception {
+        mockMvc.perform(put("/api/comments/99")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "author": { "id": 3 }, "report": { "reportId": 18 } }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verify(commentService, never()).update(any(Long.class), any(UpdateCommentRequest.class));
     }
 
 }


### PR DESCRIPTION
# 📝 Replace Comment Entity With Request And Response DTOs

Fixes #433
Fixes #435

`CommentController` was using the JPA `Comment` entity as both the `@RequestBody` type and the response type. Under Spring Boot 4 / Jackson 3 that broke both directions:

- **Inbound (#433):** Jackson 3 picks Lombok's `@AllArgsConstructor` on `RegisteredUser`/`Report` (transitively reachable through `Comment.author`/`Comment.report`) and passes `null` for absent fields. Primitive `int` targets (`RegisteredUser.points`, `Report.agrees`/`disagrees`) reject `null`, and every `POST /api/comments` returned 400 from prod.
- **Outbound (#435):** Every comment response — including unauthenticated `GET /api/comments/**` — was serializing the full `RegisteredUser`, leaking the BCrypt **password hash**, `email`, `role`, `status`, `registeredAt`, `points`, and Hibernate's internal `hibernateLazyInitializer` proxy.

This PR introduces three record DTOs that decouple the wire format from the JPA layer.

- `CreateCommentRequest` mirrors the **existing** wire shape so deployed web and mobile clients keep working unchanged: `{content, author:{id}, report:{reportId}}`.
- `UpdateCommentRequest` exposes only `{content}` for `PUT /api/comments/{id}` — author/report aren't mutable post-creation, and a content-only DTO sidesteps the same Jackson 3 trap.
- `CommentResponse` exposes only `{id, content, createdAt, author:{id, name, avatarUrl}}` — what [ReportPanel.jsx](frontend/src/components/ReportPanel.jsx) and [report_detail_screen.dart](mobile/lib/screens/report_detail_screen.dart) actually consume.

Verified end-to-end against `docker-compose.local.yml`:
- `POST /api/comments` with the exact body from the prod failure trace returns 200
- `GET /api/comments/report/{reportId}` (anonymous) returns the slim shape with no auth fields
- `PUT /api/comments/{id}` with `{content}` returns 200; the legacy entity-shaped body is rejected with 400

# 📊 Type of Change
- [x] Bug fix
- [x] Refactoring

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# ⏱️ Estimated Review Time
- [x] 5-15 min