### PR TITLE
[Web] Make Navbar Logo a Home Link

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -66,7 +66,14 @@ function Navbar() {
   return (
     <header className="w-full sticky top-0 z-[1001] bg-surface-container-lowest/80 backdrop-blur-md shadow-[0_4px_40px_-4px_rgba(45,47,47,0.08)] h-16 md:h-20 flex items-center justify-between px-4 sm:px-6 md:px-8 flex-shrink-0">
       <div className="flex items-center gap-4 md:gap-8">
-        <div className="flex items-center gap-2 sm:gap-3 -translate-y-[2px]">
+        {/* Logo doubles as the home affordance on every viewport — the
+            Home/Feed nav links are hidden on `<md`, leaving mobile users
+            on /profile or /admin without a way back to the map otherwise. */}
+        <Link
+          to="/"
+          aria-label="Mapcess home"
+          className="flex items-center gap-2 sm:gap-3 -translate-y-[2px] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-lg"
+        >
           <img
             src={logo}
             alt="Mapcess logo"
@@ -75,7 +82,7 @@ function Navbar() {
           <span className="text-xl md:text-2xl font-bold text-primary tracking-tight font-headline leading-none -translate-y-[1px]">
             Mapcess
           </span>
-        </div>
+        </Link>
         <nav className="hidden md:flex items-center gap-6">
           <NavLink
             to="/"


### PR DESCRIPTION
## 📝 Description

Closes #474.

The Home / Feed nav entries in the navbar are gated by `hidden md:flex` so they disappear below 768px. The avatar dropdown only offers Profile and Log Out. As a result, a mobile user landing on `/profile` (or any sub-route) had no in-app way back to the map and had to resort to the browser back button.

Wraps the logo and "Mapcess" title in `<Link to="/">` so it works as the home affordance on every viewport. Standard web app convention; no new affordance to learn. Existing Home/Feed/Admin links keep working on desktop.

## 📊 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code
- [x] I have added/updated tests (existing Navbar tests still pass; this is a presentational link-wrap)
- [x] All tests passed (237/237)

## 🧪 How to Test

1. Open the site at 375px (DevTools mobile mode).
2. Sign in, tap avatar, tap Profile.
3. Tap the Mapcess logo/title. Returns to /.
4. Resize to desktop. Same logo click still works; existing Home/Feed nav links unchanged.

## ⏱️ Estimated Review Time

- [x] < 5 min