### PR TITLE
[Backend] Drop Legacy CHECK Constraints on Enum Columns to Allow New Values

### DIFF
--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -21,6 +21,16 @@ CREATE TABLE IF NOT EXISTS report_object_issues (
     PRIMARY KEY (report_object_id, issue_type)
 );
 
+-- Drop legacy CHECK constraints on enum columns. Hibernate generated these
+-- from the original 5 ObjectType / 24 IssueType enums; ddl-auto=update does
+-- NOT extend them when new enum values are added, so inserts with newer
+-- values fail at the DB layer with a constraint violation. Without these
+-- constraints the columns remain plain VARCHAR — application-side enum
+-- parsing is the source of truth, and Hibernate does not re-create them
+-- on subsequent boots.
+ALTER TABLE report_objects        DROP CONSTRAINT IF EXISTS report_objects_object_type_check;
+ALTER TABLE report_object_issues  DROP CONSTRAINT IF EXISTS report_object_issues_issue_type_check;
+
 -- One-time backfill for rows that predate the status/points columns
 UPDATE registered_users SET status = 'ACTIVE' WHERE status IS NULL;
 UPDATE registered_users SET points = 0        WHERE points IS NULL;


### PR DESCRIPTION
# 📝 Description
Fixes #456 

Production POST /api/reports requests using any of the new enum values (WASHROOM, ROOM_SIGN, PEDESTRIAN_CROSSING, CURB_RAMP, and the new issue types) were returning 500 Internal Server Error. The root cause is that Hibernate generated CHECK constraints on `report_objects.object_type` and `report_object_issues.issue_type` against the original 5 ObjectType / 24 IssueType enums, and `ddl-auto=update` does not extend those constraints when new enum values are added. Inserts with the new values therefore fail at the DB layer with a constraint violation. Inspection via `pg_constraint` confirmed both legacy constraints still listed only the original enum values on production.

`schema.sql` now drops both constraints idempotently with `ALTER TABLE … DROP CONSTRAINT IF EXISTS`. The columns stay plain VARCHAR; enum validation is enforced application-side via `@Enumerated(EnumType.STRING)` and Spring deserialization, which already rejects unknown enum values at the JSON layer with a 400 before any DB write happens. Hibernate `ddl-auto=update` does not re-create the constraints on subsequent boots, and `IF EXISTS` keeps the migration safe to run repeatedly on every container start.

No data is lost — `DROP CONSTRAINT` only removes the rule, not the rows. Existing valid records continue to be readable and writable. The proper long-term fix is a versioned migration tool (Flyway or Liquibase) so each enum addition gets its own migration script; without it the same drift will recur the next time enum values change. That is intentionally out of scope for this hotfix and should be tracked as a separate issue.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
