### PR TITLE
[Web] Implement Interactive Spatial Community Feed With Filters

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportController.java
@@ -38,6 +38,7 @@ public class ReportController {
                 query.getEnvironment(),
                 query.getLatitude(),
                 query.getLongitude(),
+                query.getRadiusInKm(),
                 pageable,
                 email);
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportFeedQuery.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportFeedQuery.java
@@ -7,6 +7,7 @@ import lombok.Data;
 /**
  * Query parameters for {@code GET /api/reports/feed}. Optional {@code latitude}/{@code longitude}
  * enable PostGIS proximity filtering and distance ordering.
+ * Optional {@code radiusInKm} bounds the search (default {@code 1.0} km when coordinates are used).
  */
 @Data
 public class ReportFeedQuery {
@@ -14,4 +15,6 @@ public class ReportFeedQuery {
     private ReportEnvironment environment;
     private Double latitude;
     private Double longitude;
+    /** Search radius in kilometers; defaults to 1.0 when latitude/longitude are provided. */
+    private Double radiusInKm;
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryCustom.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryCustom.java
@@ -8,16 +8,16 @@ import org.springframework.data.domain.Pageable;
 
 public interface ReportRepositoryCustom {
 
-    int FEED_RADIUS_METERS = 1000;
-
     /**
-     * PostGIS geography distance: filters within radius and sorts by ascending {@code ST_Distance} (meters).
+     * PostGIS geography distance: filters within {@code radiusInKm} (converted to meters for {@code ST_DWithin})
+     * and sorts strictly by ascending {@code ST_Distance} (closest first). Pagination applies after this order.
      */
     Page<Report> findFeedWithinRadius(
             ReportType reportType,
             ReportEnvironment environment,
             double latitude,
             double longitude,
+            double radiusInKm,
             Pageable pageable);
 
     /**

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryImpl.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryImpl.java
@@ -26,6 +26,7 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
             ReportEnvironment environment,
             double latitude,
             double longitude,
+            double radiusInKm,
             Pageable pageable) {
 
         StringBuilder fromWhere = new StringBuilder("""
@@ -40,7 +41,7 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
         Map<String, Object> params = new HashMap<>();
         params.put("lat", latitude);
         params.put("lon", longitude);
-        params.put("radiusMeters", FEED_RADIUS_METERS);
+        params.put("radiusMeters", radiusInKm * 1000.0);
 
         appendNativeReportTypeFilter(fromWhere, params, reportType);
         appendNativeEnvironmentFilter(fromWhere, params, environment);

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -92,6 +93,7 @@ public class ReportService {
             ReportEnvironment environment,
             Double latitude,
             Double longitude,
+            Double radiusInKm,
             Pageable pageable,
             String email) {
 
@@ -100,14 +102,22 @@ public class ReportService {
                     "latitude and longitude must both be provided for proximity feed");
         }
 
-        Pageable paged = PageRequest.of(
-                Math.max(0, pageable.getPageNumber()),
-                Math.min(100, Math.max(1, pageable.getPageSize())));
+        int pageNumber = Math.max(0, pageable.getPageNumber());
+        int pageSize = Math.min(100, Math.max(1, pageable.getPageSize()));
+        Pageable paged = latitude != null
+                ? PageRequest.of(pageNumber, pageSize, Sort.unsorted())
+                : PageRequest.of(pageNumber, pageSize);
 
         Long userId = resolveUserId(email);
 
         Page<Report> page = latitude != null
-                ? reportRepository.findFeedWithinRadius(reportType, environment, latitude, longitude, paged)
+                ? reportRepository.findFeedWithinRadius(
+                        reportType,
+                        environment,
+                        latitude,
+                        longitude,
+                        radiusInKm != null ? radiusInKm : 1.0,
+                        paged)
                 : reportRepository.findFeedRecent(reportType, environment, paged);
 
         Map<Long, VoteType> votesByReportId = resolveUserVotes(userId, page.getContent());

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -9,28 +9,41 @@ INSERT INTO registered_users (name, email, password, role, status, points) VALUE
     ('Yılmaz Korkmaz', 'user@test.com',       '$2a$10$2y4KXmQAwp.0WcnN4W1Xbe57Qbmzpj0dB5mYTk.rRolW3q3i8K6i.', 'USER',  'ACTIVE', 0)
 ON CONFLICT DO NOTHING;
 
+-- Minimal category hierarchy for seeded reports (FK: reports.category_id → report_categories.id).
+-- Idempotent so Hibernate-seeded categories are left unchanged.
+INSERT INTO report_categories (id, name, routing_relevant, type, parent_id) VALUES
+    (1, 'Ramp Issues', false, 'OBSTACLE', NULL),
+    (2, 'Elevator Issues', false, 'OBSTACLE', NULL),
+    (3, 'Sidewalk Issues', false, 'OBSTACLE', NULL),
+    (14, 'Ramp', true, 'FEATURE', NULL),
+    (6, 'Too Steep', false, NULL, 1),
+    (9, 'Out of Service', false, NULL, 2),
+    (12, 'Uneven Surface', false, NULL, 3),
+    (11, 'Blocked', false, NULL, 3)
+ON CONFLICT (id) DO NOTHING;
+
 -- Reports: guard with NOT EXISTS since reports table has no unique constraint
-INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 2, ST_SetSRID(ST_MakePoint(29.044383, 41.086110), 4326), 'This ramp is too steep for wheelchairs', 'OBSTACLE', 'OUTDOOR', 'PENDING', 4, 1, NOW()
+INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 2, 6, ST_SetSRID(ST_MakePoint(29.044383, 41.086110), 4326), 'This ramp is too steep for wheelchairs', 'OBSTACLE', 'OUTDOOR', 'PENDING', 4, 1, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'This ramp is too steep for wheelchairs');
 
-INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 2, ST_SetSRID(ST_MakePoint(29.045658, 41.085243), 4326), 'Elevator of Boğaziçi Metro is broken', 'OBSTACLE', 'INDOOR', 'VERIFIED', 5, 0, NOW()
+INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 2, 9, ST_SetSRID(ST_MakePoint(29.045658, 41.085243), 4326), 'Elevator of Boğaziçi Metro is broken', 'OBSTACLE', 'INDOOR', 'VERIFIED', 5, 0, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'Elevator of Boğaziçi Metro is broken');
 
-INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 3, ST_SetSRID(ST_MakePoint(29.043898, 41.087167), 4326), 'Narrow passage on the route to dormitories', 'OBSTACLE', 'OUTDOOR', 'PENDING', 1, 2, NOW()
+INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 3, 12, ST_SetSRID(ST_MakePoint(29.043898, 41.087167), 4326), 'Narrow passage on the route to dormitories', 'OBSTACLE', 'OUTDOOR', 'PENDING', 1, 2, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'Narrow passage on the route to dormitories');
 
-INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date, entry_latitude, entry_longitude, exit_latitude, exit_longitude)
-SELECT 1, ST_SetSRID(ST_MakePoint(29.044523, 41.085693), 4326), 'There is actually a ramp in north campus.', 'FEATURE', 'OUTDOOR', 'VERIFIED', 4, 0, NOW(), 41.085700, 29.044550, 41.085650, 29.044500
+INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date, entry_latitude, entry_longitude, exit_latitude, exit_longitude)
+SELECT 1, 14, ST_SetSRID(ST_MakePoint(29.044523, 41.085693), 4326), 'There is actually a ramp in north campus.', 'FEATURE', 'OUTDOOR', 'VERIFIED', 4, 0, NOW(), 41.085700, 29.044550, 41.085650, 29.044500
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'There is actually a ramp in north campus.');
 
 -- VERIFIED OUTDOOR obstacle so the routing pipeline has at least one polygon
 -- to demonstrate after the environment=OUTDOOR filter is applied.
 -- Location: 41°05'06.1"N 29°02'38.7"E  (Boğaziçi north-campus walkway corridor)
-INSERT INTO reports (user_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
-SELECT 3, ST_SetSRID(ST_MakePoint(29.044083, 41.085028), 4326), 'Sidewalk blocked by construction debris', 'OBSTACLE', 'OUTDOOR', 'VERIFIED', 5, 0, NOW()
+INSERT INTO reports (user_id, category_id, location, description, report_type, environment, status, agrees, disagrees, publish_date)
+SELECT 3, 11, ST_SetSRID(ST_MakePoint(29.044083, 41.085028), 4326), 'Sidewalk blocked by construction debris', 'OBSTACLE', 'OUTDOOR', 'VERIFIED', 5, 0, NOW()
 WHERE NOT EXISTS (SELECT 1 FROM reports WHERE description = 'Sidewalk blocked by construction debris');
 
 -- Report objects: resolve report_id by description so this is FK-safe on re-seed
@@ -53,7 +66,7 @@ WHERE r.description = 'Narrow passage on the route to dormitories'
   AND NOT EXISTS (SELECT 1 FROM report_objects ro WHERE ro.report_id = r.report_id AND ro.object_type = 'SIDEWALK');
 
 INSERT INTO report_objects (report_id, object_type, measurements)
-SELECT r.report_id, 'RAMP', '{"slope_percent": 6, "width_cm": 120}'
+SELECT r.report_id, 'RAMP', '{"slope_percent": 4, "width_cm": 120}'
 FROM reports r
 WHERE r.description = 'There is actually a ramp in north campus.'
   AND NOT EXISTS (SELECT 1 FROM report_objects ro WHERE ro.report_id = r.report_id AND ro.object_type = 'RAMP');

--- a/frontend/src/components/ReportCard.jsx
+++ b/frontend/src/components/ReportCard.jsx
@@ -1,0 +1,112 @@
+import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
+import { formatDistanceKm } from '../utils/geo.js'
+
+/**
+ * Compact report preview for list feeds (design aligned with ReportPanel / Home).
+ */
+function ReportCard({
+  report,
+  distanceKm = null,
+  showProximity = false,
+  onCardClick,
+}) {
+  const cfg = OBJECT_TYPE_MAP[report.primaryObjectType] ?? {
+    icon: 'report',
+    markerColor: '#767777',
+  }
+  const isFixed = report.status === 'fixed'
+  const isRejected = report.status === 'rejected'
+  const isValidated = report.status === 'verified'
+
+  return (
+    <article
+      role="button"
+      tabIndex={0}
+      onClick={() => onCardClick?.()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onCardClick?.()
+        }
+      }}
+      className="
+        group flex min-w-0 cursor-pointer flex-col overflow-hidden rounded-md border border-outline-variant/25 bg-white/85 backdrop-blur-md text-left
+        shadow-[0_3px_10px_rgb(0,0,0,0.045)] transition-all duration-150
+        hover:border-primary/35 hover:shadow-[0_6px_14px_rgb(23,106,33,0.09)] hover:-translate-y-0.5
+        focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary
+      "
+    >
+      <div className="relative aspect-[3/1] max-h-[4.75rem] w-full overflow-hidden bg-surface-container sm:max-h-[5rem]">
+        {report.image ? (
+          <img
+            src={report.image}
+            alt=""
+            className="h-full w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+          />
+        ) : (
+          <div
+            className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/8 to-tertiary/10"
+            aria-hidden
+          >
+            <span className="material-symbols-outlined text-2xl text-primary/35" style={{ fontVariationSettings: "'FILL' 1" }}>
+              {cfg.icon}
+            </span>
+          </div>
+        )}
+        {showProximity && distanceKm != null && (
+          <div className="absolute left-1.5 top-1.5 flex flex-wrap gap-1">
+            <span className="rounded-full bg-primary px-1 py-0.5 text-[8px] font-bold uppercase tracking-wide text-on-primary shadow-sm">
+              Nearby · {formatDistanceKm(distanceKm)}
+            </span>
+          </div>
+        )}
+        <div className="absolute right-1.5 top-1.5">
+          <span
+            className={`text-[8px] font-bold px-1 py-0.5 rounded-full uppercase tracking-wider shadow-sm ring-1 ring-white/30 ${
+              isFixed
+                ? 'bg-emerald-600 text-white'
+                : isRejected
+                  ? 'bg-error text-on-error'
+                  : isValidated
+                    ? 'bg-primary-container text-on-primary-container'
+                    : 'bg-amber-100 text-amber-900'
+            }`}
+          >
+            {isFixed ? 'Fixed' : isRejected ? 'Rejected' : isValidated ? 'Validated' : 'Unverified'}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-1.5 p-2.5">
+        <div className="flex items-start gap-2">
+          <div
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary transition group-hover:bg-primary/15"
+            aria-hidden
+          >
+            <span className="material-symbols-outlined text-[16px]" style={{ fontVariationSettings: "'FILL' 1", color: cfg.markerColor }}>
+              {cfg.icon}
+            </span>
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="font-headline text-[11px] font-extrabold leading-snug text-on-surface group-hover:text-primary transition-colors line-clamp-2 sm:text-[12px]">
+              {report.title}
+            </h2>
+            <p className="mt-0.5 text-[9px] text-on-surface-variant">{report.date}</p>
+          </div>
+        </div>
+        {report.description && (
+          <p className="line-clamp-1 text-[10px] leading-snug text-on-surface-variant">{report.description}</p>
+        )}
+        <div className="mt-auto flex items-center justify-between border-t border-outline-variant/15 pt-1 text-[9px] text-on-surface-variant">
+          <span className="flex items-center gap-0.5">
+            <span className="material-symbols-outlined text-[12px] text-secondary">thumb_up</span>
+            <span className="font-semibold text-on-surface">{report.agrees ?? 0}</span>
+            <span className="text-on-surface-variant">agrees</span>
+          </span>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+export default ReportCard

--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -27,8 +27,14 @@ import CreateFixRequestPanel from './CreateFixRequestPanel.jsx'
  *  - onClose: () => void
  *  - onVoteUpdate: (updatedReport) => void
  */
-function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, onFollowChange }) {
-
+function ReportPanel({
+  report,
+  userVote,
+  onVoteChange,
+  onClose,
+  onVoteUpdate,
+  onFollowChange,
+}) {
   const { token, isAuthenticated, userId } = useAuth()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
@@ -171,14 +177,13 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
         aria-hidden="true"
       />
 
-      <aside className="
-        fixed top-0 right-0 h-full z-[1200]
-        w-full lg:w-[500px]
-        bg-surface-container-low
-        overflow-y-auto
-        border-l border-outline-variant/10
-        flex flex-col
-      ">
+      <aside
+        className="
+          fixed top-0 right-0 z-[1200] h-full
+          flex w-full flex-col overflow-y-auto border-l border-outline-variant/10 bg-surface-container-low
+          lg:w-[500px]
+        "
+      >
 
         {/* Top status strip — always visible, holds the close button and the
             current status pills so they stay reachable even when an active

--- a/frontend/src/pages/Feed.jsx
+++ b/frontend/src/pages/Feed.jsx
@@ -1,55 +1,685 @@
+import { useMemo, useState, useCallback, useEffect, useRef } from 'react'
+import { MapContainer, TileLayer, Marker, Circle, Popup, useMap, useMapEvents } from 'react-leaflet'
+import L from 'leaflet'
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 import Navbar from '../components/Navbar.jsx'
+import ReportCard from '../components/ReportCard.jsx'
+import ReportPanel from '../components/ReportPanel.jsx'
+import Toast from '../components/Toast.jsx'
+import { useAuth } from '../context/AuthContext.jsx'
+import { getReportsFeed, mapReport } from '../services/reportService.js'
+import { haversineKm } from '../utils/geo.js'
+import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
 
-function Feed() {
+const DEFAULT_CENTER = { lat: 41.0683, lng: 29.0505 }
+const DEFAULT_ZOOM = 13
+const FLY_ZOOM = 16
+const GEO_OPTIONS = { enableHighAccuracy: true, timeout: 25_000, maximumAge: 0 }
+/** Map height inside the constrained feed grid (below the toolbar). Detail mode uses Home-style full bleed. */
+const FEED_EMBEDDED_MAP_H_CLASS = 'h-[min(41vh,360px)]'
+
+const LOCATION_SERVICES_MSG = 'Location services are not enabled.'
+const BLANK_MESSAGE =
+  'Please allow location access or choose a location on the map.'
+
+const BTN_PRIMARY =
+  'inline-flex h-11 shrink-0 items-center justify-center gap-2 rounded-xl bg-primary px-4 text-sm font-bold text-on-primary shadow-sm transition hover:bg-primary-dim focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary font-headline disabled:pointer-events-none disabled:opacity-40'
+
+const BTN_OUTLINE =
+  'inline-flex h-11 shrink-0 items-center justify-center gap-2 rounded-xl border border-outline-variant bg-white px-4 text-sm font-bold text-on-surface shadow-sm transition hover:bg-surface-container-high focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary font-headline disabled:pointer-events-none disabled:opacity-40'
+
+const BTN_ICON_CLOSE =
+  'inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-outline-variant bg-surface-container-low text-on-surface shadow-sm transition hover:bg-surface-container-high focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary'
+
+/** Extra control on feed map detail — matches floating map toolbar tokens (does not alter ReportPanel). */
+const BTN_BACK_MAP_LAYER =
+  'inline-flex items-center gap-2 rounded-xl border border-outline-variant/25 bg-white/90 px-3 py-2 text-sm font-semibold text-on-surface shadow-md backdrop-blur-sm transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary'
+
+/** Page size for spatial feed pagination (must match backend Pageable). */
+const FEED_PAGE_SIZE = 10
+
+function makeMarkerIcon(status, objectType) {
+  const cfg = OBJECT_TYPE_MAP[objectType] ?? { icon: 'warning', markerColor: '#767777' }
+  const borderColor = status === 'verified' ? '#176a21' : cfg.markerColor
+  return L.divIcon({
+    className: '',
+    html: `
+      <div style="
+        width:40px;height:40px;
+        background:white;
+        border-radius:50%;
+        border:2.5px solid ${borderColor};
+        box-shadow:0 4px 12px rgba(0,0,0,0.15);
+        display:flex;align-items:center;justify-content:center;
+        cursor:pointer;
+      ">
+        <span class="material-symbols-outlined" style="
+          font-size:20px;
+          color:${borderColor};
+          font-variation-settings:'FILL' 1;
+          line-height:1;
+        ">${cfg.icon}</span>
+      </div>`,
+    iconSize: [40, 40],
+    iconAnchor: [20, 20],
+    popupAnchor: [0, -24],
+  })
+}
+
+function MapInvalidateOnOpen() {
+  const map = useMap()
+  useEffect(() => {
+    const t = window.setTimeout(() => map.invalidateSize(), 200)
+    return () => window.clearTimeout(t)
+  }, [map])
+  return null
+}
+
+function MapClickPanTo() {
+  const map = useMap()
+  useMapEvents({
+    click(e) {
+      map.panTo(e.latlng)
+    },
+  })
+  return null
+}
+
+/**
+ * Tracks map viewport center on pan/zoom: circle sticks to geographic center under a fixed HUD pin overlay.
+ */
+function MapViewportCenterCircle({ radiusKm, onCenterDebounced }) {
+  const map = useMap()
+  const [centerLatLng, setCenterLatLng] = useState(() => {
+    const c = map.getCenter()
+    return { lat: c.lat, lng: c.lng }
+  })
+
+  useEffect(() => {
+    let debounceTimer = null
+    function sync() {
+      const c = map.getCenter()
+      const ll = { lat: c.lat, lng: c.lng }
+      setCenterLatLng(ll)
+      if (debounceTimer) window.clearTimeout(debounceTimer)
+      debounceTimer = window.setTimeout(() => {
+        debounceTimer = null
+        onCenterDebounced(ll)
+      }, 280)
+    }
+    sync()
+    map.on('moveend', sync)
+    map.on('zoomend', sync)
+    return () => {
+      map.off('moveend', sync)
+      map.off('zoomend', sync)
+      if (debounceTimer) window.clearTimeout(debounceTimer)
+    }
+  }, [map, onCenterDebounced])
+
+  if (radiusKm <= 0) return null
   return (
-    <div className="flex flex-col h-screen overflow-hidden bg-background font-body">
-      <Navbar />
-      
-      <main className="flex-1 overflow-auto relative bg-background flex items-center justify-center p-8">
-        {/* Animated background blobs with app theme colors */}
-        <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-primary/10 rounded-full mix-blend-multiply filter blur-[100px] opacity-70 animate-blob"></div>
-        <div className="absolute top-1/3 right-1/4 w-96 h-96 bg-tertiary/10 rounded-full mix-blend-multiply filter blur-[100px] opacity-70 animate-blob animation-delay-2000"></div>
-        <div className="absolute -bottom-8 left-1/2 w-96 h-96 bg-secondary/10 rounded-full mix-blend-multiply filter blur-[100px] opacity-70 animate-blob animation-delay-4000"></div>
+    <Circle
+      center={[centerLatLng.lat, centerLatLng.lng]}
+      radius={radiusKm * 1000}
+      pathOptions={{
+        color: '#176a21',
+        fillColor: '#176a21',
+        fillOpacity: 0.08,
+        weight: 2,
+      }}
+    />
+  )
+}
 
-        <div className="relative z-10 flex flex-col items-center max-w-3xl w-full bg-white/60 backdrop-blur-2xl border border-outline-variant/30 rounded-[2rem] p-12 shadow-[0_8px_30px_rgb(0,0,0,0.06)] overflow-hidden transition-transform hover:scale-[1.01] duration-500">
-          
-          <div className="w-24 h-24 mb-8 bg-gradient-to-tr from-primary to-primary-container rounded-3xl flex items-center justify-center shadow-lg transform rotate-[10deg] hover:rotate-0 transition-transform duration-500 cursor-pointer">
-            <span className="material-symbols-outlined text-white" style={{ fontSize: '48px', fontVariationSettings: "'FILL' 1" }}>groups</span>
+function MapFlyToReport({ report }) {
+  const map = useMap()
+  useEffect(() => {
+    if (!report?.id) return
+    map.flyTo([report.latitude, report.longitude], FLY_ZOOM, { duration: 0.75 })
+  }, [map, report?.id, report?.latitude, report?.longitude])
+  return null
+}
+
+/** Main feed map: markers + radius + fly to selection */
+function FeedBrowseMap({
+  activeCoords,
+  radiusKm,
+  reports,
+  selectedReport,
+  onMarkerSelect,
+  markersRef,
+  /** Same footprint as Home map (`/`) when a report is open. */
+  viewportFill = false,
+}) {
+  const mapCenter = [activeCoords.lat, activeCoords.lng]
+  const mapClass = viewportFill
+    ? 'relative z-0 h-full w-full min-h-0'
+    : `w-full ${FEED_EMBEDDED_MAP_H_CLASS} min-h-[200px] lg:h-full lg:min-h-0`
+
+  return (
+    <MapContainer
+      center={mapCenter}
+      zoom={DEFAULT_ZOOM}
+      zoomControl
+      className={mapClass}
+      style={viewportFill ? { height: '100%', width: '100%' } : { height: '100%' }}
+      scrollWheelZoom
+    >
+      <MapInvalidateOnOpen />
+      <TileLayer
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+      />
+      {radiusKm > 0 && activeCoords && (
+        <Circle
+          center={[activeCoords.lat, activeCoords.lng]}
+          radius={radiusKm * 1000}
+          pathOptions={{
+            color: '#176a21',
+            fillColor: '#176a21',
+            fillOpacity: 0.06,
+            weight: 1,
+            dashArray: '6 10',
+          }}
+        />
+      )}
+      <MapFlyToReport report={selectedReport} />
+      {reports.map((report) => (
+        <Marker
+          key={report.id}
+          position={[report.latitude, report.longitude]}
+          icon={makeMarkerIcon(report.status, report.primaryObjectType)}
+          eventHandlers={{
+            add(e) {
+              markersRef.current[report.id] = e.target
+            },
+            remove() {
+              delete markersRef.current[report.id]
+            },
+            click() {
+              onMarkerSelect({ ...report })
+            },
+          }}
+        >
+          <Popup closeButton>
+            <div className="min-w-[210px] max-w-[260px] pr-1">
+              <p className="font-headline text-sm font-bold leading-snug text-on-surface">{report.title}</p>
+              {report.description && (
+                <p className="mt-1 text-xs leading-relaxed text-on-surface-variant line-clamp-3">{report.description}</p>
+              )}
+              <p className="mt-2 text-[11px] font-semibold uppercase tracking-wide text-primary">
+                Open below for details
+              </p>
+            </div>
+          </Popup>
+        </Marker>
+      ))}
+    </MapContainer>
+  )
+}
+
+function CenterHudPinOverlay() {
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 z-[650] flex items-center justify-center"
+      aria-hidden
+    >
+      <div className="-mt-12 flex flex-col items-center drop-shadow-lg">
+        <span
+          className="material-symbols-outlined text-[3.5rem] text-primary"
+          style={{ fontVariationSettings: "'FILL' 1" }}
+        >
+          location_on
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function LocationMapModal({
+  open,
+  onClose,
+  initialCenter,
+  radiusKm,
+  mapKey,
+  onCenterDebounced,
+  onUseMyLocation,
+}) {
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-[2000]">
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-[2px]" aria-hidden />
+      <div className="relative z-[2001] flex min-h-full items-center justify-center p-4 pointer-events-none sm:p-6">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="feed-map-title"
+          className="
+            pointer-events-auto flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden
+            rounded-[1.5rem] border border-outline-variant/20 bg-surface-container-low shadow-2xl
+          "
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-outline-variant/15 px-4 py-3 sm:px-5">
+            <h2 id="feed-map-title" className="font-headline text-lg font-bold text-on-surface">
+              Choose location
+            </h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <button type="button" className={BTN_OUTLINE} onClick={onUseMyLocation}>
+                <span className="material-symbols-outlined text-[20px]">my_location</span>
+                Use my current location
+              </button>
+              <button type="button" className={BTN_ICON_CLOSE} onClick={onClose} aria-label="Close map">
+                <span className="material-symbols-outlined text-xl">close</span>
+              </button>
+            </div>
           </div>
-          
-          <h1 className="text-5xl md:text-7xl font-extrabold font-headline text-on-surface mb-6 text-center tracking-tight">
-            COMING SOON
-          </h1>
-          
-          <p className="text-lg md:text-xl text-on-surface-variant text-center mb-10 max-w-xl leading-relaxed">
-            We're building a community feed! Soon you'll be able to explore, upvote, and interact with accessibility reports shared by others in your neighborhood.
+          <p className="border-b border-outline-variant/10 px-4 py-2 text-xs text-on-surface-variant sm:px-5">
+            Pan and zoom—the guide marks the viewport center used for nearby results. Close with ✕ only.
           </p>
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full mt-6">
-            <div className="bg-white border border-outline-variant/20 rounded-2xl p-6 shadow-sm hover:shadow-lg transition-all group cursor-pointer hover:-translate-y-1">
-               <div className="w-12 h-12 bg-primary/10 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
-                 <span className="material-symbols-outlined text-primary">forum</span>
-               </div>
-               <h3 className="font-bold text-on-surface mb-2 font-headline">Community Feed</h3>
-               <p className="text-xs text-on-surface-variant leading-relaxed">Discover recently reported accessibility issues directly from other users.</p>
-            </div>
-            <div className="bg-white border border-outline-variant/20 rounded-2xl p-6 shadow-sm hover:shadow-lg transition-all group cursor-pointer hover:-translate-y-1">
-               <div className="w-12 h-12 bg-tertiary/10 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
-                 <span className="material-symbols-outlined text-tertiary">thumb_up</span>
-               </div>
-               <h3 className="font-bold text-on-surface mb-2 font-headline">Upvote & Verify</h3>
-               <p className="text-xs text-on-surface-variant leading-relaxed">Support local issues by upvoting and verifying community reports.</p>
-            </div>
-            <div className="bg-white border border-outline-variant/20 rounded-2xl p-6 shadow-sm hover:shadow-lg transition-all group cursor-pointer hover:-translate-y-1">
-               <div className="w-12 h-12 bg-secondary/10 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
-                 <span className="material-symbols-outlined text-secondary">verified</span>
-               </div>
-               <h3 className="font-bold text-on-surface mb-2 font-headline">Track Impact</h3>
-               <p className="text-xs text-on-surface-variant leading-relaxed">Follow along as city officials and others help resolve community issues.</p>
-            </div>
+          <div className="relative min-h-[min(55vh,420px)] w-full flex-1">
+            <MapContainer
+              key={mapKey}
+              center={[initialCenter.lat, initialCenter.lng]}
+              zoom={DEFAULT_ZOOM}
+              zoomControl
+              className="h-[min(55vh,420px)] w-full"
+              style={{ height: 'min(55vh,420px)' }}
+              scrollWheelZoom
+            >
+              <MapInvalidateOnOpen />
+              <TileLayer
+                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+              />
+              <MapClickPanTo />
+              <MapViewportCenterCircle radiusKm={radiusKm} onCenterDebounced={onCenterDebounced} />
+            </MapContainer>
+            <CenterHudPinOverlay />
           </div>
         </div>
-      </main>
+      </div>
+    </div>
+  )
+}
+
+function parseRadiusKm(raw) {
+  const n = Number.parseFloat(String(raw).replace(',', '.'))
+  if (Number.isNaN(n) || n <= 0) return null
+  return Math.min(5000, n)
+}
+
+function Feed() {
+  const { token } = useAuth()
+  const queryClient = useQueryClient()
+  const suppressInitialGeo = useRef(false)
+  const markersRef = useRef({})
+
+  const [activeCoords, setActiveCoords] = useState(null)
+  const [geoState, setGeoState] = useState('pending')
+  const [radiusInput, setRadiusInput] = useState('1')
+  const [mapModalOpen, setMapModalOpen] = useState(false)
+  const [mapKey, setMapKey] = useState(0)
+  const [selectedReport, setSelectedReport] = useState(null)
+  const [userVotes, setUserVotes] = useState({})
+  const [toast, setToast] = useState(null)
+
+  const feedScrollRef = useRef(null)
+  const loadMoreSentinelRef = useRef(null)
+
+  const dismissToast = useCallback(() => setToast(null), [])
+
+  const radiusKm = useMemo(() => parseRadiusKm(radiusInput) ?? 1, [radiusInput])
+
+  const showLocationServicesAlert = useCallback(() => {
+    setToast({ message: LOCATION_SERVICES_MSG, type: 'error' })
+  }, [])
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setGeoState('unsupported')
+      return
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        if (suppressInitialGeo.current) return
+        const c = { lat: pos.coords.latitude, lng: pos.coords.longitude }
+        setActiveCoords(c)
+        setGeoState('granted')
+      },
+      (err) => {
+        if (err.code === 1) setGeoState('denied')
+        else if (err.code === 2) setGeoState('unavailable')
+        else if (err.code === 3) setGeoState('timeout')
+        else setGeoState('unavailable')
+      },
+      GEO_OPTIONS
+    )
+  }, [])
+
+  const hasLocation = activeCoords != null
+
+  const {
+    data: feedData,
+    isPending: feedInitialPending,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ['reports-feed', activeCoords?.lat, activeCoords?.lng, radiusKm, token ?? ''],
+    queryFn: ({ pageParam }) =>
+      getReportsFeed(
+        {
+          latitude: activeCoords.lat,
+          longitude: activeCoords.lng,
+          radiusInKm: radiusKm,
+          page: pageParam,
+          size: FEED_PAGE_SIZE,
+        },
+        token
+      ),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage || lastPage.last) return undefined
+      const n = lastPage.number
+      return typeof n === 'number' ? n + 1 : undefined
+    },
+    enabled: hasLocation,
+  })
+
+  useEffect(() => {
+    const root = feedScrollRef.current
+    const sentinel = loadMoreSentinelRef.current
+    if (!root || !sentinel || !hasNextPage) return undefined
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const hit = entries.some((e) => e.isIntersecting)
+        if (hit) fetchNextPage()
+      },
+      { root, rootMargin: '140px', threshold: 0 }
+    )
+
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [fetchNextPage, hasNextPage, feedData?.pages?.length])
+
+  const viewportCenterCommit = useCallback((ll) => {
+    suppressInitialGeo.current = true
+    setActiveCoords(ll)
+  }, [])
+
+  const openMapPicker = useCallback(() => {
+    setMapKey((k) => k + 1)
+    setMapModalOpen(true)
+  }, [])
+
+  const requestMyLocation = useCallback(() => {
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setGeoState('unsupported')
+      showLocationServicesAlert()
+      return
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        suppressInitialGeo.current = true
+        const c = { lat: pos.coords.latitude, lng: pos.coords.longitude }
+        setActiveCoords(c)
+        setGeoState('granted')
+        // Remount picker map so its center matches GPS; otherwise debounced
+        // MapViewportCenterCircle would briefly overwrite coords with the old center.
+        setMapKey((k) => k + 1)
+        queueMicrotask(() => {
+          queryClient.invalidateQueries({ queryKey: ['reports-feed'] })
+        })
+      },
+      (err) => {
+        if (err.code === 1) setGeoState('denied')
+        else if (err.code === 2) setGeoState('unavailable')
+        else if (err.code === 3) setGeoState('timeout')
+        else setGeoState('unavailable')
+        showLocationServicesAlert()
+      },
+      GEO_OPTIONS
+    )
+  }, [queryClient, showLocationServicesAlert])
+
+  const handleCloseModal = useCallback(() => {
+    setMapModalOpen(false)
+  }, [])
+
+  const reports = useMemo(() => {
+    const pages = feedData?.pages
+    if (!pages?.length) return []
+    return pages.flatMap((page) => {
+      const raw = page?.content
+      if (!Array.isArray(raw)) return []
+      return raw.map(mapReport)
+    })
+  }, [feedData])
+
+  const rows = useMemo(() => {
+    if (!activeCoords || !reports.length) return []
+    return reports.map((r) => ({
+      report: r,
+      distanceKm: haversineKm(activeCoords.lat, activeCoords.lng, r.latitude, r.longitude),
+    }))
+  }, [reports, activeCoords])
+
+  const handleSelectReportFromFeedOrMap = useCallback((report) => {
+    setSelectedReport(report)
+  }, [])
+
+  const handleBackToList = useCallback(() => {
+    setSelectedReport(null)
+  }, [])
+
+  const handleVoteUpdate = useCallback(
+    (updatedReport) => {
+      setSelectedReport(updatedReport)
+      queryClient.invalidateQueries({ queryKey: ['reports-feed'] })
+    },
+    [queryClient]
+  )
+
+  useEffect(() => {
+    if (!selectedReport) return
+    const id = selectedReport.id
+    const timer = window.setTimeout(() => {
+      try {
+        markersRef.current[id]?.openPopup?.()
+      } catch {
+        /* ignore */
+      }
+    }, 550)
+    return () => window.clearTimeout(timer)
+  }, [selectedReport])
+
+  const showBlankState = !hasLocation
+  const showGeoPending = geoState === 'pending' && !hasLocation
+
+  const toolbar = (
+    <div className="border-b border-outline-variant/15 bg-surface-container-low/80 py-4 backdrop-blur-sm">
+      <div className="mb-4">
+        <h1 className="font-headline text-2xl font-extrabold tracking-tight text-on-surface md:text-3xl">
+          Community feed
+        </h1>
+      </div>
+      <div className="flex flex-wrap items-end gap-x-6 gap-y-3">
+        <div className="flex min-w-0 flex-wrap items-center gap-2 sm:gap-3">
+          <button type="button" className={BTN_PRIMARY} onClick={openMapPicker}>
+            <span className="material-symbols-outlined text-[20px]">map</span>
+            Choose location from map
+          </button>
+          <button type="button" className={BTN_OUTLINE} onClick={requestMyLocation}>
+            <span className="material-symbols-outlined text-[20px]">my_location</span>
+            Use my current location
+          </button>
+        </div>
+        <div className="flex items-center gap-2 border-outline-variant pt-3 sm:border-t-0 sm:pt-0 lg:border-l lg:pl-6">
+          <label
+            htmlFor="feed-radius-km"
+            className="mb-px whitespace-nowrap text-sm font-semibold leading-none text-on-surface-variant"
+          >
+            Radius (km)
+          </label>
+          <input
+            id="feed-radius-km"
+            type="text"
+            inputMode="decimal"
+            autoComplete="off"
+            value={radiusInput}
+            onChange={(e) => setRadiusInput(e.target.value)}
+            placeholder="1"
+            disabled={!hasLocation}
+            className="
+              h-11 w-[5.75rem] rounded-xl border border-outline-variant bg-white px-3 text-center text-sm font-semibold text-on-surface
+              shadow-sm outline-none transition
+              focus:border-primary focus:ring-2 focus:ring-primary/15
+              disabled:cursor-not-allowed disabled:bg-surface-container-high disabled:opacity-50
+            "
+          />
+        </div>
+      </div>
+    </div>
+  )
+
+  /** Horizontal inset + max width for list/empty states only; detail matches Home (`/`) full bleed. */
+  const pageInset = 'px-4 md:px-8 lg:px-16'
+  const pageInner = 'mx-auto flex h-full min-h-0 w-full max-w-7xl flex-col'
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-background font-body">
+      <Navbar />
+
+      {selectedReport ? (
+        <div className="relative flex min-h-0 flex-1 overflow-hidden">
+          <main className="relative min-h-0 flex-1">
+            <FeedBrowseMap
+              viewportFill
+              activeCoords={activeCoords}
+              radiusKm={radiusKm}
+              reports={reports}
+              selectedReport={selectedReport}
+              onMarkerSelect={handleSelectReportFromFeedOrMap}
+              markersRef={markersRef}
+            />
+            <button
+              type="button"
+              aria-label="Back to feed list"
+              onClick={handleBackToList}
+              className={`${BTN_BACK_MAP_LAYER} absolute left-3 top-24 z-[1260] sm:left-10`}
+            >
+              <span className="material-symbols-outlined text-xl">arrow_back</span>
+              Back to feed
+            </button>
+          </main>
+          <ReportPanel
+            key={selectedReport.id}
+            report={selectedReport}
+            userVote={userVotes[selectedReport.id] ?? null}
+            onVoteChange={(vote) => setUserVotes((prev) => ({ ...prev, [selectedReport.id]: vote }))}
+            onClose={handleBackToList}
+            onVoteUpdate={handleVoteUpdate}
+          />
+        </div>
+      ) : (
+        <div className={`min-h-0 flex-1 ${pageInset}`}>
+          <div className={pageInner}>
+            {showBlankState ? (
+              <main className="relative flex min-h-0 flex-1 flex-col overflow-auto">
+                <div className="py-6">{toolbar}</div>
+                <div className="mx-auto w-full max-w-4xl flex-1 pb-12">
+                  <div className="flex flex-col items-center justify-center rounded-[2rem] border border-outline-variant/20 bg-white/60 py-20 text-center shadow-sm backdrop-blur-md">
+                    {showGeoPending ? (
+                      <span className="material-symbols-outlined animate-pulse text-6xl text-primary/50">near_me</span>
+                    ) : (
+                      <span className="material-symbols-outlined text-6xl text-on-surface-variant/30">map_search</span>
+                    )}
+                    <p className="mx-auto mt-6 max-w-md text-base leading-relaxed text-on-surface-variant">
+                      {BLANK_MESSAGE}
+                    </p>
+                  </div>
+                </div>
+              </main>
+            ) : (
+              <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                {toolbar}
+                <div ref={feedScrollRef} className="min-h-0 flex-1 overflow-y-auto overscroll-contain py-5">
+                    {!showBlankState && hasLocation && feedInitialPending && (
+                      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-3">
+                        {[1, 2, 3, 4].map((k) => (
+                          <div
+                            key={k}
+                            className="h-36 animate-pulse rounded-lg border border-outline-variant/20 bg-white/50"
+                          />
+                        ))}
+                      </div>
+                    )}
+
+                    {!showBlankState && hasLocation && !feedInitialPending && rows.length === 0 && (
+                      <div className="flex flex-col items-center justify-center py-16 text-center">
+                        <span className="material-symbols-outlined text-5xl text-on-surface-variant/35">map_search</span>
+                        <p className="mt-3 font-headline text-lg font-bold text-on-surface">No reports in this area</p>
+                      </div>
+                    )}
+
+                    {!showBlankState && hasLocation && !feedInitialPending && rows.length > 0 && (
+                      <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2 sm:gap-3">
+                        {rows.map(({ report, distanceKm }) => (
+                          <ReportCard
+                            key={report.id}
+                            report={report}
+                            distanceKm={distanceKm}
+                            showProximity
+                            onCardClick={() => handleSelectReportFromFeedOrMap({ ...report })}
+                          />
+                        ))}
+                      </div>
+                    )}
+
+                    {hasLocation && (hasNextPage === true || isFetchingNextPage) && (
+                      <div
+                        ref={loadMoreSentinelRef}
+                        className="flex min-h-8 w-full items-center justify-center py-4"
+                        aria-hidden
+                      >
+                        {isFetchingNextPage && (
+                          <span
+                            className="material-symbols-outlined animate-spin text-3xl text-primary"
+                            aria-label="Loading more"
+                          >
+                            progress_activity
+                          </span>
+                        )}
+                      </div>
+                    )}
+                </div>
+              </main>
+            )}
+          </div>
+        </div>
+      )}
+
+      <LocationMapModal
+        open={mapModalOpen}
+        onClose={handleCloseModal}
+        initialCenter={activeCoords ?? DEFAULT_CENTER}
+        radiusKm={radiusKm}
+        mapKey={mapKey}
+        onCenterDebounced={viewportCenterCommit}
+        onUseMyLocation={requestMyLocation}
+      />
+
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          duration={toast.type === 'error' ? 5000 : 3000}
+          onDismiss={dismissToast}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -7,7 +7,7 @@ import ReportPanel from '../components/ReportPanel.jsx'
 import CreateReportPanel from '../components/CreateReportPanel.jsx'
 import RoutePanel from '../components/RoutePanel.jsx'
 import { useAuth } from '../context/AuthContext.jsx'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
 import Toast from '../components/Toast.jsx'
 import { useReports, reportKeys } from '../hooks/useReports.js'
