### PR TITLE
[Backend] Implement Dynamic Radius And Proximity Sorting For Feed

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportController.java
@@ -38,6 +38,7 @@ public class ReportController {
                 query.getEnvironment(),
                 query.getLatitude(),
                 query.getLongitude(),
+                query.getRadiusInKm(),
                 pageable,
                 email);
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportFeedQuery.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportFeedQuery.java
@@ -7,6 +7,7 @@ import lombok.Data;
 /**
  * Query parameters for {@code GET /api/reports/feed}. Optional {@code latitude}/{@code longitude}
  * enable PostGIS proximity filtering and distance ordering.
+ * Optional {@code radiusInKm} bounds the search (default {@code 1.0} km when coordinates are used).
  */
 @Data
 public class ReportFeedQuery {
@@ -14,4 +15,6 @@ public class ReportFeedQuery {
     private ReportEnvironment environment;
     private Double latitude;
     private Double longitude;
+    /** Search radius in kilometers; defaults to 1.0 when latitude/longitude are provided. */
+    private Double radiusInKm;
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryCustom.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryCustom.java
@@ -8,16 +8,16 @@ import org.springframework.data.domain.Pageable;
 
 public interface ReportRepositoryCustom {
 
-    int FEED_RADIUS_METERS = 1000;
-
     /**
-     * PostGIS geography distance: filters within radius and sorts by ascending {@code ST_Distance} (meters).
+     * PostGIS geography distance: filters within {@code radiusInKm} (converted to meters for {@code ST_DWithin})
+     * and sorts strictly by ascending {@code ST_Distance} (closest first). Pagination applies after this order.
      */
     Page<Report> findFeedWithinRadius(
             ReportType reportType,
             ReportEnvironment environment,
             double latitude,
             double longitude,
+            double radiusInKm,
             Pageable pageable);
 
     /**

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryImpl.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryImpl.java
@@ -26,6 +26,7 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
             ReportEnvironment environment,
             double latitude,
             double longitude,
+            double radiusInKm,
             Pageable pageable) {
 
         StringBuilder fromWhere = new StringBuilder("""
@@ -40,7 +41,7 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
         Map<String, Object> params = new HashMap<>();
         params.put("lat", latitude);
         params.put("lon", longitude);
-        params.put("radiusMeters", FEED_RADIUS_METERS);
+        params.put("radiusMeters", radiusInKm * 1000.0);
 
         appendNativeReportTypeFilter(fromWhere, params, reportType);
         appendNativeEnvironmentFilter(fromWhere, params, environment);

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -92,6 +93,7 @@ public class ReportService {
             ReportEnvironment environment,
             Double latitude,
             Double longitude,
+            Double radiusInKm,
             Pageable pageable,
             String email) {
 
@@ -100,14 +102,22 @@ public class ReportService {
                     "latitude and longitude must both be provided for proximity feed");
         }
 
-        Pageable paged = PageRequest.of(
-                Math.max(0, pageable.getPageNumber()),
-                Math.min(100, Math.max(1, pageable.getPageSize())));
+        int pageNumber = Math.max(0, pageable.getPageNumber());
+        int pageSize = Math.min(100, Math.max(1, pageable.getPageSize()));
+        Pageable paged = latitude != null
+                ? PageRequest.of(pageNumber, pageSize, Sort.unsorted())
+                : PageRequest.of(pageNumber, pageSize);
 
         Long userId = resolveUserId(email);
 
         Page<Report> page = latitude != null
-                ? reportRepository.findFeedWithinRadius(reportType, environment, latitude, longitude, paged)
+                ? reportRepository.findFeedWithinRadius(
+                        reportType,
+                        environment,
+                        latitude,
+                        longitude,
+                        radiusInKm != null ? radiusInKm : 1.0,
+                        paged)
                 : reportRepository.findFeedRecent(reportType, environment, paged);
 
         Map<Long, VoteType> votesByReportId = resolveUserVotes(userId, page.getContent());

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -9,28 +9,41 @@ INSERT INTO registered_users (name, email, password, role, status, points) VALUE
     ('Yılmaz Korkmaz', 'user@test.com',       '$2a$10$2y4KXmQAwp.0WcnN4W1Xbe57Qbmzpj0dB5mYTk.rRolW3q3i8K6i.', 'USER',  'ACTIVE', 0)
 ON CONFLICT DO NOTHING;
 
+-- Minimal category hierarchy for seeded reports (FK: reports.category_id → report_categories.id).
+-- Idempotent so Hibernate-seeded categories are left unchanged.
+INSERT INTO report_categories (id, name, routing_relevant, type, parent_id) VALUES
+    (1, 'Ramp Issues', false, 'OBSTACLE', NULL),
+    (2, 'Elevator Issues', false, 'OBSTACLE', NULL),
+    (3, 'Sidewalk Issues', false, 'OBSTACLE', NULL),
+    (14, 'Ramp', true, 'FEATURE', NULL),
+    (6, 'Too Steep', false, NULL, 1),
+    (9, 'Out of Service', false, NULL, 2),
+    (12, 'Uneven Surface', false, NULL, 3),
+    (11, 'Blocked', false, NULL, 3)
+ON CONFLICT (id) DO NOTHING;
+
 -- Reports: guard with NOT EXISTS since reports table has no unique constraint
-INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 2, ST_SetSRID(ST_MakePoint(29.044383, 41.086110), 4326), 'This ramp is too steep for wheelchairs', 'OBSTACLE', 'OUTDOOR', 'PENDING', 4, 1, NOW()
+INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 2, 6, ST_SetSRID(ST_MakePoint(29.044383, 41.086110), 4326), 'This ramp is too steep for wheelchairs', 'OBSTACLE', 'OUTDOOR', 'PENDING', 4, 1, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'This ramp is too steep for wheelchairs');
 
-INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 2, ST_SetSRID(ST_MakePoint(29.045658, 41.085243), 4326), 'Elevator of Boğaziçi Metro is broken', 'OBSTACLE', 'INDOOR', 'VERIFIED', 5, 0, NOW()
+INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 2, 9, ST_SetSRID(ST_MakePoint(29.045658, 41.085243), 4326), 'Elevator of Boğaziçi Metro is broken', 'OBSTACLE', 'INDOOR', 'VERIFIED', 5, 0, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'Elevator of Boğaziçi Metro is broken');
 
-INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 3, ST_SetSRID(ST_MakePoint(29.043898, 41.087167), 4326), 'Narrow passage on the route to dormitories', 'OBSTACLE', 'OUTDOOR', 'PENDING', 1, 2, NOW()
+INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 3, 12, ST_SetSRID(ST_MakePoint(29.043898, 41.087167), 4326), 'Narrow passage on the route to dormitories', 'OBSTACLE', 'OUTDOOR', 'PENDING', 1, 2, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'Narrow passage on the route to dormitories');
 
-INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date, entry_latitude, entry_longitude, exit_latitude, exit_longitude)
-SELECT 1, ST_SetSRID(ST_MakePoint(29.044523, 41.085693), 4326), 'There is actually a ramp in north campus.', 'FEATURE', 'OUTDOOR', 'VERIFIED', 4, 0, NOW(), 41.085700, 29.044550, 41.085650, 29.044500
+INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date, entry_latitude, entry_longitude, exit_latitude, exit_longitude)
+SELECT 1, 14, ST_SetSRID(ST_MakePoint(29.044523, 41.085693), 4326), 'There is actually a ramp in north campus.', 'FEATURE', 'OUTDOOR', 'VERIFIED', 4, 0, NOW(), 41.085700, 29.044550, 41.085650, 29.044500
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'There is actually a ramp in north campus.');
 
 -- VERIFIED OUTDOOR obstacle so the routing pipeline has at least one polygon
 -- to demonstrate after the environment=OUTDOOR filter is applied.
 -- Location: 41°05'06.1"N 29°02'38.7"E  (Boğaziçi north-campus walkway corridor)
-INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 3, ST_SetSRID(ST_MakePoint(29.044083, 41.085028), 4326), 'Sidewalk blocked by construction debris', 'OBSTACLE', 'OUTDOOR', 'VERIFIED', 5, 0, NOW()
+INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 3, 11, ST_SetSRID(ST_MakePoint(29.044083, 41.085028), 4326), 'Sidewalk blocked by construction debris', 'OBSTACLE', 'OUTDOOR', 'VERIFIED', 5, 0, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'Sidewalk blocked by construction debris');
 
 -- Report objects: resolve report_id by description so this is FK-safe on re-seed
@@ -53,7 +66,7 @@ WHERE r.description = 'Narrow passage on the route to dormitories'
   AND NOT EXISTS (SELECT 1 FROM report_objects ro WHERE ro.report_id = r.report_id AND ro.object_type = 'SIDEWALK');
 
 INSERT INTO report_objects (report_id, object_type, measurements)
-SELECT r.report_id, 'RAMP', '{"slope_percent": 6, "width_cm": 120}'
+SELECT r.report_id, 'RAMP', '{"slope_percent": 4, "width_cm": 120}'
 FROM reports r
 WHERE r.description = 'There is actually a ramp in north campus.'
   AND NOT EXISTS (SELECT 1 FROM report_objects ro WHERE ro.report_id = r.report_id AND ro.object_type = 'RAMP');

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -9,41 +9,28 @@ INSERT INTO registered_users (name, email, password, role, status, points) VALUE
     ('Yılmaz Korkmaz', 'user@test.com',       '$2a$10$2y4KXmQAwp.0WcnN4W1Xbe57Qbmzpj0dB5mYTk.rRolW3q3i8K6i.', 'USER',  'ACTIVE', 0)
 ON CONFLICT DO NOTHING;
 
--- Minimal category hierarchy for seeded reports (FK: reports.category_id → report_categories.id).
--- Idempotent so Hibernate-seeded categories are left unchanged.
-INSERT INTO report_categories (id, name, routing_relevant, type, parent_id) VALUES
-    (1, 'Ramp Issues', false, 'OBSTACLE', NULL),
-    (2, 'Elevator Issues', false, 'OBSTACLE', NULL),
-    (3, 'Sidewalk Issues', false, 'OBSTACLE', NULL),
-    (14, 'Ramp', true, 'FEATURE', NULL),
-    (6, 'Too Steep', false, NULL, 1),
-    (9, 'Out of Service', false, NULL, 2),
-    (12, 'Uneven Surface', false, NULL, 3),
-    (11, 'Blocked', false, NULL, 3)
-ON CONFLICT (id) DO NOTHING;
-
 -- Reports: guard with NOT EXISTS since reports table has no unique constraint
-INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 2, 6, ST_SetSRID(ST_MakePoint(29.044383, 41.086110), 4326), 'This ramp is too steep for wheelchairs', 'OBSTACLE', 'OUTDOOR', 'PENDING', 4, 1, NOW()
+INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 2, ST_SetSRID(ST_MakePoint(29.044383, 41.086110), 4326), 'This ramp is too steep for wheelchairs', 'OBSTACLE', 'OUTDOOR', 'PENDING', 4, 1, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'This ramp is too steep for wheelchairs');
 
-INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 2, 9, ST_SetSRID(ST_MakePoint(29.045658, 41.085243), 4326), 'Elevator of Boğaziçi Metro is broken', 'OBSTACLE', 'INDOOR', 'VERIFIED', 5, 0, NOW()
+INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 2, ST_SetSRID(ST_MakePoint(29.045658, 41.085243), 4326), 'Elevator of Boğaziçi Metro is broken', 'OBSTACLE', 'INDOOR', 'VERIFIED', 5, 0, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'Elevator of Boğaziçi Metro is broken');
 
-INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 3, 12, ST_SetSRID(ST_MakePoint(29.043898, 41.087167), 4326), 'Narrow passage on the route to dormitories', 'OBSTACLE', 'OUTDOOR', 'PENDING', 1, 2, NOW()
+INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 3, ST_SetSRID(ST_MakePoint(29.043898, 41.087167), 4326), 'Narrow passage on the route to dormitories', 'OBSTACLE', 'OUTDOOR', 'PENDING', 1, 2, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'Narrow passage on the route to dormitories');
 
-INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date, entry_latitude, entry_longitude, exit_latitude, exit_longitude)
-SELECT 1, 14, ST_SetSRID(ST_MakePoint(29.044523, 41.085693), 4326), 'There is actually a ramp in north campus.', 'FEATURE', 'OUTDOOR', 'VERIFIED', 4, 0, NOW(), 41.085700, 29.044550, 41.085650, 29.044500
+INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date, entry_latitude, entry_longitude, exit_latitude, exit_longitude)
+SELECT 1, ST_SetSRID(ST_MakePoint(29.044523, 41.085693), 4326), 'There is actually a ramp in north campus.', 'FEATURE', 'OUTDOOR', 'VERIFIED', 4, 0, NOW(), 41.085700, 29.044550, 41.085650, 29.044500
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'There is actually a ramp in north campus.');
 
 -- VERIFIED OUTDOOR obstacle so the routing pipeline has at least one polygon
 -- to demonstrate after the environment=OUTDOOR filter is applied.
 -- Location: 41°05'06.1"N 29°02'38.7"E  (Boğaziçi north-campus walkway corridor)
-INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 3, 11, ST_SetSRID(ST_MakePoint(29.044083, 41.085028), 4326), 'Sidewalk blocked by construction debris', 'OBSTACLE', 'OUTDOOR', 'VERIFIED', 5, 0, NOW()
+INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 3, ST_SetSRID(ST_MakePoint(29.044083, 41.085028), 4326), 'Sidewalk blocked by construction debris', 'OBSTACLE', 'OUTDOOR', 'VERIFIED', 5, 0, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'Sidewalk blocked by construction debris');
 
 -- Report objects: resolve report_id by description so this is FK-safe on re-seed
@@ -66,7 +53,7 @@ WHERE r.description = 'Narrow passage on the route to dormitories'
   AND NOT EXISTS (SELECT 1 FROM report_objects ro WHERE ro.report_id = r.report_id AND ro.object_type = 'SIDEWALK');
 
 INSERT INTO report_objects (report_id, object_type, measurements)
-SELECT r.report_id, 'RAMP', '{"slope_percent": 4, "width_cm": 120}'
+SELECT r.report_id, 'RAMP', '{"slope_percent": 6, "width_cm": 120}'
 FROM reports r
 WHERE r.description = 'There is actually a ramp in north campus.'
   AND NOT EXISTS (SELECT 1 FROM report_objects ro WHERE ro.report_id = r.report_id AND ro.object_type = 'RAMP');


### PR DESCRIPTION
# 📝 Description
Fixes #429

This PR updates the backend spatial feed logic. Instead of a hardcoded 1km limit, the API now accepts a dynamic `radiusInKm` parameter via the query object (defaulting to 1.0km). Furthermore, the PostGIS query in `ReportRepositoryImpl` has been updated to strictly sort the results by spatial distance (`ST_Distance`) ascending, ensuring the closest reports always appear first when coordinates are provided.

# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [x]  Refactoring
- [ ]  Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed (Except existing S3 environment issues)

# 📸 Screenshots / Recordings

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min