### PR TITLE
[Backend] Adopt Flyway with Enum Constraint Drop

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -63,12 +63,18 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-flyway</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
+			<version>12.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-database-postgresql</artifactId>
+			<version>12.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.orm</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -63,6 +63,14 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-spatial</artifactId>
 			<version>7.2.7.Final</version>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -14,6 +14,15 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.jpa.database-platform=org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect
 
+# Flyway runs before Hibernate. baseline-on-migrate lets it adopt existing
+# databases (created previously by ddl-auto=update) by treating them as if
+# already at V1, then applying V2 onwards. Hybrid mode: Hibernate still
+# manages tables/columns from JPA entities; Flyway handles the tweaks
+# Hibernate cannot express (constraint drops, manual ALTERs, etc.).
+spring.flyway.enabled=true
+spring.flyway.baseline-on-migrate=true
+spring.flyway.baseline-version=1
+
 spring.web.error.include-stacktrace=never
 spring.web.error.include-message=never
 

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,11 @@
+-- Flyway baseline migration.
+--
+-- This file is intentionally empty. With spring.flyway.baseline-on-migrate=true,
+-- Flyway treats any pre-existing database (with tables but no flyway_schema_history)
+-- as if it were already at version 1, then starts applying V2 onwards.
+--
+-- For a fresh database (e.g. a new dev machine, CI, or a wiped container)
+-- Hibernate's ddl-auto=update creates the schema from JPA entities, so this
+-- baseline does not need to define any tables. Flyway's role here is purely
+-- to track tweaks Hibernate cannot express (constraint drops, manual ALTERs,
+-- index hints, etc.) — see V2 onwards.

--- a/backend/src/main/resources/db/migration/V2__drop_legacy_enum_constraints.sql
+++ b/backend/src/main/resources/db/migration/V2__drop_legacy_enum_constraints.sql
@@ -11,5 +11,5 @@
 -- IF EXISTS keeps this safe to apply on databases that may or may not
 -- have these constraints — e.g. fresh environments where the constraint
 -- never existed in the first place.
-ALTER TABLE report_objects        DROP CONSTRAINT IF EXISTS report_objects_object_type_check;
-ALTER TABLE report_object_issues  DROP CONSTRAINT IF EXISTS report_object_issues_issue_type_check;
+ALTER TABLE IF EXISTS report_objects        DROP CONSTRAINT IF EXISTS report_objects_object_type_check;
+ALTER TABLE IF EXISTS report_object_issues  DROP CONSTRAINT IF EXISTS report_object_issues_issue_type_check;

--- a/backend/src/main/resources/db/migration/V2__drop_legacy_enum_constraints.sql
+++ b/backend/src/main/resources/db/migration/V2__drop_legacy_enum_constraints.sql
@@ -1,0 +1,15 @@
+-- Drop legacy CHECK constraints on enum columns. Hibernate generated these
+-- from the original 5 ObjectType / 24 IssueType enums when ddl-auto=update
+-- first ran against this schema; ddl-auto does NOT extend existing CHECK
+-- constraints when new enum values are added later, so inserts using the
+-- newer values fail at the DB layer with a constraint violation.
+--
+-- The columns stay plain VARCHAR; enum validation is enforced application-side
+-- via @Enumerated(EnumType.STRING) and Spring deserialization, which already
+-- rejects unknown values at the JSON layer with a 400 before any DB write.
+--
+-- IF EXISTS keeps this safe to apply on databases that may or may not
+-- have these constraints — e.g. fresh environments where the constraint
+-- never existed in the first place.
+ALTER TABLE report_objects        DROP CONSTRAINT IF EXISTS report_objects_object_type_check;
+ALTER TABLE report_object_issues  DROP CONSTRAINT IF EXISTS report_object_issues_issue_type_check;


### PR DESCRIPTION
# 📝 Description
Fixes #456 and partly fixes #151 

Supersedes #457 (the schema.sql-only fix in `fix/drop-legacy-enum-check-constraints`). The same constraint drop is now applied as a Flyway migration here, and merging both would stage the drop in two places.

Adds Flyway as a versioned database migration tool to handle DB tweaks Hibernate `ddl-auto=update` cannot express. Hibernate generated CHECK constraints on `report_objects.object_type` and `report_object_issues.issue_type` from the original 5 ObjectType / 24 IssueType enums; `ddl-auto` does NOT extend those constraints when new enum values are added later, so production inserts with WASHROOM, ROOM_SIGN, PEDESTRIAN_CROSSING, CURB_RAMP and the new issue types fail at the DB layer with a constraint violation that surfaces as 500 Internal Server Error.

`spring.flyway.baseline-on-migrate=true` with `baseline-version=1` lets Flyway adopt existing databases (created previously by `ddl-auto=update`) by treating them as if they were already at V1, then applying V2 onwards. `V1__init.sql` is intentionally empty — it serves only as the baseline marker so `flyway_schema_history` can be initialized on existing environments without trying to recreate tables that Hibernate already manages. `V2__drop_legacy_enum_constraints.sql` is the actual fix; it idempotently drops the two stale CHECK constraints with `IF EXISTS`, safe to run on environments that may or may not have them.

Future schema tweaks (constraint changes, manual ALTERs, indexes Hibernate cannot infer) should be written as `V<n>__<description>.sql` migration files under `db/migration/` instead of being appended to `schema.sql`. The long-term path is to move fully to Flyway with `ddl-auto=validate` and a baseline snapshot of the current schema, but that is intentionally out of scope for this hotfix; this PR only sets up the infrastructure and addresses the immediate constraint blocker.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
