### PR TITLE
[Backend] Expand report taxonomy

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/model/IssueType.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/IssueType.java
@@ -6,15 +6,21 @@ import java.util.Set;
 public enum IssueType {
     MISSING(
         "This feature is absent where it should exist.",
-        EnumSet.of(ObjectType.RAMP, ObjectType.ELEVATOR, ObjectType.SIDEWALK, ObjectType.DOOR, ObjectType.STAIR)
+        EnumSet.of(
+            ObjectType.RAMP, ObjectType.ELEVATOR, ObjectType.SIDEWALK, ObjectType.DOOR, ObjectType.STAIR,
+            ObjectType.PEDESTRIAN_CROSSING, ObjectType.CURB_RAMP, ObjectType.WASHROOM, ObjectType.ROOM_SIGN
+        )
     ),
     TOO_STEEP(
         "The ramp slope exceeds accessibility limits (>10% for existing, >8% for new construction).",
-        EnumSet.of(ObjectType.RAMP)
+        EnumSet.of(ObjectType.RAMP, ObjectType.CURB_RAMP)
     ),
     TOO_NARROW(
         "The clear passage width is below the accessible minimum.",
-        EnumSet.of(ObjectType.RAMP, ObjectType.SIDEWALK, ObjectType.DOOR, ObjectType.STAIR)
+        EnumSet.of(
+            ObjectType.RAMP, ObjectType.SIDEWALK, ObjectType.DOOR, ObjectType.STAIR,
+            ObjectType.CURB_RAMP, ObjectType.WASHROOM
+        )
     ),
     MISSING_HANDRAIL(
         "No handrail is present; handrails are required on both sides at 90 cm height.",
@@ -30,11 +36,11 @@ public enum IssueType {
     ),
     BLOCKED(
         "An obstacle (parked vehicle, furniture, debris) blocks the walkway.",
-        EnumSet.of(ObjectType.SIDEWALK)
+        EnumSet.of(ObjectType.SIDEWALK, ObjectType.PEDESTRIAN_CROSSING)
     ),
     NO_TACTILE_PAVING(
         "Tactile guidance strips for visually impaired users are missing.",
-        EnumSet.of(ObjectType.SIDEWALK)
+        EnumSet.of(ObjectType.SIDEWALK, ObjectType.PEDESTRIAN_CROSSING)
     ),
     INSUFFICIENT_CLEARANCE(
         "The vertical clearance is below 220 cm (e.g. low-hanging branches, signs).",
@@ -58,7 +64,7 @@ public enum IssueType {
     ),
     NO_GRAB_BAR(
         "No grab bar inside the cabin; required at 80 cm height on at least one side wall.",
-        EnumSet.of(ObjectType.ELEVATOR)
+        EnumSet.of(ObjectType.ELEVATOR, ObjectType.WASHROOM)
     ),
     INSUFFICIENT_LANDING(
         "The approach area in front of the elevator doors is less than 120–150 cm.",
@@ -66,7 +72,7 @@ public enum IssueType {
     ),
     HIGH_THRESHOLD(
         "The raised sill at the base of the door exceeds 0.6 cm, blocking wheels and causing trips.",
-        EnumSet.of(ObjectType.DOOR)
+        EnumSet.of(ObjectType.DOOR, ObjectType.WASHROOM)
     ),
     STEP_AT_ENTRANCE(
         "One or more steps at the entrance create a barrier where a ramp is needed.",
@@ -99,6 +105,128 @@ public enum IssueType {
     OPEN_RISERS(
         "The vertical face between steps is open, allowing canes/walkers to slip through.",
         EnumSet.of(ObjectType.STAIR)
+    ),
+
+    // --- Door (indoor-relevant additions) ---
+    NO_GLASS_MARKING(
+        "Large glass surfaces lack the required three contrast bands (10–30 cm, 90–100 cm, 130–140 cm) to prevent collisions.",
+        EnumSet.of(ObjectType.DOOR)
+    ),
+    HANDLE_HEIGHT_INVALID(
+        "Door handle is mounted outside the accessible 90–110 cm range.",
+        EnumSet.of(ObjectType.DOOR)
+    ),
+    INTERCOM_INACCESSIBLE(
+        "Intercom or doorbell is outside the 90–140 cm height range or not approachable from the side.",
+        EnumSet.of(ObjectType.DOOR)
+    ),
+
+    // --- Elevator (indoor) ---
+    NO_BRAILLE(
+        "Control panel or sign lacks Braille / raised tactile labels required for visually impaired users.",
+        EnumSet.of(ObjectType.ELEVATOR, ObjectType.ROOM_SIGN)
+    ),
+    BUTTON_HEIGHT_INVALID(
+        "Control buttons are mounted outside the accessible 85–120 cm range.",
+        EnumSet.of(ObjectType.ELEVATOR)
+    ),
+    INSUFFICIENT_LIGHTING(
+        "Lighting falls below the required level (cabin floor 100 lux, controls 200 lux, signage 200+ lux).",
+        EnumSet.of(ObjectType.ELEVATOR, ObjectType.ROOM_SIGN)
+    ),
+
+    // --- Stair ---
+    IRREGULAR_STEPS(
+        "Step risers or treads vary in size; all steps in a flight must be uniform.",
+        EnumSet.of(ObjectType.STAIR)
+    ),
+    MISSING_NOSING_STRIP(
+        "Step edges lack the contrasting non-slip nosing strip (2.5–5 cm wide) required for visibility.",
+        EnumSet.of(ObjectType.STAIR)
+    ),
+
+    // --- Sidewalk ---
+    UNEVEN_SURFACE(
+        "Surface is cracked, potholed, or otherwise damaged, creating a trip/fall hazard.",
+        EnumSet.of(ObjectType.SIDEWALK)
+    ),
+    UNRAMPED_LEVEL_DIFFERENCE(
+        "A vertical level change greater than 1.3 cm is not chamfered or ramped as required.",
+        EnumSet.of(ObjectType.SIDEWALK)
+    ),
+
+    // --- Ramp ---
+    HANDRAIL_TOO_LOW(
+        "Handrail is present but mounted below the required 90 cm height.",
+        EnumSet.of(ObjectType.RAMP)
+    ),
+    INSUFFICIENT_LANDING_AREA(
+        "Top/bottom landing is smaller than the required 150 × 150 cm maneuvering area.",
+        EnumSet.of(ObjectType.RAMP)
+    ),
+
+    // --- Pedestrian crossing ---
+    NO_AUDIO_SIGNAL(
+        "Signalized crossing lacks an audible cue for visually impaired users.",
+        EnumSet.of(ObjectType.PEDESTRIAN_CROSSING)
+    ),
+    SIGNAL_TOO_SHORT(
+        "Pedestrian green-light interval is too short to cross safely at accessible walking speed.",
+        EnumSet.of(ObjectType.PEDESTRIAN_CROSSING)
+    ),
+    NO_DROPPED_CURB(
+        "Crossing lacks a flush dropped curb on at least one side, blocking wheelchair access.",
+        EnumSet.of(ObjectType.PEDESTRIAN_CROSSING)
+    ),
+    FADED_MARKINGS(
+        "Crossing markings are worn or faded, making the crossing hard to see.",
+        EnumSet.of(ObjectType.PEDESTRIAN_CROSSING)
+    ),
+    NO_PEDESTRIAN_REFUGE(
+        "Wide crossings lack a central refuge island for slower pedestrians.",
+        EnumSet.of(ObjectType.PEDESTRIAN_CROSSING)
+    ),
+
+    // --- Curb ramp ---
+    NO_TACTILE_WARNING(
+        "Curb ramp lacks the truncated-dome / tactile warning surface at the street edge.",
+        EnumSet.of(ObjectType.CURB_RAMP)
+    ),
+    RAISED_LIP(
+        "Curb ramp has a raised lip at the gutter that catches wheels.",
+        EnumSet.of(ObjectType.CURB_RAMP)
+    ),
+
+    // --- Washroom (indoor) ---
+    NO_ACCESSIBLE_STALL(
+        "No accessible toilet stall is provided (none meet the size and grab-bar requirements).",
+        EnumSet.of(ObjectType.WASHROOM)
+    ),
+    INSUFFICIENT_TURNING_SPACE(
+        "Interior turning space is below the required 150 × 150 cm wheelchair turning circle.",
+        EnumSet.of(ObjectType.WASHROOM)
+    ),
+    SINK_TOO_HIGH(
+        "Sink rim is above the accessible mounting height, preventing seated approach.",
+        EnumSet.of(ObjectType.WASHROOM)
+    ),
+    NO_EMERGENCY_BUTTON(
+        "Accessible stall lacks an emergency call button reachable from the floor.",
+        EnumSet.of(ObjectType.WASHROOM)
+    ),
+
+    // --- Room sign (indoor wayfinding) ---
+    LOW_CONTRAST(
+        "Sign text and background lack sufficient colour contrast for low-vision users.",
+        EnumSet.of(ObjectType.ROOM_SIGN)
+    ),
+    TEXT_TOO_SMALL(
+        "Sign text is below the legible size required at expected reading distance.",
+        EnumSet.of(ObjectType.ROOM_SIGN)
+    ),
+    INVALID_HEIGHT(
+        "Sign is mounted outside the accessible viewing height range (typically 120–160 cm centerline).",
+        EnumSet.of(ObjectType.ROOM_SIGN)
     );
 
     private final String description;

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/ObjectType.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/ObjectType.java
@@ -5,7 +5,11 @@ public enum ObjectType {
     ELEVATOR("A vertical lift providing access between floors."),
     SIDEWALK("A paved pedestrian path alongside a road or within a site."),
     DOOR("A door or entrance, including building entrances and interior doors."),
-    STAIR("A flight of steps connecting different floor levels.");
+    STAIR("A flight of steps connecting different floor levels."),
+    PEDESTRIAN_CROSSING("A marked or signalized pedestrian crossing where a sidewalk meets a roadway."),
+    CURB_RAMP("A short ramp cut into a curb that allows wheelchairs and strollers to traverse the kerb at crossings."),
+    WASHROOM("An accessible toilet/restroom, including stalls, sinks, and grab bars."),
+    ROOM_SIGN("A sign or plaque identifying a room or interior space, including Braille and tactile labels.");
 
     private final String description;
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingConstraint.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingConstraint.java
@@ -91,7 +91,28 @@ public enum RoutingConstraint {
     AVOID_MISSING_TACTILE_PAVING(
             "Avoid sidewalks lacking tactile paving",
             "Routes will avoid sidewalks reported as missing tactile guidance strips for visually impaired users.",
-            Set.of(new IssueHazard(SIDEWALK, NO_TACTILE_PAVING)));
+            Set.of(new IssueHazard(SIDEWALK, NO_TACTILE_PAVING))),
+
+    REQUIRE_CURB_RAMPS(
+            "Prefer crossings with curb ramps",
+            "Routes will avoid crossings reported as missing curb ramps, having unsafe slopes, or with raised lips.",
+            Set.of(
+                    new IssueHazard(CURB_RAMP, MISSING),
+                    new IssueHazard(CURB_RAMP, TOO_STEEP),
+                    new IssueHazard(CURB_RAMP, TOO_NARROW),
+                    new IssueHazard(CURB_RAMP, RAISED_LIP))),
+
+    AVOID_INACCESSIBLE_CROSSINGS(
+            "Avoid inaccessible pedestrian crossings",
+            "Routes will avoid pedestrian crossings reported as missing, blocked, lacking dropped curbs, lacking tactile paving, or lacking audio signals.",
+            Set.of(
+                    new IssueHazard(PEDESTRIAN_CROSSING, MISSING),
+                    new IssueHazard(PEDESTRIAN_CROSSING, BLOCKED),
+                    new IssueHazard(PEDESTRIAN_CROSSING, NO_DROPPED_CURB),
+                    new IssueHazard(PEDESTRIAN_CROSSING, NO_TACTILE_PAVING),
+                    new IssueHazard(PEDESTRIAN_CROSSING, NO_AUDIO_SIGNAL),
+                    new IssueHazard(PEDESTRIAN_CROSSING, SIGNAL_TOO_SHORT),
+                    new IssueHazard(PEDESTRIAN_CROSSING, FADED_MARKINGS)));
 
     private final String label;
     private final String description;

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingConstraint.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingConstraint.java
@@ -29,7 +29,9 @@ public enum RoutingConstraint {
                     new IssueHazard(STAIR, RISER_TOO_HIGH),
                     new IssueHazard(STAIR, TREAD_TOO_SHALLOW),
                     new IssueHazard(STAIR, NO_ANTI_SLIP),
-                    new IssueHazard(STAIR, OPEN_RISERS))),
+                    new IssueHazard(STAIR, OPEN_RISERS),
+                    new IssueHazard(STAIR, IRREGULAR_STEPS),
+                    new IssueHazard(STAIR, MISSING_NOSING_STRIP))),
 
     REQUIRE_RAMPS(
             "Prefer routes with ramps over steps",

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingPreset.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/RoutingPreset.java
@@ -27,14 +27,17 @@ public enum RoutingPreset {
                     REQUIRE_RAMPS,
                     AVOID_UNSAFE_RAMPS,
                     AVOID_NARROW_SIDEWALKS,
-                    AVOID_BLOCKED_OR_MISSING_SIDEWALKS),
+                    AVOID_BLOCKED_OR_MISSING_SIDEWALKS,
+                    REQUIRE_CURB_RAMPS,
+                    AVOID_INACCESSIBLE_CROSSINGS),
             TravelMode.WHEELCHAIR),
 
     BLIND_OR_LOW_VISION("Blind or low vision",
             EnumSet.of(
                     AVOID_LOW_CLEARANCE,
                     AVOID_BLOCKED_OR_MISSING_SIDEWALKS,
-                    AVOID_MISSING_TACTILE_PAVING),
+                    AVOID_MISSING_TACTILE_PAVING,
+                    AVOID_INACCESSIBLE_CROSSINGS),
             TravelMode.WALKING),
 
     MOBILITY_LIMITED("Mobility limited (cane, walker, elderly)",

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/MeasurementSchemas.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/MeasurementSchemas.java
@@ -8,24 +8,40 @@ public final class MeasurementSchemas {
 
     private MeasurementSchemas() {}
 
-    private static final Map<ObjectType, String> SCHEMAS = Map.of(
-        ObjectType.RAMP,
+    private static final Map<ObjectType, String> SCHEMAS = Map.ofEntries(
+        Map.entry(ObjectType.RAMP,
             "{\"slope_percent\":{\"min\":0,\"max\":100,\"accessible_max\":10}," +
             "\"width_cm\":{\"min\":0,\"max\":500,\"accessible_min\":100}," +
-            "\"height_cm\":{\"min\":0,\"max\":1000}}",
-        ObjectType.ELEVATOR,
+            "\"height_cm\":{\"min\":0,\"max\":1000}}"),
+        Map.entry(ObjectType.ELEVATOR,
             "{\"door_width_cm\":{\"min\":0,\"max\":300,\"accessible_min\":90}," +
             "\"cabin_width_cm\":{\"min\":0,\"max\":500,\"accessible_min\":120}," +
-            "\"cabin_depth_cm\":{\"min\":0,\"max\":500,\"accessible_min\":140}}",
-        ObjectType.SIDEWALK,
+            "\"cabin_depth_cm\":{\"min\":0,\"max\":500,\"accessible_min\":140}}"),
+        Map.entry(ObjectType.SIDEWALK,
             "{\"height_cm\":{\"min\":0,\"max\":100,\"accessible_max\":15}," +
-            "\"width_cm\":{\"min\":0,\"max\":500,\"accessible_min\":150}}",
-        ObjectType.DOOR,
+            "\"width_cm\":{\"min\":0,\"max\":500,\"accessible_min\":150}}"),
+        Map.entry(ObjectType.DOOR,
             "{\"width_cm\":{\"min\":0,\"max\":300,\"accessible_min\":90}," +
-            "\"threshold_height_cm\":{\"min\":0,\"max\":50,\"accessible_max\":0.6}}",
-        ObjectType.STAIR,
+            "\"threshold_height_cm\":{\"min\":0,\"max\":50,\"accessible_max\":0.6}}"),
+        Map.entry(ObjectType.STAIR,
             "{\"riser_cm\":{\"min\":0,\"max\":50,\"accessible_max\":16}," +
-            "\"tread_cm\":{\"min\":0,\"max\":100,\"accessible_min\":27}}"
+            "\"tread_cm\":{\"min\":0,\"max\":100,\"accessible_min\":27}}"),
+        Map.entry(ObjectType.PEDESTRIAN_CROSSING,
+            "{\"signal_duration_sec\":{\"min\":0,\"max\":120,\"accessible_min\":15}," +
+            "\"crossing_width_cm\":{\"min\":0,\"max\":2000,\"accessible_min\":300}," +
+            "\"dropped_curb_height_cm\":{\"min\":0,\"max\":50,\"accessible_max\":1.3}}"),
+        Map.entry(ObjectType.CURB_RAMP,
+            "{\"slope_percent\":{\"min\":0,\"max\":100,\"accessible_max\":8}," +
+            "\"width_cm\":{\"min\":0,\"max\":500,\"accessible_min\":120}," +
+            "\"lip_height_cm\":{\"min\":0,\"max\":20,\"accessible_max\":1.3}}"),
+        Map.entry(ObjectType.WASHROOM,
+            "{\"door_width_cm\":{\"min\":0,\"max\":300,\"accessible_min\":90}," +
+            "\"turning_space_cm\":{\"min\":0,\"max\":500,\"accessible_min\":150}," +
+            "\"sink_height_cm\":{\"min\":0,\"max\":150,\"accessible_max\":85}," +
+            "\"grab_bar_height_cm\":{\"min\":0,\"max\":150,\"accessible_min\":70}}"),
+        Map.entry(ObjectType.ROOM_SIGN,
+            "{\"mounting_height_cm\":{\"min\":0,\"max\":300,\"accessible_min\":120,\"accessible_max\":160}," +
+            "\"text_height_mm\":{\"min\":0,\"max\":200,\"accessible_min\":15}}")
     );
 
     public static String getSchemaJson(ObjectType objectType) {

--- a/backend/src/test/java/com/bounswe2026group1/backend/model/RoutingConstraintTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/model/RoutingConstraintTest.java
@@ -79,7 +79,8 @@ class RoutingConstraintTest {
         Set<IssueType> stairIssues = Set.of(
                 IssueType.MISSING_HANDRAIL, IssueType.NO_LANDING, IssueType.TOO_NARROW,
                 IssueType.SLIPPERY_SURFACE, IssueType.RISER_TOO_HIGH, IssueType.TREAD_TOO_SHALLOW,
-                IssueType.NO_ANTI_SLIP, IssueType.OPEN_RISERS);
+                IssueType.NO_ANTI_SLIP, IssueType.OPEN_RISERS,
+                IssueType.IRREGULAR_STEPS, IssueType.MISSING_NOSING_STRIP);
         for (IssueType issue : stairIssues) {
             assertTrue(hazards.contains(new IssueHazard(ObjectType.STAIR, issue)),
                     "AVOID_STAIRS missing (STAIR, " + issue + ")");

--- a/backend/src/test/java/com/bounswe2026group1/backend/model/RoutingPresetTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/model/RoutingPresetTest.java
@@ -63,10 +63,12 @@ class RoutingPresetTest {
     }
 
     @Test
-    void presetConstraints_areAllPathLevel_noElevatorOrDoorTuples() {
+    void presetConstraints_areAllPathLevel_noDestinationOrIndoorTuples() {
         // Path-level discipline check: presets should only bundle constraints that
-        // map to sidewalk/ramp/stair hazards. Door and elevator hazards are
-        // destination-level and live outside the routing-preference model.
+        // map to outdoor path-segment hazards (sidewalk/ramp/stair/pedestrian
+        // crossing/curb ramp). Door and elevator hazards are destination-level;
+        // washroom and room-sign hazards are indoor-only — both categories live
+        // outside the routing-preference model.
         for (RoutingPreset preset : RoutingPreset.values()) {
             for (RoutingConstraint c : preset.getConstraints()) {
                 for (IssueHazard h : c.getHazards()) {
@@ -76,6 +78,12 @@ class RoutingPresetTest {
                     assertNotEquals(ObjectType.ELEVATOR, h.objectType(),
                             preset.name() + " bundles " + c.name()
                                     + " which contains an ELEVATOR hazard — destination-level, not path-level");
+                    assertNotEquals(ObjectType.WASHROOM, h.objectType(),
+                            preset.name() + " bundles " + c.name()
+                                    + " which contains a WASHROOM hazard — indoor, not path-level");
+                    assertNotEquals(ObjectType.ROOM_SIGN, h.objectType(),
+                            preset.name() + " bundles " + c.name()
+                                    + " which contains a ROOM_SIGN hazard — indoor, not path-level");
                 }
             }
         }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ObjectTypeServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ObjectTypeServiceTest.java
@@ -21,10 +21,10 @@ class ObjectTypeServiceTest {
     }
 
     @Test
-    void getAll_returnsFiveObjectTypes() {
+    void getAll_returnsAllObjectTypes() {
         List<ObjectTypeInfoResponse> result = objectTypeService.getAll();
 
-        assertEquals(5, result.size());
+        assertEquals(ObjectType.values().length, result.size());
     }
 
     @Test
@@ -32,11 +32,9 @@ class ObjectTypeServiceTest {
         List<ObjectTypeInfoResponse> result = objectTypeService.getAll();
         List<ObjectType> returnedTypes = result.stream().map(ObjectTypeInfoResponse::getObjectType).toList();
 
-        assertTrue(returnedTypes.contains(ObjectType.RAMP));
-        assertTrue(returnedTypes.contains(ObjectType.ELEVATOR));
-        assertTrue(returnedTypes.contains(ObjectType.SIDEWALK));
-        assertTrue(returnedTypes.contains(ObjectType.DOOR));
-        assertTrue(returnedTypes.contains(ObjectType.STAIR));
+        for (ObjectType type : ObjectType.values()) {
+            assertTrue(returnedTypes.contains(type), type + " should be returned by getAll()");
+        }
     }
 
     @Test


### PR DESCRIPTION
# 📝 Description
Fixes #444

Expands the report taxonomy from 5 to 9 `ObjectType` values and from 24 to 50 `IssueType` values, covering accessibility gaps that the previous catalog could not represent — particularly indoor scenarios and pedestrian crossings.

Two new `RoutingConstraint` values (`REQUIRE_CURB_RAMPS`, `AVOID_INACCESSIBLE_CROSSINGS`) are wired into the existing `WHEELCHAIR_USER` and `BLIND_OR_LOW_VISION` presets so the new outdoor hazards generate avoid polygons in the same way as existing ones. The two new indoor types (`WASHROOM`, `ROOM_SIGN`) are excluded from routing by the existing OUTDOOR-only repository filter and remain informational.

`CURB_RAMP` is restricted to OBSTACLE reports via frontend gating, matching the existing RAMP-only-as-FEATURE pattern. `ObstacleService`'s nearest-ramp lookup keeps its `RAMP`-only filter, so `CURB_RAMP` cannot be used as a wheelchair routing leg even if a stray FEATURE report were created.

Existing measurement schema strings for the original 5 object types are preserved verbatim. The `SCHEMAS` map is migrated from `Map.of` to `Map.ofEntries` to accommodate the four new entries. No DB migration is required because enum values are persisted as strings.

`AVOID_STAIRS` is extended to cover the two new stair issues (`IRREGULAR_STEPS`, `MISSING_NOSING_STRIP`) so its "cover every reported stair issue" contract continues to hold. Existing tests are updated accordingly: `presetConstraints_areAllPathLevel` now also rejects `WASHROOM` and `ROOM_SIGN` hazards, and the `ObjectTypeService` catalog tests are made dynamic over `ObjectType.values()` so future taxonomy growth no longer breaks them.

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min

 **Note:** This PR is backend-only. Frontend changes (surfacing the new object types in the report form, keeping `CURB_RAMP` out of the FEATURE selector, and exposing the new routing constraints in the preferences UI) will follow in a separate PR.
