### PR TITLE
[Web] Add Delete to Report Panel + Admin Edit/Delete Gating

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -260,7 +260,9 @@ public class ReportService {
         RegisteredUser requester = registeredUserRepository.findByEmail(email)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
 
-        if (!report.getCreatedBy().getId().equals(requester.getId())) {
+        boolean isOwner = report.getCreatedBy().getId().equals(requester.getId());
+        boolean isAdmin = requester.getRole() == UserRole.ADMIN;
+        if (!isOwner && !isAdmin) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You are not the owner of this report");
         }
 

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -260,6 +260,22 @@ class ReportServiceTest {
     }
 
     @Test
+    void delete_adminDeletesOtherUsersReport_deletesAndBroadcasts() {
+        RegisteredUser admin = new RegisteredUser();
+        admin.setId(2L);
+        admin.setEmail("admin@test.com");
+        admin.setRole(UserRole.ADMIN);
+
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("admin@test.com")).thenReturn(Optional.of(admin));
+
+        reportService.delete(1L, "admin@test.com");
+
+        verify(reportRepository).delete(testReport);
+        verify(publicSseService).broadcastReportDeleted(1L);
+    }
+
+    @Test
     void delete_withMedia_callsS3DeleteForEachFile() {
         Media media = new Media();
         media.setFilePath("https://bucket.s3.amazonaws.com/file.jpg");

--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -17,9 +17,10 @@ import {
 } from '../services/reportService.js'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '../context/AuthContext.jsx'
-import { reportKeys, useUpdateMapReport } from '../hooks/useReports.js'
+import { reportKeys, useUpdateMapReport, useDeleteMapReport } from '../hooks/useReports.js'
 import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
 import CreateFixRequestPanel from './CreateFixRequestPanel.jsx'
+import Toast from './Toast.jsx'
 
 const MAX_DESCRIPTION = 1000
 
@@ -35,9 +36,9 @@ const MAX_DESCRIPTION = 1000
  *  - onClose: () => void
  *  - onVoteUpdate: (updatedReport) => void
  */
-function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, onFollowChange }) {
+function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, onFollowChange, onShowToast }) {
 
-  const { token, isAuthenticated, userId } = useAuth()
+  const { token, isAuthenticated, userId, isAdmin } = useAuth()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [voteError, setVoteError] = useState('')
@@ -54,9 +55,22 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
   const [editDescription, setEditDescription] = useState('')
   const [editEnvironment, setEditEnvironment] = useState('OUTDOOR')
   const [editError, setEditError] = useState('')
+  const [toast, setToast] = useState(null)
   const updateReportMutation = useUpdateMapReport()
+  const deleteReportMutation = useDeleteMapReport()
+
+  // Prefer the parent's toast slot when wired (Home does this), so a toast
+  // raised on actions that unmount the panel (e.g. successful delete) still
+  // renders. Falls back to local panel-scoped toast for callers that don't
+  // pass onShowToast — keeps existing tests untouched.
+  const showToast = (t) => {
+    if (onShowToast) onShowToast(t)
+    else setToast(t)
+  }
 
   const isOwner = !!userId && report?.ownerId != null && String(userId) === String(report.ownerId)
+  // Admins can edit/delete any report; owners can edit/delete their own.
+  const canModify = isOwner || isAdmin
 
   // Bottom-sheet drag-to-resize (mobile only — desktop layout uses lg: utilities to ignore this).
   // Snap points in dvh; below DISMISS_THRESHOLD on release we call onClose().
@@ -271,9 +285,35 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
         body: { description: trimmed, environment: editEnvironment },
       })
       setIsEditing(false)
+      showToast({ type: 'success', message: 'Report updated.' })
     } catch (e) {
+      // Error stays inline in the form (setEditError) AND surfaces a toast
+      // so users notice it even if they've scrolled past the form fields.
       setEditError(e.message || 'Failed to save changes.')
+      showToast({ type: 'error', message: messageForApiError(e, 'Failed to save changes.') })
     }
+  }
+
+  async function handleDelete() {
+    if (!window.confirm('Delete this report? This cannot be undone.')) return
+    try {
+      await deleteReportMutation.mutateAsync(report.id)
+      showToast({ type: 'success', message: 'Report deleted.' })
+      // Close panel after the toast is visible — the parent removes the
+      // selection state and the SSE event fans the deletion to other
+      // clients via useSseSync (REPORT_DELETED).
+      onClose()
+    } catch (e) {
+      showToast({ type: 'error', message: messageForApiError(e, 'Failed to delete report.') })
+    }
+  }
+
+  // Map common HTTP statuses surfaced by apiFetch into user-friendly text.
+  function messageForApiError(err, fallback) {
+    const msg = err?.message ?? ''
+    if (msg.includes('403')) return 'You don’t have permission to do that.'
+    if (msg.includes('404')) return 'Report no longer exists.'
+    return msg || fallback
   }
 
   const editDescriptionTooLong = editDescription.length > MAX_DESCRIPTION
