### PR TITLE
[Web] Pass MapTiler key to frontend build

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -28,6 +28,7 @@ jobs:
         working-directory: frontend
         env:
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_MAPTILER_KEY: ${{ secrets.VITE_MAPTILER_KEY }}
         run: npm run build
 
       - name: Copy dist to Droplet

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,7 @@
 VITE_API_URL=http://localhost:8080
 VITE_API_KEY=your-api-key-here
+# MapTiler key powers the dark-mode basemap (streets-v2-dark). Free tier at
+# https://cloud.maptiler.com — 100k tiles/month is comfortably above MVP traffic.
+# If unset, dark mode falls back to Stadia AlidadeSmoothDark, which only works
+# on localhost (returns 401 on any deployed domain).
+VITE_MAPTILER_KEY=your-maptiler-key-here


### PR DESCRIPTION
## 📝 Description
Adds `VITE_MAPTILER_KEY` to the frontend deploy job's build env so production tiles load from MapTiler instead of falling back to Stadia, which 401s outside localhost. Also enables `workflow_dispatch` so we can re-run the deploy manually after env changes.

## 📊 Type of Change
- [x] Bug fix
- [ ] New feature

## ⏱️ Estimated Review Time
- [x] < 5 min