### PR TITLE
[Web] Don't Flash Signup Password Rules Red on First Keystroke

### DIFF
--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -151,8 +151,11 @@ function Signup() {
                     aria-live="polite"
                   >
                     {passwordValidation.results.map((rule) => {
-                      const showFailure =
-                        (passwordTouched || password.length > 0) && !rule.passed
+                      // Show red only after the user has tabbed away or
+                      // tried to submit (passwordTouched). While they're
+                      // still typing for the first time, unmet rules stay
+                      // grey so the form doesn't flash red on every keystroke.
+                      const showFailure = passwordTouched && !rule.passed
                       const colorClass = rule.passed
                         ? 'text-[#176a21]'
                         : showFailure

--- a/frontend/src/pages/Signup.test.jsx
+++ b/frontend/src/pages/Signup.test.jsx
@@ -158,11 +158,19 @@ describe('Signup page', () => {
   // ─── Password validation UI ──────────────────────────────────────────────────
 
   describe('password requirements checklist', () => {
-    it('shows a descriptive message for each unmet rule as the user types', async () => {
+    it('keeps unmet rules in a neutral state while typing, then surfaces error copy after blur', async () => {
       const user = userEvent.setup()
       renderSignup()
-      await user.type(screen.getByLabelText(/^password$/i), 'abc')
+      const passwordInput = screen.getByLabelText(/^password$/i)
+      await user.type(passwordInput, 'abc')
 
+      // While the user is still typing for the first time the unmet rules
+      // show their short label, not the long error message.
+      expect(screen.queryByText(/at least 8 characters long/i)).not.toBeInTheDocument()
+      expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument()
+
+      // After blur (or attempt to submit) the long descriptive error copy appears.
+      await user.tab()
       expect(screen.getByText(/at least 8 characters long/i)).toBeInTheDocument()
       expect(screen.getByText(/uppercase letter/i)).toBeInTheDocument()
       expect(screen.getByText(/at least one number/i)).toBeInTheDocument()


### PR DESCRIPTION
Closes #489.

The signup password checklist used `(passwordTouched || password.length > 0)` to flip rules to red. The OR meant a single keystroke turned every still-unmet rule red ,discouraging while the user is mid-typing.

Tightened the predicate to `passwordTouched && !rule.passed`. Unmet rules now stay neutral grey while typing, turn green the moment they're satisfied, and only flip to red once the user blurs the field or hits Submit (the existing handler already sets `passwordTouched` on submit).

Updated the matching Vitest case so it asserts both phases (neutral during typing, red copy after blur).

## 📊 Type of Change
- [x] Bug fix

## ✅ Checklist
- [x] All tests passed (255/255)

## 🧪 How to Test
1. Open `/signup`. Type one character. None of the unmet rules turn red.
2. Keep typing. Rules turn green one by one as they're satisfied.
3. Tab away (or click Create Account with an invalid password). Remaining unmet rules now turn red with descriptive copy.

## ⏱️ Estimated Review Time
- [x] < 5 min