@@ -488,14 +528,25 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
               <h1 className="text-3xl font-extrabold font-headline tracking-tight text-on-surface leading-tight">
                 {report.title}
               </h1>
-              {isOwner && !isEditing && (
-                <button
-                  type="button"
-                  onClick={handleStartEdit}
-                  className="px-3 py-1.5 rounded-lg bg-surface-container-high text-on-surface font-semibold text-sm cursor-pointer flex-shrink-0"
-                >
-                  Edit
-                </button>
+              {canModify && !isEditing && (
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <button
+                    type="button"
+                    onClick={handleStartEdit}
+                    className="px-3 py-1.5 rounded-lg bg-surface-container-high text-on-surface font-semibold text-sm cursor-pointer"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    disabled={deleteReportMutation.isPending}
+                    aria-label="Delete report"
+                    className="px-3 py-1.5 rounded-lg bg-error/10 text-error font-semibold text-sm cursor-pointer disabled:opacity-60"
+                  >
+                    {deleteReportMutation.isPending ? 'Deleting…' : 'Delete'}
+                  </button>
+                </div>
               )}
             </div>
             <div className="flex items-center justify-between">
@@ -873,6 +924,14 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
           reportTitle={report.title}
           onClose={() => setShowCreateFix(false)}
           onSubmitted={handleFixSubmitted}
+        />
+      )}
+
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onDismiss={() => setToast(null)}
         />
       )}
     </>

--- a/frontend/src/components/ReportPanel.test.jsx
+++ b/frontend/src/components/ReportPanel.test.jsx
@@ -4,14 +4,18 @@ import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import ReportPanel from './ReportPanel.jsx'
 
