### PR TITLE
[Backend][Bug] Verified Reports Don't Revert to Pending When Agrees Drop Below Threshold

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/service/NotificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/NotificationService.java
@@ -70,20 +70,18 @@ public class NotificationService {
         return saved;
     }
 
-    /** Trigger: report status transitioned to VERIFIED, REJECTED, or FIXED.
+    /** Trigger: report status transitioned to PENDING, VERIFIED, REJECTED, or FIXED.
      *  Notifies the report author, anyone who commented or voted on the report,
      *  and any explicit subscribers, minus the actor whose action triggered the
      *  change. Caller must only invoke this when the status actually changed. */
     public void notifyStatusChange(Report report, Long actorUserId) {
         if (report == null || report.getCreatedBy() == null) return;
         ReportStatus status = report.getStatus();
-        if (status != ReportStatus.VERIFIED
+        if (status != ReportStatus.PENDING
+                && status != ReportStatus.VERIFIED
                 && status != ReportStatus.REJECTED
                 && status != ReportStatus.FIXED) return;
 
-        // Use Locale.ROOT so 'VERIFIED' lowercases to 'verified' even on Turkish JVMs
-        // (default-locale toLowerCase would map I -> dotless 'ı').
-        String statusLower = status.name().toLowerCase(Locale.ROOT);
         Long reportId = report.getReportId();
         Long authorId = report.getCreatedBy().getId();
 
@@ -92,7 +90,7 @@ public class NotificationService {
         for (Long recipientId : audience) {
             RegisteredUser recipient = recipientsById.get(recipientId);
             if (recipient == null) continue;
-            String message = buildStatusMessage(recipientId, authorId, reportId, statusLower);
+            String message = buildStatusMessage(recipientId, authorId, reportId, status);
             create(recipient, message, NotificationType.STATUS_CHANGE, reportId);
         }
     }
@@ -166,8 +164,16 @@ public class NotificationService {
                 .collect(Collectors.toMap(RegisteredUser::getId, Function.identity()));
     }
 
-    private static String buildStatusMessage(Long recipientId, Long authorId, Long reportId, String statusLower) {
+    private static String buildStatusMessage(Long recipientId, Long authorId, Long reportId, ReportStatus status) {
         boolean isAuthor = authorId != null && authorId.equals(recipientId);
+        if (status == ReportStatus.PENDING) {
+            return isAuthor
+                    ? "Your report #" + reportId + " is now pending again."
+                    : "Report #" + reportId + " you follow is now pending again.";
+        }
+        // Use Locale.ROOT so 'VERIFIED' lowercases to 'verified' even on Turkish JVMs
+        // (default-locale toLowerCase would map I -> dotless 'ı').
+        String statusLower = status.name().toLowerCase(Locale.ROOT);
         return isAuthor
                 ? "Your report #" + reportId + " was " + statusLower + "."
                 : "Report #" + reportId + " you follow was " + statusLower + ".";

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -362,13 +362,9 @@ public class ReportService {
             target = ReportStatus.VERIFIED;
         } else if (disagrees >= verificationThreshold && disagreeRatio >= verificationRatio) {
             target = ReportStatus.REJECTED;
-        } else if (current == ReportStatus.VERIFIED
-                && disagrees >= verificationThreshold
-                && agreeRatio < verificationRatio) {
-            target = ReportStatus.PENDING;
-        } else if (current == ReportStatus.REJECTED
-                && agrees >= verificationThreshold
-                && disagreeRatio < verificationRatio) {
+        } else if (current == ReportStatus.VERIFIED || current == ReportStatus.REJECTED) {
+            // Verification/rejection criteria no longer hold (count or ratio fell below
+            // threshold, e.g. via vote retraction). Revert to PENDING symmetrically.
             target = ReportStatus.PENDING;
         }
 

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/NotificationServiceTest.java
@@ -126,12 +126,24 @@ class NotificationServiceTest {
     }
 
     @Test
-    void notifyStatusChange_skipsTransitionsThatAreNotVerifiedOrRejectedOrFixed() {
+    void notifyStatusChange_persistsRevertToPendingWithDistinctPhrasing() {
+        stubEmptyAudience();
+        stubSaveAssignsId();
+        stubFindAllByIdReturns(author);
         report.setStatus(ReportStatus.PENDING);
 
         notificationService.notifyStatusChange(report, 999L);
 
-        verify(notificationRepository, never()).save(any());
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+
+        Notification saved = captor.getValue();
+        assertEquals(NotificationType.STATUS_CHANGE, saved.getType());
+        assertEquals(author, saved.getRecipient());
+        // PENDING reverts use "is now pending again" instead of the past-tense
+        // "was X" used for VERIFIED/REJECTED/FIXED milestones.
+        assertTrue(saved.getMessage().contains("pending again"),
+                "Revert message should read naturally, got: " + saved.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -590,6 +590,56 @@ class ReportServiceTest {
     }
 
     @Test
+    void verifyReport_retractAgreeFromVerifiedDropsBelowThreshold_revertsToPending() {
+        // Pre VERIFIED, agrees=5, disagrees=0. User retracts their agree -> agrees=4.
+        // Verification criteria no longer hold (4 < 5) -> revert to PENDING.
+        ReflectionTestUtils.setField(testReport, "agrees", 5);
+        ReflectionTestUtils.setField(testReport, "disagrees", 0);
+        ReflectionTestUtils.setField(testReport, "status", ReportStatus.VERIFIED);
+        ReflectionTestUtils.setField(reportService, "verificationThreshold", 5);
+        ReflectionTestUtils.setField(reportService, "verificationRatio", 0.60);
+        testUser.setEmail("user@test.com");
+        ReportVerification existing = new ReportVerification(testUser, testReport, VoteType.AGREE);
+
+        when(registeredUserRepository.findByEmail("user@test.com")).thenReturn(Optional.of(testUser));
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(verificationRepository.findByUserIdAndReportReportId(1L, 1L)).thenReturn(Optional.of(existing));
+        when(reportRepository.save(any(Report.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        reportService.verifyReport(1L, "user@test.com");
+
+        assertEquals(4, testReport.getAgrees());
+        assertEquals(ReportStatus.PENDING, testReport.getStatus());
+        verify(publicSseService).broadcastReportUpdated(testReport, "pending");
+        verify(notificationService).notifyStatusChange(testReport, testUser.getId());
+    }
+
+    @Test
+    void unverifyReport_retractDisagreeFromRejectedDropsBelowThreshold_revertsToPending() {
+        // Pre REJECTED, disagrees=5, agrees=0. User retracts their disagree -> disagrees=4.
+        // Rejection criteria no longer hold (4 < 5) -> revert to PENDING.
+        ReflectionTestUtils.setField(testReport, "agrees", 0);
+        ReflectionTestUtils.setField(testReport, "disagrees", 5);
+        ReflectionTestUtils.setField(testReport, "status", ReportStatus.REJECTED);
+        ReflectionTestUtils.setField(reportService, "verificationThreshold", 5);
+        ReflectionTestUtils.setField(reportService, "verificationRatio", 0.60);
+        testUser.setEmail("user@test.com");
+        ReportVerification existing = new ReportVerification(testUser, testReport, VoteType.DISAGREE);
+
+        when(registeredUserRepository.findByEmail("user@test.com")).thenReturn(Optional.of(testUser));
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(verificationRepository.findByUserIdAndReportReportId(1L, 1L)).thenReturn(Optional.of(existing));
+        when(reportRepository.save(any(Report.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        reportService.unverifyReport(1L, "user@test.com");
+
+        assertEquals(4, testReport.getDisagrees());
+        assertEquals(ReportStatus.PENDING, testReport.getStatus());
+        verify(publicSseService).broadcastReportUpdated(testReport, "pending");
+        verify(notificationService).notifyStatusChange(testReport, testUser.getId());
+    }
+
+    @Test
     void verifyReport_rejectedRecoversDirectlyToVerified() {
         // Pre REJECTED, disagrees=5, agrees=7 + 1 new = 8 -> 8/13 = 0.615 >= 0.60 -> VERIFIED
         ReflectionTestUtils.setField(testReport, "agrees", 7);


### PR DESCRIPTION
# 📝 Verified Reports Don't Revert to Pending When Agrees Drop Below Threshold
Fixes #441

Once a report reached `VERIFIED`, `evaluateStatus` only reverted to `PENDING` when 5+ disagrees came in with ratio < 60%, leaving stale-criteria reports stuck verified after a vote retraction (e.g. 4 agrees, 0 disagrees, still VERIFIED). Same asymmetry on the `REJECTED` side. The fix collapses both revert branches into a single fall-through and extends the status-change fan-out so PENDING reverts produce a notification.

# 📊 Type of Change
- [x] Bug fix

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# ⏱️ Estimated Review Time
- [x] < 5 min