### PR TITLE
[Backend] Use Report ID for New Comment Notifications

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/service/NotificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/NotificationService.java
@@ -116,7 +116,7 @@ public class NotificationService {
             RegisteredUser recipient = recipientsById.get(recipientId);
             if (recipient == null) continue;
             String message = buildCommentMessage(recipientId, authorId, reportId, commenterName);
-            create(recipient, message, NotificationType.NEW_COMMENT, comment.getId());
+            create(recipient, message, NotificationType.NEW_COMMENT, reportId);
         }
     }
 

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/NotificationServiceTest.java
@@ -259,7 +259,7 @@ class NotificationServiceTest {
         Notification saved = captor.getValue();
         assertEquals(NotificationType.NEW_COMMENT, saved.getType());
         assertEquals(author, saved.getRecipient());
-        assertEquals(55L, saved.getRelatedEntityId());
+        assertEquals(100L, saved.getRelatedEntityId());
         assertTrue(saved.getMessage().startsWith("Bob"));
     }
 


### PR DESCRIPTION
# 📝 Use Report ID for New Comment Notifications
Fixes #445

`NEW_COMMENT` notifications were storing the comment id in `relatedEntityId`, while `STATUS_CHANGE` stores the report id. Clients that route on `relatedEntityId` (e.g. the mobile notification center in #442) need a consistent target — the parent report. This change makes both notification types carry the report id.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min