+// Mutable auth state so individual tests can flip isAdmin / userId without
+// resetting the whole module mock. Default: signed-in non-admin "user123".
+const mockAuth = { token: 'mock-token', isAuthenticated: true, userId: 'user123', isAdmin: false }
 vi.mock('../context/AuthContext.jsx', () => ({
-  useAuth: () => ({ token: 'mock-token', isAuthenticated: true, userId: 'user123' }),
+  useAuth: () => mockAuth,
 }))
 
 vi.mock('../services/reportService.js', () => ({
   agreeReport: vi.fn(),
   disagreeReport: vi.fn(),
   updateReport: vi.fn(),
+  deleteReport: vi.fn(() => Promise.resolve()),
   agreeFixRequest: vi.fn(),
   disagreeFixRequest: vi.fn(),
   mapReport: vi.fn(r => r),
@@ -28,6 +32,7 @@ import {
   agreeReport,
   disagreeReport,
   updateReport,
+  deleteReport,
   agreeFixRequest,
   getCommentsByReport,
   createComment,
@@ -63,6 +68,11 @@ describe('ReportPanel', () => {
     user = userEvent.setup()
     vi.clearAllMocks()
     getCommentsByReport.mockResolvedValue([])
+    // Reset auth defaults between tests so admin/owner flags don't leak.
+    mockAuth.token = 'mock-token'
+    mockAuth.isAuthenticated = true
+    mockAuth.userId = 'user123'
+    mockAuth.isAdmin = false
   })
 
   function renderPanel(props = {}) {
@@ -177,6 +187,75 @@ describe('ReportPanel', () => {
       await user.click(screen.getByRole('button', { name: /^cancel$/i }))
       expect(screen.queryByLabelText(/^description$/i)).not.toBeInTheDocument()
       expect(updateReport).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('owner / admin delete', () => {
+    const ownedReport = { ...report, ownerId: 'user123', environment: 'OUTDOOR' }
+    const otherReport = { ...report, ownerId: 'someone-else', environment: 'OUTDOOR' }
+
+    test('does not show Delete button for non-owner non-admin', () => {
+      renderPanel({ report: otherReport })
+      expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument()
+    })
+
+    test('shows Delete button for the report owner', () => {
+      renderPanel({ report: ownedReport })
+      expect(screen.getByRole('button', { name: /delete report|^delete$/i })).toBeInTheDocument()
+    })
+
+    test('shows Delete button for an admin even when not the owner', () => {
+      mockAuth.isAdmin = true
+      renderPanel({ report: otherReport })
+      expect(screen.getByRole('button', { name: /delete report|^delete$/i })).toBeInTheDocument()
+    })
+
+    test('clicking Delete + confirming calls deleteReport and closes the panel', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+      deleteReport.mockResolvedValueOnce(undefined)
+      renderPanel({ report: ownedReport })
+
+      await user.click(screen.getByRole('button', { name: /delete report|^delete$/i }))
+
+      await waitFor(() => {
+        expect(deleteReport).toHaveBeenCalledWith('r1', 'mock-token')
+      })
+      expect(onCloseMock).toHaveBeenCalled()
+      confirmSpy.mockRestore()
+    })
+
+    test('clicking Delete and dismissing the confirm does not call deleteReport', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+      renderPanel({ report: ownedReport })
+
+      await user.click(screen.getByRole('button', { name: /delete report|^delete$/i }))
+
+      expect(deleteReport).not.toHaveBeenCalled()
+      expect(onCloseMock).not.toHaveBeenCalled()
+      confirmSpy.mockRestore()
+    })
+
+    test('shows a permission toast on 403 and does not close the panel', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+      deleteReport.mockRejectedValueOnce(new Error('Request failed: 403'))
+      renderPanel({ report: ownedReport })
+
+      await user.click(screen.getByRole('button', { name: /delete report|^delete$/i }))
+
+      await screen.findByText(/permission/i)
+      expect(onCloseMock).not.toHaveBeenCalled()
+      confirmSpy.mockRestore()
+    })
+
+    test('shows a "no longer exists" toast on 404', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+      deleteReport.mockRejectedValueOnce(new Error('Request failed: 404'))
+      renderPanel({ report: ownedReport })
+
+      await user.click(screen.getByRole('button', { name: /delete report|^delete$/i }))
+
+      await screen.findByText(/no longer exists/i)
+      confirmSpy.mockRestore()
     })
   })
 

--- a/frontend/src/hooks/useReports.js
+++ b/frontend/src/hooks/useReports.js
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { getReports, getReportById, mapReport, mapReportStatus, updateReport } from '../services/reportService.js'
+import { getReports, getReportById, mapReport, mapReportStatus, updateReport, deleteReport } from '../services/reportService.js'
 import { useSseStatus } from '../context/SseContext.jsx'
 import { useAuth } from '../context/AuthContext.jsx'
 
@@ -52,6 +52,23 @@ export function useUpdateMapReport() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: ({ id, body }) => updateReport(id, body, token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reportKeys.all })
+      queryClient.invalidateQueries({ queryKey: ['userReports'] })
+    },
+  })
+}
+
+/**
+ * Delete a report from the map's ReportPanel — used by the report's owner
+ * or an admin. Invalidates both the map list and any per-user lists shown
+ * on /profile so the row disappears in both surfaces.
+ */
+export function useDeleteMapReport() {
+  const { token } = useAuth()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id) => deleteReport(id, token),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: reportKeys.all })
       queryClient.invalidateQueries({ queryKey: ['userReports'] })

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -695,6 +695,9 @@ function Home() {
             report={selectedReport}
             userVote={userVotes[selectedReport.id] ?? null}
             onVoteChange={(vote) => setUserVotes(prev => ({ ...prev, [selectedReport.id]: vote }))}
+            // Toast lives on Home so it survives the panel unmounting
+            // (e.g. after a successful delete that closes the panel).
+            onShowToast={(t) => setToast(t)}
             onClose={() => { setSelectedReportId(null); navigate('/', { replace: true }) }}
             onVoteUpdate={(updatedReport) => {
               setSelectedReportId(updatedReport.id)


### PR DESCRIPTION
## 📝 Description

Closes #431.

Adds a Delete button to the map's report panel, opens Edit and Delete to admins, and runs both flows' errors through the existing Toast component. Builds on the partial owner-edit work merged in #427.

### What's in
- New `useDeleteMapReport()` hook hitting `DELETE /api/reports/{id}`. Invalidates the map list and any per-user lists so the marker disappears everywhere it was rendered.
- `ReportPanel.jsx`: Delete button sits next to Edit, gated by `isOwner || isAdmin`. Confirm dialog before the call, panel closes on success, SSE (`REPORT_DELETED`) propagates to other clients.
- Edit save and Delete both surface a toast. 403 and 404 are humanised ("You don't have permission to do that.", "Report no longer exists.") instead of leaking raw HTTP messages.
- 6 new Vitest cases: gating (owner / admin / neither), confirm dismissal, success, 403, 404.

### What's out (follow-up)
The issue also lists object, lat/lng, and media editing. Each needs real form sharing with `CreateReportPanel` (cascading object picker, drag-drop uploader) and would dwarf the rest of the diff. Splitting keeps the immediate gap shippable and gives the richer editing its own focused review. I'll file a follow-up once this lands.

## 📊 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

## ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed (244/244)

### Issue acceptance criteria
- [x] Edit and Delete buttons appear only when the current user is the report's author or an admin
- [x] Editing description and environment persists via `PUT /api/reports/{id}` and the panel reflects the updated values
- [ ] Editing location, objects, and removing media: deferred (see "What's out" above)
- [x] Deleting a report closes the panel, removes the pin from the map, and other clients see the removal via SSE (`REPORT_DELETED`)
- [x] Failure states (403, 404, network error) surface as a toast and don't corrupt local state
- [x] Description length is enforced client-side before submit (`MAX_DESCRIPTION = 1000`); media count/size limits deferred with media editing
- [x] All tests pass
- [x] Documentation updated (N/A, no user-facing docs touched)

## 🧪 How to Test

1. Sign in, open one of your own reports. Both Edit and Delete buttons should be visible.
2. Click Delete, confirm the browser dialog. Green toast at the bottom, marker disappears from the map.
3. Open another user's report. Neither button should be visible.
4. (Optional) Promote a second account to admin and repeat step 3. Both buttons should now show.

## ⏱️ Estimated Review Time

- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min