### PR TITLE
[Web] Theme Notification Dropdown for Dark Mode

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -133,7 +133,10 @@ function Navbar() {
               )}
             </button>
             {notifOpen && (
-              <NotificationDropdown onClose={() => setNotifOpen(false)} />
+              <NotificationDropdown
+                onClose={() => setNotifOpen(false)}
+                triggerRef={notifButtonRef}
+              />
             )}
           </div>
         )}

--- a/frontend/src/components/NotificationDropdown.jsx
+++ b/frontend/src/components/NotificationDropdown.jsx
@@ -92,7 +92,7 @@ function NotificationDropdown({ onClose }) {
   return (
     <div
       ref={ref}
-      className="absolute right-0 mt-2 w-80 max-h-[480px] flex flex-col rounded-xl bg-white shadow-lg ring-1 ring-black/8 z-[1100] overflow-hidden"
+      className="absolute right-0 mt-2 w-80 max-h-[480px] flex flex-col rounded-xl bg-surface-container-high shadow-lg ring-1 ring-outline-variant/30 z-[1100] overflow-hidden"
       role="dialog"
       aria-label="Notifications"
     >

--- a/frontend/src/components/NotificationDropdown.jsx
+++ b/frontend/src/components/NotificationDropdown.jsx
@@ -55,8 +55,11 @@ function NotificationItem({ notification, onRead }) {
 /**
  * Props:
  *  - onClose: () => void
+ *  - triggerRef: ref to the button that opens this dropdown — clicks
+ *      inside it are ignored by the outside-click handler so the trigger
+ *      can toggle the dropdown closed without racing this listener.
  */
-function NotificationDropdown({ onClose }) {
+function NotificationDropdown({ onClose, triggerRef }) {
   const { data: notifications, isLoading } = useNotifications()
   const { mutate: markRead } = useMarkNotificationRead()
   const { mutate: markAllRead, isPending: markingAll } = useMarkAllNotificationsRead()
@@ -65,7 +68,9 @@ function NotificationDropdown({ onClose }) {
 
   useEffect(() => {
     function handlePointerDown(e) {
-      if (ref.current && !ref.current.contains(e.target)) onClose()
+      if (ref.current?.contains(e.target)) return
+      if (triggerRef?.current?.contains(e.target)) return
+      onClose()
     }
     function handleKeyDown(e) {
       if (e.key === 'Escape') onClose()
@@ -76,7 +81,7 @@ function NotificationDropdown({ onClose }) {
       document.removeEventListener('pointerdown', handlePointerDown)
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [onClose])
+  }, [onClose, triggerRef])
 
   function handleRead(notification) {
     if (!notification.read) markRead(notification.id)


### PR DESCRIPTION
## 📝 Description

Closes #478.

The notification dropdown opened from the navbar bell hardcoded `bg-white` and `ring-1 ring-black/8`, so it stayed bright white when the rest of the navbar flipped to dark. One-line swap to `bg-surface-container-high` (sits one shade brighter than the navbar so it pops) and `ring-outline-variant/30`.

Also fixes a flicker where clicking the bell while the dropdown was open re-opened it: the outside-click handler now ignores clicks on the trigger ref, matching how the avatar menu already handles toggling.

Light mode unchanged.

## 📊 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] I have performed a self-review
- [x] All tests passed (244/244)

## 📸 Screenshots
<img width="1363" height="608" alt="Ekran Resmi 2026-05-09 17 32 12" src="https://github.com/user-attachments/assets/90f957cc-9429-4239-94bb-c710b28502d0" />





## 🧪 How to Test

1. Sign in. Toggle Dark from the navbar.
2. Click the bell. Dropdown opens on a dark surface, readable text, no glaring white panel.
3. Toggle back to Light. Looks identical to before.

## ⏱️ Estimated Review Time

- [x] < 5 min