@@ -152,6 +152,7 @@ function MapFlyTo({ target }) {
 function Home() {
   const { isAuthenticated } = useAuth()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const queryClient = useQueryClient()
   const { data: reports = [], isLoading: loading, error } = useReports()
   const [selectedReportId, setSelectedReportId] = useState(null)
@@ -174,6 +175,13 @@ function Home() {
   const [toast, setToast] = useState(null)
   const handleToastDismiss = useCallback(() => setToast(null), [])
   const selectedReport = reports.find((r) => r.id === selectedReportId) ?? null
+
+  useEffect(() => {
+    const rid = searchParams.get('report')
+    if (!rid) return
+    const id = Number.parseInt(rid, 10)
+    if (!Number.isNaN(id)) setSelectedReportId(id)
+  }, [searchParams])
 
   function handleSearchChange(e) {
     const query = e.target.value
@@ -618,7 +626,14 @@ function Home() {
             report={selectedReport}
             userVote={userVotes[selectedReport.id] ?? null}
             onVoteChange={(vote) => setUserVotes(prev => ({ ...prev, [selectedReport.id]: vote }))}
-            onClose={() => setSelectedReportId(null)}
+            onClose={() => {
+              setSelectedReportId(null)
+              if (searchParams.get('report')) {
+                const next = new URLSearchParams(searchParams)
+                next.delete('report')
+                setSearchParams(next, { replace: true })
+              }
+            }}
             onVoteUpdate={(updatedReport) => {
               setSelectedReportId(updatedReport.id)
               queryClient.setQueryData(reportKeys.lists(), (prev) =>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,22 +1,62 @@
 const BASE_URL = import.meta.env.VITE_API_URL
 const API_KEY = import.meta.env.VITE_API_KEY
 
+function apiBaseMissingMessage() {
+  return (
+    'API base URL is not configured (VITE_API_URL). ' +
+    'Create frontend/.env from frontend/.env.example and set VITE_API_URL to your backend (e.g. http://localhost:8080), then restart the dev server.'
+  )
+}
+
+/**
+ * Pull a useful message from Spring / RFC7807 error bodies (message/detail/title).
+ */
+function parseErrorBody(body, fallback) {
+  if (!body || typeof body !== 'object') return fallback
+  return (
+    body.message ||
+    body.detail ||
+    body.title ||
+    (typeof body.status === 'number' ? `${body.status}` : null) ||
+    fallback
+  )
+}
+
 export async function apiFetch(path, options = {}) {
+  if (!BASE_URL || BASE_URL === 'undefined') {
+    throw new Error(apiBaseMissingMessage())
+  }
+
   const { headers, ...rest } = options
-  const res = await fetch(`${BASE_URL}${path}`, {
-    ...rest,
-    headers: { 'Content-Type': 'application/json', 'Mapcess-Key': API_KEY, ...headers },
-  })
+  let res
+  try {
+    res = await fetch(`${BASE_URL}${path}`, {
+      ...rest,
+      headers: { 'Content-Type': 'application/json', 'Mapcess-Key': API_KEY ?? '', ...headers },
+    })
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    throw new Error(
+      `Cannot reach API at ${BASE_URL}${path}. Start the backend (e.g. ./mvnw spring-boot:run) or fix VITE_API_URL. (${msg})`
+    )
+  }
 
   if (!res.ok) {
     if (res.status === 401 && !res.url.includes('/error')) {
       window.dispatchEvent(new CustomEvent('auth:expired'))
     }
-    const error = await res.json().catch(() => ({ message: res.statusText }))
-    throw new Error(error.message || res.statusText)
+    const body = await res.json().catch(() => null)
+    const piece = parseErrorBody(body, res.statusText)
+    throw new Error(piece ? `${res.status} ${piece}` : `${res.status} ${res.statusText}`)
   }
 
   if (res.status === 204) return null
   const text = await res.text()
-  return text ? JSON.parse(text) : null
+  try {
+    return text ? JSON.parse(text) : null
+  } catch {
+    throw new Error(
+      `Invalid JSON from API (${path}). Check VITE_API_URL points to the MapCess backend, not an HTML page.`
+    )
+  }
 }

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -10,6 +10,77 @@ export async function getReports() {
 }
 
 /**
+ * Normalize Spring Data {@code Page} JSON so infinite scroll works across Jackson versions.
+ * Fills in {@code number}, {@code last}, and ensures {@code content} is an array.
+ */
+export function normalizeFeedPagePayload(payload) {
+  if (!payload || typeof payload !== 'object') return payload
+  if (!Object.prototype.hasOwnProperty.call(payload, 'content')) return payload
+
+  const rawContent = payload.content
+  const content = Array.isArray(rawContent) ? rawContent : []
+
+  let number = payload.number
+  if (typeof number !== 'number') {
+    const pn = payload.pageable?.pageNumber ?? payload.page?.number
+    number = typeof pn === 'number' ? pn : 0
+  }
+
+  let last = payload.last
+  if (typeof last !== 'boolean') {
+    const totalPages = payload.totalPages
+    const totalElements = payload.totalElements
+    const size = typeof payload.size === 'number' ? payload.size : 10
+    if (typeof totalPages === 'number' && totalPages > 0) {
+      last = number >= totalPages - 1
+    } else if (typeof totalElements === 'number') {
+      last = number * size + content.length >= totalElements
+    } else {
+      last = content.length < size
+    }
+  }
+
+  return { ...payload, content, number, last }
+}
+
+/**
+ * Paged community feed. With latitude and longitude, results are filtered by
+ * radius and ordered by distance; otherwise the latest reports are returned.
+ * GET /api/reports/feed
+ */
+export async function getReportsFeed(
+  {
+    latitude,
+    longitude,
+    radiusInKm = 1,
+    page = 0,
+    size = 20,
+    reportType,
+    environment,
+  } = {},
+  token
+) {
+  const search = new URLSearchParams()
+  search.set('page', String(page))
+  search.set('size', String(size))
+  if (latitude != null && longitude != null) {
+    search.set('latitude', String(latitude))
+    search.set('longitude', String(longitude))
+    search.set('radiusInKm', String(radiusInKm))
+  }
+  if (reportType != null && reportType !== '') {
+    search.set('reportType', String(reportType))
+  }
+  if (environment != null && environment !== '') {
+    search.set('environment', String(environment))
+  }
+  const raw = await apiFetch(`/api/reports/feed?${search.toString()}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  })
+  return normalizeFeedPagePayload(raw)
+}
+
+/**
  * Fetch a single report by ID.
  * GET /api/reports/{id}
  */
@@ -191,7 +262,10 @@ export function mapReport(r) {
         })
       : 'Unknown date',
     fixedAt: r.fixedAt || null,
-    location: `${r.latitude.toFixed(4)}, ${r.longitude.toFixed(4)}`,
+    location:
+      typeof r.latitude === 'number' && typeof r.longitude === 'number'
+        ? `${r.latitude.toFixed(4)}, ${r.longitude.toFixed(4)}`
+        : 'Unknown location',
     reportedBy: `User #${r.userId}`,
     agrees: r.agrees,
     disagrees: r.disagrees,

--- a/frontend/src/utils/geo.js
+++ b/frontend/src/utils/geo.js
@@ -1,0 +1,20 @@
+/**
+ * Great-circle distance between two WGS84 points in kilometers.
+ */
+export function haversineKm(lat1, lon1, lat2, lon2) {
+  const R = 6371
+  const toRad = (d) => (d * Math.PI) / 180
+  const dLat = toRad(lat2 - lat1)
+  const dLon = toRad(lon2 - lon1)
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  return R * c
+}
+
+export function formatDistanceKm(km) {
+  if (km == null || Number.isNaN(km)) return ''
+  if (km < 1) return `${Math.round(km * 1000)} m`
+  return `${km < 10 ? km.toFixed(1) : Math.round(km)} km`
+}


### PR DESCRIPTION
# 📝 Description
Fixes #320 

This PR implements the complete frontend layer for the dynamic spatial Community Feed, replacing the initial "Coming Soon" placeholder. It introduces a highly interactive, map-integrated user experience and full data pagination.

Key features and UI/UX improvements include:
- **Geolocation & State:** Auto-prompts for location on mount (default 1km radius). Displays a clean empty state if permission is denied. Includes a fully functional "Use My Current Location" button.
- **Custom Map Selection:** Map is hidden by default. When opened, it features a fixed-center selection guide (the pin remains static while the map pans underneath) for precise location targeting without extra buttons.
- **Grid Layout & Sizing:** The feed list is built as a compact 2-column grid. The main page container includes proper horizontal padding (`container mx-auto`) for better readability. The radius selector is now a manual number input.
- **Synchronized Split-View:** Clicking a report card transitions the UI into a split view (Map on the left panned to the report's coordinates, Details on the right).
- **Strict Component Reuse:** To maintain 1-to-1 visual parity and DRY principles, the detail view perfectly mirrors the original map popup without any distorting wrapper padding. A clean "Back" button manages the state transition back to the grid.
- **Infinite Scroll & Filtering:** Implemented pagination handling with infinite scrolling for large datasets. Added a filter bar at the top of the feed, strictly reusing the accessible, icon-based toggle UI from the report creation form for "Report Type" and "Environment".

# 📊 Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Refactoring
- [x] UI/UX Improvement

# ✅ Acceptance Criteria / Checklist
- [x] Reports are displayed in a scrollable feed format
- [x] Infinite scroll appends new reports as the user scrolls down
- [x] Existing report and filter components are strictly reused
- [x] Users can navigate to report details (synchronized split-view)
- [x] Loading/error states and empty states are handled gracefully
- [x] Project builds successfully
- [x] I have performed a self-review

# 📸 Screenshots / Recordings
# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min