### PR TITLE
[Web] Move Zoom Controls to Upper-Left to Avoid Overlap

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -69,7 +69,7 @@ function makeMarkerIcon(status, objectType, selected = false) {
 function ZoomControls() {
   const map = useMap()
   return (
-    <div className="absolute right-3 sm:right-10 top-24 sm:top-1/3 sm:-translate-y-1/2 flex flex-col gap-2 z-[1000]">
+    <div className="absolute left-3 sm:left-10 top-24 sm:top-28 flex flex-col gap-2 z-[1000]">
       <button
         onClick={() => map.zoomIn()}
         className="w-10 h-10 sm:w-12 sm:h-12 bg-surface-container-lowest/80 backdrop-blur-md rounded-xl flex items-center justify-center shadow-lg hover:bg-surface-container-lowest text-secondary hover:text-primary transition-colors"

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -66,10 +66,16 @@ function makeMarkerIcon(status, objectType, selected = false) {
   })
 }
 
-function ZoomControls() {
+function ZoomControls({ shiftRight = false }) {
   const map = useMap()
+  // RoutePanel is a 360px left sidebar at ≥lg. When it's open, shift the zoom
+  // controls past it on desktop so they aren't hidden behind the panel.
+  // Mobile keeps the upper-left position (RoutePanel is a bottom sheet there).
+  const positionClasses = shiftRight
+    ? 'left-3 sm:left-10 lg:left-[376px] top-24 sm:top-28'
+    : 'left-3 sm:left-10 top-24 sm:top-28'
   return (
-    <div className="absolute left-3 sm:left-10 top-24 sm:top-28 flex flex-col gap-2 z-[1000]">
+    <div className={`absolute ${positionClasses} flex flex-col gap-2 z-[1000] transition-[left] duration-200`}>
       <button
         onClick={() => map.zoomIn()}
         className="w-10 h-10 sm:w-12 sm:h-12 bg-surface-container-lowest/80 backdrop-blur-md rounded-xl flex items-center justify-center shadow-lg hover:bg-surface-container-lowest text-secondary hover:text-primary transition-colors"
@@ -537,7 +543,7 @@ function Home() {
                 />
               )
             })}
-            <ZoomControls />
+            <ZoomControls shiftRight={routeMode} />
           </MapContainer>
 
           {/* Loading / error overlay */}


### PR DESCRIPTION
Closes #487.

Both zoom controls and the Community Pulse card sat at `right-10` in the right-side column of the map. On short Chrome windows (~700 px tall and below) the card stack (FABs + Community Pulse, ~380 px tall) reached high enough to collide with the zoom buttons regardless of where the buttons were anchored vertically.

Moved zoom controls to the upper-left (`left-3 sm:left-10 top-24 sm:top-28`), which is Leaflet's default position anyway. Now zoom is in the left column, the card stack owns the right column, and they can't collide on any viewport.

## 📊 Type of Change
- [x] Bug fix

## ✅ Checklist
- [x] Project builds successfully
- [x] All tests passed (255/255)

## 📸 Screenshot
<img width="1066" height="726" alt="Ekran Resmi 2026-05-09 20 01 08" src="https://github.com/user-attachments/assets/3174382d-763b-4ef7-a8b7-ea79f12f052a" />



## 🧪 How to Test
1. Open the map. Resize Chrome to ~800x600.
2. Zoom controls now sit upper-left under the search bar; Community Pulse card and FABs stay lower-right with clear space between them.
3. Fullscreen, same layout, no regression.
4. Mobile (375 px) ,zoom controls upper-left under the search bar, FABs lower-right, no overlap.

## ⏱️ Estimated Review Time
- [x] < 5 min