### PR TITLE
[Web] Add Contextual "How to Measure" Tutorial Modal to CreateReportPanel

### DIFF
--- a/frontend/src/components/CreateReportPanel.jsx
+++ b/frontend/src/components/CreateReportPanel.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
 import { createReport, mapReport } from '../services/reportService.js'
 import { OBJECT_TYPES } from '../utils/objectTypeConfig.js'
+import ObjectTutorialModal from './ObjectTutorialModal.jsx'
 
 function CreateReportPanel({ position, onClose, onCreated }) {
   const { token, userId } = useAuth()
@@ -17,6 +18,8 @@ function CreateReportPanel({ position, onClose, onCreated }) {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const fileInputRef = useRef(null)
+  // Object type whose tutorial modal is currently shown, null when closed.
+  const [tutorialFor, setTutorialFor] = useState(null)
 
   // Bottom-sheet drag-to-resize (mobile only — desktop keeps right-sidebar layout).
   // Snap points in dvh; below DISMISS_THRESHOLD on release we call onClose().
@@ -466,13 +469,24 @@ function CreateReportPanel({ position, onClose, onCreated }) {
                       {/* Measurements — optional, collapsible */}
                       {cfg && cfg.measurements.length > 0 && (
                         <div>
-                          <button
-                            onClick={() => toggleShowMeasurements(obj.id)}
-                            className="flex items-center gap-1.5 text-xs font-semibold text-primary mb-2"
-                          >
-                            <span className="material-symbols-outlined text-base">straighten</span>
-                            {obj.showMeasurements ? 'Hide measurements' : 'Show measurements (optional)'}
-                          </button>
+                          <div className="flex items-center justify-between gap-2 mb-2">
+                            <button
+                              onClick={() => toggleShowMeasurements(obj.id)}
+                              className="flex items-center gap-1.5 text-xs font-semibold text-primary"
+                            >
+                              <span className="material-symbols-outlined text-base">straighten</span>
+                              {obj.showMeasurements ? 'Hide measurements' : 'Show measurements (optional)'}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setTutorialFor(obj.objectType)}
+                              aria-label={`How to measure ${cfg.label}`}
+                              className="flex items-center gap-1 text-xs font-semibold text-on-surface-variant hover:text-primary cursor-pointer"
+                            >
+                              <span className="material-symbols-outlined text-sm">help_outline</span>
+                              How to measure
+                            </button>
+                          </div>
                           {obj.showMeasurements && (
                             <div className="flex flex-col gap-3">
                               {cfg.measurements.map(m => (
@@ -567,6 +581,12 @@ function CreateReportPanel({ position, onClose, onCreated }) {
 
       </div>
       </aside>
+      {tutorialFor && (
+        <ObjectTutorialModal
+          objectType={tutorialFor}
+          onClose={() => setTutorialFor(null)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/ObjectTutorialModal.jsx
+++ b/frontend/src/components/ObjectTutorialModal.jsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
+
+/**
+ * ObjectTutorialModal
+ * Just-in-time accessibility tutorial shown from inside an object card on
+ * the create-report flow. Pulls measurement metadata + plain-language
+ * descriptions straight from objectTypeConfig.js so authors only edit
+ * one file when the standards change.
+ *
+ * Props:
+ *  - objectType: 'RAMP' | 'ELEVATOR' | … (must exist in OBJECT_TYPE_MAP)
+ *  - onClose:    () => void
+ */
+function ObjectTutorialModal({ objectType, onClose }) {
+  const cfg = OBJECT_TYPE_MAP[objectType]
+  const closeButtonRef = useRef(null)
+
+  useEffect(() => {
+    function handleKey(e) { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    closeButtonRef.current?.focus()
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  function handleBackdrop(e) {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  if (!cfg) return null
+  if (typeof document === 'undefined') return null
+
+  function thresholdText(m) {
+    if (m.accessible_min !== undefined && m.accessible_max !== undefined) {
+      return `${m.accessible_min}–${m.accessible_max} ${m.unit} is accessible`
+    }
+    if (m.accessible_min !== undefined) return `≥ ${m.accessible_min} ${m.unit} is accessible`
+    if (m.accessible_max !== undefined) return `≤ ${m.accessible_max} ${m.unit} is accessible`
+    return null
+  }
+
+  // Portal to body so the modal doesn't inherit `pointer-events-none`
+  // from CreateReportPanel's outer wrapper (which lets users click the
+  // map behind the bottom-sheet) — without this the X close button
+  // wouldn't receive clicks.
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`How to measure ${cfg.label}`}
+      onClick={handleBackdrop}
+      className="fixed inset-0 z-[1500] flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className="bg-surface-container-high rounded-2xl shadow-xl max-w-lg w-full max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between p-5 border-b border-outline-variant/20">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined" style={{ color: cfg.markerColor }}>{cfg.icon}</span>
+            <h3 className="text-base font-bold font-headline text-on-surface">
+              How to measure: {cfg.label}
+            </h3>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Close tutorial"
+            className="w-9 h-9 rounded-full hover:bg-surface-container flex items-center justify-center cursor-pointer"
+          >
+            <span className="material-symbols-outlined text-on-surface-variant">close</span>
+          </button>
+        </div>
+
+        <div className="p-5 flex flex-col gap-4">
+          {cfg.measurements.length === 0 ? (
+            <p className="text-sm text-on-surface-variant">
+              No measurements are tracked for this object type.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-4">
+              {cfg.measurements.map((m) => {
+                const threshold = thresholdText(m)
+                return (
+                  <li key={m.key} className="flex flex-col gap-1">
+                    <div className="flex items-baseline gap-2 flex-wrap">
+                      <span className="text-sm font-bold text-on-surface">{m.label}</span>
+                      <span className="text-xs text-on-surface-variant">({m.unit})</span>
+                      {threshold && (
+                        <span className="text-xs font-semibold text-primary">{threshold}</span>
+                      )}
+                    </div>
+                    {m.description && (
+                      <p className="text-sm text-on-surface-variant leading-relaxed">
+                        {m.description}
+                      </p>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+
+          <p className="text-[11px] text-on-surface-variant pt-2 border-t border-outline-variant/15">
+            Use these as a guide, not a strict rule. When in doubt, report what you observe and let the community verify.
+          </p>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+export default ObjectTutorialModal

--- a/frontend/src/components/ObjectTutorialModal.test.jsx
+++ b/frontend/src/components/ObjectTutorialModal.test.jsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ObjectTutorialModal from './ObjectTutorialModal.jsx'
+
+describe('ObjectTutorialModal', () => {
+  let onClose, user
+
+  beforeEach(() => {
+    onClose = vi.fn()
+    user = userEvent.setup()
+  })
+
+  it('renders the type label and every measurement for RAMP', () => {
+    render(<ObjectTutorialModal objectType="RAMP" onClose={onClose} />)
+    expect(screen.getByRole('dialog', { name: /how to measure ramp/i })).toBeInTheDocument()
+    // Three RAMP measurements: Slope, Width, Height
+    expect(screen.getByText('Slope')).toBeInTheDocument()
+    expect(screen.getByText('Width')).toBeInTheDocument()
+    expect(screen.getByText('Height')).toBeInTheDocument()
+  })
+
+  it('renders threshold pills for measurements that define them', () => {
+    render(<ObjectTutorialModal objectType="RAMP" onClose={onClose} />)
+    expect(screen.getByText(/≤ 10 % is accessible/i)).toBeInTheDocument()
+    expect(screen.getByText(/≥ 100 cm is accessible/i)).toBeInTheDocument()
+  })
+
+  it('renders a min-max range when both thresholds exist', () => {
+    render(<ObjectTutorialModal objectType="ROOM_SIGN" onClose={onClose} />)
+    expect(screen.getByText(/120–160 cm is accessible/i)).toBeInTheDocument()
+  })
+
+  it('swaps content when the objectType prop changes', () => {
+    const { rerender } = render(<ObjectTutorialModal objectType="RAMP" onClose={onClose} />)
+    expect(screen.getByText('Slope')).toBeInTheDocument()
+    rerender(<ObjectTutorialModal objectType="ELEVATOR" onClose={onClose} />)
+    expect(screen.queryByText('Slope')).not.toBeInTheDocument()
+    expect(screen.getByText('Door Width')).toBeInTheDocument()
+    expect(screen.getByText('Cabin Width')).toBeInTheDocument()
+  })
+
+  it('renders nothing for an unknown objectType', () => {
+    const { container } = render(<ObjectTutorialModal objectType="NOPE" onClose={onClose} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('closes via the explicit Close button', async () => {
+    render(<ObjectTutorialModal objectType="RAMP" onClose={onClose} />)
+    await user.click(screen.getByRole('button', { name: /close tutorial/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes when Escape is pressed', async () => {
+    render(<ObjectTutorialModal objectType="RAMP" onClose={onClose} />)
+    await user.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes when the backdrop is clicked', async () => {
+    render(<ObjectTutorialModal objectType="RAMP" onClose={onClose} />)
+    await user.click(screen.getByRole('dialog', { name: /how to measure ramp/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/utils/objectTypeConfig.js
+++ b/frontend/src/utils/objectTypeConfig.js
@@ -16,9 +16,9 @@ export const OBJECT_TYPES = [
       { key: 'INSUFFICIENT_LANDING_AREA', label: 'Insufficient Landing Area' },
     ],
     measurements: [
-      { key: 'slope_percent', label: 'Slope',  unit: '%',  accessible_max: 10 },
-      { key: 'width_cm',      label: 'Width',  unit: 'cm', accessible_min: 100 },
-      { key: 'height_cm',     label: 'Height', unit: 'cm' },
+      { key: 'slope_percent', label: 'Slope',  unit: '%',  accessible_max: 10,  description: 'Steepness of the ramp. A wheelchair user can manage up to about 10% (a 1 cm rise per 10 cm of length) without exhausting effort.' },
+      { key: 'width_cm',      label: 'Width',  unit: 'cm', accessible_min: 100, description: 'Clear travel width. 100 cm lets a single wheelchair pass; wider lets two people pass each other.' },
+      { key: 'height_cm',     label: 'Height', unit: 'cm',                      description: 'Total vertical rise the ramp covers, used to gauge whether the slope is sustainable over its length.' },
     ],
   },
   {
@@ -40,9 +40,9 @@ export const OBJECT_TYPES = [
       { key: 'INSUFFICIENT_LIGHTING', label: 'Insufficient Lighting' },
     ],
     measurements: [
-      { key: 'door_width_cm',  label: 'Door Width',  unit: 'cm', accessible_min: 90 },
-      { key: 'cabin_width_cm', label: 'Cabin Width', unit: 'cm', accessible_min: 120 },
-      { key: 'cabin_depth_cm', label: 'Cabin Depth', unit: 'cm', accessible_min: 140 },
+      { key: 'door_width_cm',  label: 'Door Width',  unit: 'cm', accessible_min: 90,  description: 'Clear opening when the doors are fully open. 90 cm fits a standard wheelchair plus its handgrips.' },
+      { key: 'cabin_width_cm', label: 'Cabin Width', unit: 'cm', accessible_min: 120, description: 'Inside width of the cabin. 120 cm gives a wheelchair user enough room to fit comfortably.' },
+      { key: 'cabin_depth_cm', label: 'Cabin Depth', unit: 'cm', accessible_min: 140, description: 'Inside depth front-to-back. 140 cm lets a wheelchair turn or fit beside another passenger.' },
     ],
   },
   {
@@ -62,8 +62,8 @@ export const OBJECT_TYPES = [
       { key: 'UNRAMPED_LEVEL_DIFFERENCE', label: 'Unramped Level Difference' },
     ],
     measurements: [
-      { key: 'height_cm', label: 'Curb Height', unit: 'cm', accessible_max: 15 },
-      { key: 'width_cm',  label: 'Width',       unit: 'cm', accessible_min: 150 },
+      { key: 'height_cm', label: 'Curb Height', unit: 'cm', accessible_max: 15,  description: 'Step from sidewalk to road. Above ~15 cm without a curb ramp blocks wheels and walkers.' },
+      { key: 'width_cm',  label: 'Width',       unit: 'cm', accessible_min: 150, description: 'Usable walking width (ignore lamp posts and benches). 150 cm lets two wheelchairs pass each other.' },
     ],
   },
   {
@@ -85,8 +85,8 @@ export const OBJECT_TYPES = [
       { key: 'INTERCOM_INACCESSIBLE', label: 'Intercom Inaccessible' },
     ],
     measurements: [
-      { key: 'width_cm',            label: 'Width',            unit: 'cm', accessible_min: 90 },
-      { key: 'threshold_height_cm', label: 'Threshold Height', unit: 'cm', accessible_max: 0.6 },
+      { key: 'width_cm',            label: 'Width',            unit: 'cm', accessible_min: 90,  description: 'Clear opening when the door is fully open. 90 cm fits a standard wheelchair.' },
+      { key: 'threshold_height_cm', label: 'Threshold Height', unit: 'cm', accessible_max: 0.6, description: 'The lip at the bottom of the doorway. Above ~0.6 cm catches small front wheels on a wheelchair.' },
     ],
   },
   {
@@ -109,8 +109,8 @@ export const OBJECT_TYPES = [
       { key: 'MISSING_NOSING_STRIP', label: 'Missing Nosing Strip' },
     ],
     measurements: [
-      { key: 'riser_cm', label: 'Riser Height', unit: 'cm', accessible_max: 16 },
-      { key: 'tread_cm', label: 'Tread Depth',  unit: 'cm', accessible_min: 27 },
+      { key: 'riser_cm', label: 'Riser Height', unit: 'cm', accessible_max: 16, description: 'Height of each step. Above 16 cm gets exhausting and risky for people with mobility limits.' },
+      { key: 'tread_cm', label: 'Tread Depth',  unit: 'cm', accessible_min: 27, description: 'Front-to-back depth of each step. Below 27 cm is too narrow to land a whole foot safely.' },
     ],
   },
   {
@@ -130,9 +130,9 @@ export const OBJECT_TYPES = [
       { key: 'NO_PEDESTRIAN_REFUGE', label: 'No Pedestrian Refuge' },
     ],
     measurements: [
-      { key: 'signal_duration_sec',    label: 'Signal Duration',    unit: 's',  accessible_min: 15 },
-      { key: 'crossing_width_cm',      label: 'Crossing Width',     unit: 'cm', accessible_min: 300 },
-      { key: 'dropped_curb_height_cm', label: 'Dropped Curb Height', unit: 'cm', accessible_max: 1.3 },
+      { key: 'signal_duration_sec',    label: 'Signal Duration',     unit: 's',  accessible_min: 15,  description: 'How long the walk signal stays on. 15 s is enough for a slow walker to cross a typical street.' },
+      { key: 'crossing_width_cm',      label: 'Crossing Width',      unit: 'cm', accessible_min: 300, description: 'Width of the marked crossing. 300 cm fits two wheelchairs passing in opposite directions.' },
+      { key: 'dropped_curb_height_cm', label: 'Dropped Curb Height', unit: 'cm', accessible_max: 1.3, description: 'Step from the crossing onto the sidewalk. Above ~1.3 cm catches wheels and trips canes.' },
     ],
   },
   {
@@ -149,9 +149,9 @@ export const OBJECT_TYPES = [
       { key: 'RAISED_LIP',         label: 'Raised Lip' },
     ],
     measurements: [
-      { key: 'slope_percent', label: 'Slope',      unit: '%',  accessible_max: 8 },
-      { key: 'width_cm',      label: 'Width',      unit: 'cm', accessible_min: 120 },
-      { key: 'lip_height_cm', label: 'Lip Height', unit: 'cm', accessible_max: 1.3 },
+      { key: 'slope_percent', label: 'Slope',      unit: '%',  accessible_max: 8,   description: 'Steepness of the curb ramp. 8% is the comfortable maximum for a person pushing themself in a wheelchair.' },
+      { key: 'width_cm',      label: 'Width',      unit: 'cm', accessible_min: 120, description: 'Width of the ramp surface. 120 cm matches the wheelchair-friendly minimum.' },
+      { key: 'lip_height_cm', label: 'Lip Height', unit: 'cm', accessible_max: 1.3, description: 'Bump where the ramp meets the road. Above 1.3 cm jolts wheels and trips canes.' },
     ],
   },
   {
@@ -171,10 +171,10 @@ export const OBJECT_TYPES = [
       { key: 'NO_EMERGENCY_BUTTON',        label: 'No Emergency Button' },
     ],
     measurements: [
-      { key: 'door_width_cm',      label: 'Door Width',      unit: 'cm', accessible_min: 90 },
-      { key: 'turning_space_cm',   label: 'Turning Space',   unit: 'cm', accessible_min: 150 },
-      { key: 'sink_height_cm',     label: 'Sink Height',     unit: 'cm', accessible_max: 85 },
-      { key: 'grab_bar_height_cm', label: 'Grab Bar Height', unit: 'cm', accessible_min: 70 },
+      { key: 'door_width_cm',      label: 'Door Width',      unit: 'cm', accessible_min: 90,  description: 'Clear opening when the door is fully open. 90 cm fits a standard wheelchair.' },
+      { key: 'turning_space_cm',   label: 'Turning Space',   unit: 'cm', accessible_min: 150, description: 'Open circle of clear floor space. 150 cm lets a wheelchair turn fully around.' },
+      { key: 'sink_height_cm',     label: 'Sink Height',     unit: 'cm', accessible_max: 85,  description: 'Top of the sink rim from the floor. Below 85 cm lets a seated user reach the tap.' },
+      { key: 'grab_bar_height_cm', label: 'Grab Bar Height', unit: 'cm', accessible_min: 70,  description: 'Height of the grab bars from the floor. 70 cm or higher lines up with most transfer holds.' },
     ],
   },
   {
@@ -192,8 +192,8 @@ export const OBJECT_TYPES = [
       { key: 'INVALID_HEIGHT',        label: 'Invalid Height' },
     ],
     measurements: [
-      { key: 'mounting_height_cm', label: 'Mounting Height', unit: 'cm', accessible_min: 120, accessible_max: 160 },
-      { key: 'text_height_mm',     label: 'Text Height',     unit: 'mm', accessible_min: 15 },
+      { key: 'mounting_height_cm', label: 'Mounting Height', unit: 'cm', accessible_min: 120, accessible_max: 160, description: 'Center of the sign from the floor. 120-160 cm aligns with eye level for both standing and seated users.' },
+      { key: 'text_height_mm',     label: 'Text Height',     unit: 'mm', accessible_min: 15,                       description: 'Height of the letterforms. Below 15 mm is hard to read from door distance.' },
     ],
   },
 ]


### PR DESCRIPTION
## 📝 Description

Closes #483.

Adds a per-object tutorial modal in the create-report flow. After the user picks an object type (Ramp, Elevator, etc.), a "How to measure" link appears next to the existing "Show measurements" toggle inside the object card. Clicking it opens a modal that lists every measurement for that type with:

- The label and unit (e.g. "Slope (%)").
- The accessible threshold sourced from `accessible_min` / `accessible_max` (e.g. "≤ 10 % is accessible").
- A short, plain-language explanation of what to measure and why the threshold matters.

The descriptions live next to the threshold values in `objectTypeConfig.js` so future edits are one-file changes.

Visual aids (diagrams, illustrations) from the parent issue #374 are intentionally out of scope, we don't have design assets, and the textual content + thresholds are the high-value half. Mobile is owned by another assignee under #374.

## 📊 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

## ✅ Acceptance Criteria / Checklist

- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have added/updated tests (8 new in `ObjectTutorialModal.test.jsx`)
- [x] All tests passed (263/263)

### Issue acceptance criteria
- [x] Selecting Ramp shows ramp measurements; selecting Elevator swaps to elevator measurements
- [x] Each explanation is plain English, non-expert
- [x] Link is unobtrusive and does not block the report-creation flow
- [x] Modal usable on mobile (375 px) — uses the same modal pattern as `MyReportDetailModal`
- [x] All existing tests pass

## 📸 Screenshots

**Desktop*
<img width="1351" height="721" alt="Ekran Resmi 2026-05-09 19 30 38" src="https://github.com/user-attachments/assets/37f530fe-dd85-4825-a742-d7374f09240c" />
*




**Mobile**
<img width="364" height="657" alt="Ekran Resmi 2026-05-09 19 34 05" src="https://github.com/user-attachments/assets/8e5040ee-d612-43bd-8e1e-ce4e7466f19e" />


## 🧪 How to Test

1. Sign in. Click **Report an Issue**.
2. Add an object, pick **Ramp**. A "How to measure" link appears next to "Show measurements".
3. Click it. Modal lists Slope / Width / Height with their thresholds and one-line explanations.
4. Close via X, backdrop click, or Escape — all three work.
5. Switch the object type to **Elevator** and click "How to measure" again. Content swaps.

## ⏱️ Estimated Review Time

- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min