### PR TITLE
[Web] Sign Up Pill Contrast and Log In Spacing

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -212,7 +212,7 @@ function Navbar() {
             )}
           </div>
         ) : (
-          <div className="flex items-center gap-2 ml-1 sm:ml-2">
+          <div className="flex items-center gap-3 sm:gap-4 ml-1 sm:ml-2">
             <Link
               to="/login"
               className="text-on-surface-variant hover:text-primary transition-colors font-medium text-sm sm:text-base"
@@ -221,7 +221,7 @@ function Navbar() {
             </Link>
             <Link
               to="/signup"
-              className="bg-primary text-white rounded-full px-3 py-1.5 sm:px-4 sm:py-2 hover:bg-primary/90 transition-colors font-semibold text-sm sm:text-base"
+              className="bg-primary text-on-primary rounded-full px-3 py-1.5 sm:px-4 sm:py-2 hover:bg-primary/90 transition-colors font-semibold text-sm sm:text-base"
             >
               Sign Up
             </Link>


### PR DESCRIPTION
Closes #485.

Two small navbar polish items.

1. Sign Up pill uses `text-white`, which sits poorly on the mint dark-mode primary. Switched to `text-on-primary` so it flips to the dark-green token in dark mode (matching what the Report-an-Issue FAB does).
2. Log In and Sign Up sat too close together (`gap-2`). Bumped to `gap-3 sm:gap-4` so the secondary text-link has room to breathe.

## 📊 Type of Change
- [x] Bug fix
- [ ] New feature

## ✅ Checklist
- [x] Project builds successfully
- [x] All tests passed (255/255)

## 🧪 How to Test
1. Sign out. Toggle Dark.
2. Look at the navbar — Sign Up pill text reads cleanly; Log In has visible breathing room.
3. Resize to 375 px — same.

## ⏱️ Estimated Review Time
- [x] < 5 min