### PR TITLE
[Backend] Add Gamification Foundation

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/model/Badge.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/Badge.java
@@ -1,0 +1,33 @@
+package com.bounswe2026group1.backend.model;
+
+/**
+ * Gamification badges.
+ *
+ * Tier ordering matches {@link #getTier()} — used to surface a single
+ * "highest badge" next to the author's name in report panels. Higher
+ * tier wins; ties never occur because each user holds at most one
+ * row per badge.
+ */
+public enum Badge {
+    /** Awarded once a user reaches 10 verified reports. Permanent. */
+    TRUSTED_REPORTER(1),
+
+    /** Awarded once a user reaches 50 verified reports. Permanent. */
+    EXPERT_MAPPER(2),
+
+    /**
+     * Awarded to the current top-10 leaderboard holders. Revoked the moment
+     * the user drops below rank 10.
+     */
+    TOP_10(3);
+
+    private final int tier;
+
+    Badge(int tier) {
+        this.tier = tier;
+    }
+
+    public int getTier() {
+        return tier;
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/PointEvent.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/PointEvent.java
@@ -1,0 +1,71 @@
+package com.bounswe2026group1.backend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * Append-only ledger of every gamification point change.
+ *
+ * The running balance on {@link RegisteredUser#getPoints()} is the
+ * authoritative value for sorting and display, but this ledger lets us
+ * audit, debug, and surface a points history view in admin tooling.
+ * {@code delta} records what was actually applied after the
+ * "score must not drop below 0" clamp, so summing deltas always
+ * reconstructs the current balance.
+ */
+@Entity
+@Table(
+        name = "point_events",
+        indexes = {
+                @Index(name = "idx_point_events_user_created",
+                        columnList = "user_id, created_at"),
+                @Index(name = "idx_point_events_related",
+                        columnList = "related_entity_id")
+        }
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private RegisteredUser user;
+
+    @Column(nullable = false)
+    private int delta;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private PointReason reason;
+
+    /** Report id that triggered the change, or null for events not tied to
+     *  a single report (e.g. a hypothetical admin adjustment). */
+    @Column(name = "related_entity_id")
+    private Long relatedEntityId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = Instant.now();
+        }
+    }
+
+    public PointEvent(RegisteredUser user, int delta, PointReason reason, Long relatedEntityId) {
+        this.user = user;
+        this.delta = delta;
+        this.reason = reason;
+        this.relatedEntityId = relatedEntityId;
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/PointReason.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/PointReason.java
@@ -1,0 +1,31 @@
+package com.bounswe2026group1.backend.model;
+
+/**
+ * Audit reason on every {@link PointEvent}. The set of reasons is the
+ * full enumeration of point-changing events in the gamification rules,
+ * so that the running balance on {@link RegisteredUser#getPoints()}
+ * can always be reconstructed from the ledger.
+ */
+public enum PointReason {
+
+    /** Author submitted a new report. */
+    REPORT_SUBMIT,
+
+    /** A vote was cast on someone else's report. */
+    VOTE_CAST,
+
+    /** A previously cast vote was fully withdrawn. */
+    VOTE_WITHDRAWN,
+
+    /** Author bonus when their report reaches VERIFIED. */
+    REPORT_VERIFIED_BONUS,
+
+    /** Author penalty when their report reaches REJECTED. */
+    REPORT_REJECTED_PENALTY,
+
+    /** Voter reward when their vote agreed with the final status. */
+    VOTE_ALIGNED,
+
+    /** Voter penalty when their vote opposed the final status. */
+    VOTE_OPPOSED
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/RegisteredUser.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/RegisteredUser.java
@@ -107,6 +107,20 @@ public class RegisteredUser {
     @EqualsAndHashCode.Exclude
     private UserCustomRoutingProfile activeCustomProfile;
 
+    /**
+     * Leaderboard opt-out. When true the user is filtered out of the
+     * public top-100 list and their rank is hidden on their public
+     * profile, but their points field stays accurate so they can
+     * re-enter the ranking instantly if they toggle this off.
+     *
+     * Declared last so the Lombok-generated all-args constructor keeps the
+     * pre-existing parameter order — preserves call-sites in tests and code
+     * that build users via {@code new RegisteredUser(id, name, email, …)}.
+     */
+    @Column(name = "leaderboard_hidden", nullable = false,
+            columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean leaderboardHidden = false;
+
     @PrePersist
     protected void onCreate() {
         if (this.registeredAt == null) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/UserBadge.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/UserBadge.java
@@ -1,0 +1,59 @@
+package com.bounswe2026group1.backend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * Award record linking a {@link RegisteredUser} to a {@link Badge}.
+ *
+ * The unique constraint enforces idempotency — milestone re-evaluation can
+ * fire multiple times without producing duplicate rows. Top-10 churn is
+ * modelled by deleting the row on revoke rather than soft-flagging it,
+ * because the rule is "revoke immediately"; the audit trail lives in
+ * {@link PointEvent}.
+ */
+@Entity
+@Table(
+        name = "user_badges",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_badge",
+                columnNames = {"user_id", "badge"}
+        ),
+        indexes = @Index(name = "idx_user_badges_user", columnList = "user_id")
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserBadge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private RegisteredUser user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private Badge badge;
+
+    @Column(name = "awarded_at", nullable = false, updatable = false)
+    private Instant awardedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.awardedAt == null) {
+            this.awardedAt = Instant.now();
+        }
+    }
+
+    public UserBadge(RegisteredUser user, Badge badge) {
+        this.user = user;
+        this.badge = badge;
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/PointEventRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/PointEventRepository.java
@@ -1,0 +1,28 @@
+package com.bounswe2026group1.backend.repository;
+
+import com.bounswe2026group1.backend.model.PointEvent;
+import com.bounswe2026group1.backend.model.PointReason;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PointEventRepository extends JpaRepository<PointEvent, Long> {
+
+    Page<PointEvent> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    /** Used by GamificationService to ensure idempotency for vote-cast
+     *  awards: at most one VOTE_CAST event per (user, report). */
+    boolean existsByUserIdAndRelatedEntityIdAndReason(Long userId,
+                                                     Long relatedEntityId,
+                                                     PointReason reason);
+
+    /** Used by GamificationService to pair vote-cast and vote-withdrawn
+     *  events on the same (user, report). The two are tracked
+     *  independently so the user can cycle vote → withdraw → vote again
+     *  without losing points net (each cycle is +5 / -5). */
+    long countByUserIdAndRelatedEntityIdAndReason(Long userId,
+                                                  Long relatedEntityId,
+                                                  PointReason reason);
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/PointEventRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/PointEventRepository.java
@@ -17,12 +17,4 @@ public interface PointEventRepository extends JpaRepository<PointEvent, Long> {
     boolean existsByUserIdAndRelatedEntityIdAndReason(Long userId,
                                                      Long relatedEntityId,
                                                      PointReason reason);
-
-    /** Used by GamificationService to pair vote-cast and vote-withdrawn
-     *  events on the same (user, report). The two are tracked
-     *  independently so the user can cycle vote → withdraw → vote again
-     *  without losing points net (each cycle is +5 / -5). */
-    long countByUserIdAndRelatedEntityIdAndReason(Long userId,
-                                                  Long relatedEntityId,
-                                                  PointReason reason);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepository.java
@@ -21,6 +21,9 @@ public interface ReportRepository extends JpaRepository<Report, Long>, JpaSpecif
 
     long countByCreatedById(Long userId);
 
+    /** Used by the milestone badge engine (Trusted Reporter / Expert Mapper). */
+    long countByCreatedByIdAndStatus(Long userId, ReportStatus status);
+
     /** Batch variant of {@link #countByCreatedById}: one query, grouped by user.
      *  Returns rows of {@code [userId, count]}; absent users mean zero. */
     @Query("""

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportVerificationRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportVerificationRepository.java
@@ -35,4 +35,14 @@ public interface ReportVerificationRepository extends JpaRepository<ReportVerifi
      *  Used by the notification audience fan-out, so we project ids only. */
     @Query("select distinct rv.user.id from ReportVerification rv where rv.report.reportId = :reportId")
     List<Long> findVoterUserIdsByReportId(@Param("reportId") Long reportId);
+
+    /** Returns {@code [userId, VoteType]} tuples for everyone who voted on a report.
+     *  Used by GamificationService at status-transition time to award/deduct points
+     *  to voters based on whether they aligned with the final status. */
+    @Query("""
+            select rv.user.id, rv.voteType
+            from ReportVerification rv
+            where rv.report.reportId = :reportId
+            """)
+    List<Object[]> findVoteTuplesByReportId(@Param("reportId") Long reportId);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/UserBadgeRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/UserBadgeRepository.java
@@ -1,0 +1,38 @@
+package com.bounswe2026group1.backend.repository;
+
+import com.bounswe2026group1.backend.model.Badge;
+import com.bounswe2026group1.backend.model.UserBadge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
+
+    List<UserBadge> findByUserId(Long userId);
+
+    Optional<UserBadge> findByUserIdAndBadge(Long userId, Badge badge);
+
+    boolean existsByUserIdAndBadge(Long userId, Badge badge);
+
+    long deleteByUserIdAndBadge(Long userId, Badge badge);
+
+    /** All current holders of a single badge — used to compute the diff
+     *  during top-10 recomputation. */
+    @Query("select ub.user.id from UserBadge ub where ub.badge = :badge")
+    List<Long> findUserIdsByBadge(@Param("badge") Badge badge);
+
+    /** Returns {@code [userId, badge]} pairs for the given user ids — single
+     *  query for batch profile rendering and report-author top-badge lookup. */
+    @Query("""
+            select ub.user.id, ub.badge
+            from UserBadge ub
+            where ub.user.id in :userIds
+            """)
+    List<Object[]> findBadgesByUserIds(@Param("userIds") Collection<Long> userIds);
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/AdminUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/AdminUserService.java
@@ -87,7 +87,6 @@ public class AdminUserService {
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.setRole(request.getRole());
         user.setStatus(UserStatus.ACTIVE);
-        user.setPoints(0);
 
         return AdminUserResponse.fromEntity(userRepository.save(user));
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
@@ -1,0 +1,254 @@
+package com.bounswe2026group1.backend.service;
+
+import com.bounswe2026group1.backend.model.Badge;
+import com.bounswe2026group1.backend.model.PointEvent;
+import com.bounswe2026group1.backend.model.PointReason;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.model.ReportStatus;
+import com.bounswe2026group1.backend.model.UserBadge;
+import com.bounswe2026group1.backend.model.VoteType;
+import com.bounswe2026group1.backend.repository.PointEventRepository;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.repository.ReportRepository;
+import com.bounswe2026group1.backend.repository.ReportVerificationRepository;
+import com.bounswe2026group1.backend.repository.UserBadgeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Owns every gamification side-effect: point award/deduct, ledger writes,
+ * milestone badge evaluation. Callers (ReportService, FixRequestService)
+ * invoke high-level methods like {@link #awardOnReportSubmit} — never
+ * {@link #applyDelta} directly — so all rule changes stay localised here.
+ *
+ * Top-10 badges are owned by LeaderboardService once it lands; this
+ * service does not touch the TOP_10 badge.
+ */
+@Service
+@RequiredArgsConstructor
+public class GamificationService {
+
+    private final RegisteredUserRepository userRepository;
+    private final ReportRepository reportRepository;
+    private final ReportVerificationRepository verificationRepository;
+    private final PointEventRepository pointEventRepository;
+    private final UserBadgeRepository userBadgeRepository;
+
+    @Value("${app.gamification.points.report-submit:10}")
+    private int reportSubmitDelta;
+
+    @Value("${app.gamification.points.vote-cast:5}")
+    private int voteCastDelta;
+
+    @Value("${app.gamification.points.vote-withdrawn:-5}")
+    private int voteWithdrawnDelta;
+
+    @Value("${app.gamification.points.verified-bonus:20}")
+    private int verifiedBonusDelta;
+
+    @Value("${app.gamification.points.rejected-penalty:-15}")
+    private int rejectedPenaltyDelta;
+
+    @Value("${app.gamification.points.vote-aligned:15}")
+    private int voteAlignedDelta;
+
+    @Value("${app.gamification.points.vote-opposed:-5}")
+    private int voteOpposedDelta;
+
+    @Value("${app.gamification.badges.trusted-reporter-threshold:10}")
+    private int trustedReporterThreshold;
+
+    @Value("${app.gamification.badges.expert-mapper-threshold:50}")
+    private int expertMapperThreshold;
+
+    // ────────────────────────── Public API ──────────────────────────────
+
+    /** Author submitted a new report. Awarded once per report (callers
+     *  fire this exactly once from ReportService.create). */
+    @Transactional
+    public void awardOnReportSubmit(RegisteredUser author, Long reportId) {
+        if (author == null) return;
+        applyDelta(author, reportSubmitDelta, PointReason.REPORT_SUBMIT, reportId);
+    }
+
+    /**
+     * Voter cast a fresh vote on someone else's report. Modifying an
+     * existing vote (agree → disagree or vice versa) MUST NOT yield
+     * extra points; callers handle that by NOT calling this method on
+     * modify, only on first cast.
+     *
+     * The cast/withdraw cycle is allowed to net out: a user who casts (+5),
+     * withdraws (-5), and casts again receives a fresh +5. We detect that
+     * by comparing CAST and WITHDRAWN event counts on (user, report) — if
+     * casts already exceed withdrawals, the user is currently in "voted"
+     * state and another call here is a modify, not a fresh cast.
+     */
+    @Transactional
+    public void awardOnVoteCast(RegisteredUser voter, Long reportId) {
+        if (voter == null || reportId == null) return;
+        if (isCurrentlyVoted(voter.getId(), reportId)) {
+            return; // Modify-vote path, no extra points.
+        }
+        applyDelta(voter, voteCastDelta, PointReason.VOTE_CAST, reportId);
+    }
+
+    /** Voter fully withdrew their previously cast vote. */
+    @Transactional
+    public void deductOnVoteWithdraw(RegisteredUser voter, Long reportId) {
+        if (voter == null || reportId == null) return;
+        if (!isCurrentlyVoted(voter.getId(), reportId)) {
+            // Defensive: never deduct points for a withdraw the user never
+            // paired with a cast (would otherwise let a malicious caller
+            // drive any user to zero via spurious withdraw events).
+            return;
+        }
+        applyDelta(voter, voteWithdrawnDelta, PointReason.VOTE_WITHDRAWN, reportId);
+    }
+
+    /**
+     * A report transitioned to its terminal status. Apply author bonus
+     * or penalty and reward/penalise voters by alignment.
+     *
+     * <p>Per the agreed plan, only PENDING→VERIFIED and PENDING→REJECTED
+     * transitions trigger this; reverts (VERIFIED→PENDING, REJECTED→PENDING)
+     * deliberately do NOT undo points, to keep the audit ledger stable
+     * and the leaderboard predictable.
+     */
+    @Transactional
+    public void onReportStatusTransition(Report report, ReportStatus from, ReportStatus to) {
+        if (report == null || from == to) return;
+        if (from != ReportStatus.PENDING) return;
+        if (to != ReportStatus.VERIFIED && to != ReportStatus.REJECTED) return;
+
+        boolean verified = (to == ReportStatus.VERIFIED);
+
+        // 1) Author bonus or penalty.
+        RegisteredUser author = report.getCreatedBy();
+        if (author != null) {
+            int delta = verified ? verifiedBonusDelta : rejectedPenaltyDelta;
+            PointReason reason = verified
+                    ? PointReason.REPORT_VERIFIED_BONUS
+                    : PointReason.REPORT_REJECTED_PENALTY;
+            applyDelta(author, delta, reason, report.getReportId());
+
+            // Milestone badges only matter for VERIFIED transitions, since the
+            // count we evaluate is verified-reports. Cheap to skip on REJECTED.
+            if (verified) {
+                evaluateMilestoneBadges(author);
+            }
+        }
+
+        // 2) Voter alignment payout.
+        VoteType winningSide = verified ? VoteType.AGREE : VoteType.DISAGREE;
+        List<Object[]> voteTuples = verificationRepository
+                .findVoteTuplesByReportId(report.getReportId());
+        if (voteTuples.isEmpty()) return;
+
+        List<Long> voterIds = voteTuples.stream()
+                .map(row -> (Long) row[0])
+                .filter(id -> author == null || !id.equals(author.getId()))
+                .toList();
+        if (voterIds.isEmpty()) return;
+
+        Map<Long, RegisteredUser> votersById = userRepository.findAllById(voterIds).stream()
+                .collect(Collectors.toMap(RegisteredUser::getId, Function.identity()));
+
+        for (Object[] row : voteTuples) {
+            Long voterId = (Long) row[0];
+            VoteType voteType = (VoteType) row[1];
+            if (author != null && voterId.equals(author.getId())) continue;
+
+            RegisteredUser voter = votersById.get(voterId);
+            if (voter == null) continue;
+
+            boolean aligned = (voteType == winningSide);
+            int delta = aligned ? voteAlignedDelta : voteOpposedDelta;
+            PointReason reason = aligned ? PointReason.VOTE_ALIGNED : PointReason.VOTE_OPPOSED;
+            applyDelta(voter, delta, reason, report.getReportId());
+        }
+    }
+
+    /**
+     * Re-evaluates Trusted Reporter / Expert Mapper milestone badges for
+     * a user. Idempotent: badges already held are skipped, and a
+     * transient drop in verified-count (e.g. one report later REJECTED)
+     * does NOT revoke milestone badges — the rule says "automatically
+     * award", revocation language only applies to TOP_10.
+     */
+    @Transactional
+    public List<Badge> evaluateMilestoneBadges(RegisteredUser user) {
+        if (user == null) return List.of();
+        long verifiedCount = reportRepository
+                .countByCreatedByIdAndStatus(user.getId(), ReportStatus.VERIFIED);
+
+        List<Badge> newlyAwarded = new ArrayList<>();
+        if (verifiedCount >= trustedReporterThreshold) {
+            if (awardBadgeIfMissing(user, Badge.TRUSTED_REPORTER)) {
+                newlyAwarded.add(Badge.TRUSTED_REPORTER);
+            }
+        }
+        if (verifiedCount >= expertMapperThreshold) {
+            if (awardBadgeIfMissing(user, Badge.EXPERT_MAPPER)) {
+                newlyAwarded.add(Badge.EXPERT_MAPPER);
+            }
+        }
+        return newlyAwarded;
+    }
+
+    // ────────────────────────── Internals ───────────────────────────────
+
+    /**
+     * Single point of mutation for the user's points field. Clamps the
+     * resulting balance at zero and writes the delta that was actually
+     * applied to the ledger, so summing ledger deltas always
+     * reconstructs the running balance.
+     */
+    void applyDelta(RegisteredUser user, int requestedDelta, PointReason reason, Long relatedId) {
+        if (user == null || requestedDelta == 0) return;
+
+        int before = user.getPoints();
+        int after = Math.max(0, before + requestedDelta);
+        int actualDelta = after - before;
+        if (actualDelta == 0) return;
+
+        // Persist the user balance and the ledger entry together. We log
+        // the actualDelta (post-clamp), so summing the ledger always
+        // reconstructs the running balance — no "absorbed by clamp" rows.
+        user.setPoints(after);
+        userRepository.save(user);
+        pointEventRepository.save(new PointEvent(user, actualDelta, reason, relatedId));
+    }
+
+    private boolean awardBadgeIfMissing(RegisteredUser user, Badge badge) {
+        if (userBadgeRepository.existsByUserIdAndBadge(user.getId(), badge)) {
+            return false;
+        }
+        userBadgeRepository.save(new UserBadge(user, badge));
+        return true;
+    }
+
+    /**
+     * True iff the user currently holds an un-withdrawn vote on this report,
+     * computed from the ledger so we don't have to add a flag column on
+     * {@link com.bounswe2026group1.backend.model.ReportVerification}.
+     * Each cast inserts a VOTE_CAST event; each withdraw inserts a
+     * VOTE_WITHDRAWN event. The user is "currently voted" when CAST count
+     * exceeds WITHDRAWN count.
+     */
+    private boolean isCurrentlyVoted(Long userId, Long reportId) {
+        long casts = pointEventRepository
+                .countByUserIdAndRelatedEntityIdAndReason(userId, reportId, PointReason.VOTE_CAST);
+        long withdrawals = pointEventRepository
+                .countByUserIdAndRelatedEntityIdAndReason(userId, reportId, PointReason.VOTE_WITHDRAWN);
+        return casts > withdrawals;
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
@@ -224,19 +224,4 @@ public class GamificationService {
         return true;
     }
 
-    /**
-     * True iff the user currently holds an un-withdrawn vote on this report,
-     * computed from the ledger so we don't have to add a flag column on
-     * {@link com.bounswe2026group1.backend.model.ReportVerification}.
-     * Each cast inserts a VOTE_CAST event; each withdraw inserts a
-     * VOTE_WITHDRAWN event. The user is "currently voted" when CAST count
-     * exceeds WITHDRAWN count.
-     */
-    private boolean isCurrentlyVoted(Long userId, Long reportId) {
-        long casts = pointEventRepository
-                .countByUserIdAndRelatedEntityIdAndReason(userId, reportId, PointReason.VOTE_CAST);
-        long withdrawals = pointEventRepository
-                .countByUserIdAndRelatedEntityIdAndReason(userId, reportId, PointReason.VOTE_WITHDRAWN);
-        return casts > withdrawals;
-    }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
@@ -81,23 +81,13 @@ public class GamificationService {
     }
 
     /**
-     * Voter cast a fresh vote on someone else's report. Modifying an
-     * existing vote (agree → disagree or vice versa) MUST NOT yield
-     * extra points; callers handle that by NOT calling this method on
-     * modify, only on first cast.
-     *
-     * The cast/withdraw cycle is allowed to net out: a user who casts (+5),
-     * withdraws (-5), and casts again receives a fresh +5. We detect that
-     * by comparing CAST and WITHDRAWN event counts on (user, report) — if
-     * casts already exceed withdrawals, the user is currently in "voted"
-     * state and another call here is a modify, not a fresh cast.
+     * Voter cast a fresh vote on someone else's report. Caller is the
+     * source of truth for fresh-cast vs. modify-vote; this method
+     * unconditionally awards the points.
      */
     @Transactional
     public void awardOnVoteCast(RegisteredUser voter, Long reportId) {
         if (voter == null || reportId == null) return;
-        if (isCurrentlyVoted(voter.getId(), reportId)) {
-            return; // Modify-vote path, no extra points.
-        }
         applyDelta(voter, voteCastDelta, PointReason.VOTE_CAST, reportId);
     }
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
@@ -91,16 +91,14 @@ public class GamificationService {
         applyDelta(voter, voteCastDelta, PointReason.VOTE_CAST, reportId);
     }
 
-    /** Voter fully withdrew their previously cast vote. */
+    /**
+     * Voter fully withdrew their previously cast vote. Caller is the
+     * source of truth for whether an active vote exists; this method
+     * unconditionally deducts the points.
+     */
     @Transactional
     public void deductOnVoteWithdraw(RegisteredUser voter, Long reportId) {
         if (voter == null || reportId == null) return;
-        if (!isCurrentlyVoted(voter.getId(), reportId)) {
-            // Defensive: never deduct points for a withdraw the user never
-            // paired with a cast (would otherwise let a malicious caller
-            // drive any user to zero via spurious withdraw events).
-            return;
-        }
         applyDelta(voter, voteWithdrawnDelta, PointReason.VOTE_WITHDRAWN, reportId);
     }
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
@@ -56,7 +56,6 @@ public class RegisteredUserService {
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.setRole(UserRole.USER);
         user.setStatus(com.bounswe2026group1.backend.model.UserStatus.ACTIVE);
-        user.setPoints(0);
 
         // 4. Save to Database
         RegisteredUser savedUser = registeredUserRepository.save(user);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -73,3 +73,14 @@ app.report.fix.ratio=0.60
 app.report.fix.window-days=7
 # Days a FIXED report is retained before the cleanup job deletes it.
 app.report.deletion.delay-days=7
+
+# Gamification & leaderboard
+app.gamification.points.report-submit=10
+app.gamification.points.vote-cast=5
+app.gamification.points.vote-withdrawn=-5
+app.gamification.points.verified-bonus=20
+app.gamification.points.rejected-penalty=-15
+app.gamification.points.vote-aligned=15
+app.gamification.points.vote-opposed=-5
+app.gamification.badges.trusted-reporter-threshold=10
+app.gamification.badges.expert-mapper-threshold=50

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/AdminUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/AdminUserServiceTest.java
@@ -44,9 +44,9 @@ class AdminUserServiceTest {
     @BeforeEach
     void setUp() {
         adminUser = new RegisteredUser(1L, "Admin", "admin@test.com", "hash", UserRole.ADMIN,
-                UserStatus.ACTIVE, null, 0, null, null, null, null, null, null);
+                UserStatus.ACTIVE, null, 0, null, null, null, null, null, null, false);
         regularUser = new RegisteredUser(2L, "User", "user@test.com", "hash", UserRole.USER,
-                UserStatus.ACTIVE, null, 0, null, null, null, null, null, null);
+                UserStatus.ACTIVE, null, 0, null, null, null, null, null, null, false);
     }
 
     // --- listUsers ---
@@ -170,7 +170,7 @@ class AdminUserServiceTest {
     @Test
     void changeRole_Fail_LastAdmin() {
         RegisteredUser anotherAdmin = new RegisteredUser(3L, "Admin2", "admin2@test.com", "hash", UserRole.ADMIN,
-                UserStatus.ACTIVE, null, 0, null, null, null, null, null, null);
+                UserStatus.ACTIVE, null, 0, null, null, null, null, null, null, false);
         when(userRepository.findById(3L)).thenReturn(Optional.of(anotherAdmin));
         when(userRepository.countByRole(UserRole.ADMIN)).thenReturn(1L);
 
@@ -190,7 +190,7 @@ class AdminUserServiceTest {
         when(userRepository.existsByEmail("new@test.com")).thenReturn(false);
         when(passwordEncoder.encode(any())).thenReturn("encoded");
         RegisteredUser saved = new RegisteredUser(5L, "New", "new@test.com", "encoded", UserRole.USER,
-                UserStatus.ACTIVE, null, 0, null, null, null, null, null, null);
+                UserStatus.ACTIVE, null, 0, null, null, null, null, null, null, false);
         when(userRepository.save(any())).thenReturn(saved);
 
         AdminCreateUserRequest req = new AdminCreateUserRequest();
@@ -249,7 +249,7 @@ class AdminUserServiceTest {
     @Test
     void deleteUser_Fail_LastAdmin() {
         RegisteredUser anotherAdmin = new RegisteredUser(3L, "Admin2", "admin2@test.com", "hash", UserRole.ADMIN,
-                UserStatus.ACTIVE, null, 0, null, null, null, null, null, null);
+                UserStatus.ACTIVE, null, 0, null, null, null, null, null, null, false);
         when(userRepository.findById(3L)).thenReturn(Optional.of(anotherAdmin));
         when(userRepository.countByRole(UserRole.ADMIN)).thenReturn(1L);
 

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
@@ -91,42 +91,6 @@ class GamificationServiceTest {
     @Test
     void awardOnVoteCast_addsFivePointsOnFreshVote() {
         RegisteredUser voter = newUser(2L, 100);
-        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
-                2L, 100L, PointReason.VOTE_CAST)).thenReturn(0L);
-        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
-                2L, 100L, PointReason.VOTE_WITHDRAWN)).thenReturn(0L);
-
-        gamificationService.awardOnVoteCast(voter, 100L);
-
-        assertThat(voter.getPoints()).isEqualTo(105);
-        verify(pointEventRepository).save(any(PointEvent.class));
-    }
-
-    @Test
-    void awardOnVoteCast_isNoOpWhenAlreadyVoted_modifyVotePath() {
-        // Modify-vote (agree → disagree or vice versa) must NOT yield extra points.
-        RegisteredUser voter = newUser(2L, 100);
-        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
-                2L, 100L, PointReason.VOTE_CAST)).thenReturn(1L);
-        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
-                2L, 100L, PointReason.VOTE_WITHDRAWN)).thenReturn(0L);
-
-        gamificationService.awardOnVoteCast(voter, 100L);
-
-        assertThat(voter.getPoints()).isEqualTo(100);
-        verify(pointEventRepository, never()).save(any(PointEvent.class));
-        verify(userRepository, never()).save(any());
-    }
-
-    @Test
-    void awardOnVoteCast_addsPointsAfterWithdraw_recastIsLegitimate() {
-        // cycle: cast(+5) → withdraw(-5) → cast(+5). Casts 1, withdrawals 1
-        // → currently NOT voted → fresh cast pays.
-        RegisteredUser voter = newUser(2L, 100);
-        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
-                2L, 100L, PointReason.VOTE_CAST)).thenReturn(1L);
-        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
-                2L, 100L, PointReason.VOTE_WITHDRAWN)).thenReturn(1L);
 
         gamificationService.awardOnVoteCast(voter, 100L);
 
@@ -139,10 +103,6 @@ class GamificationServiceTest {
     @Test
     void deductOnVoteWithdraw_subtractsFiveOnActiveVote() {
         RegisteredUser voter = newUser(2L, 100);
-        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
-                2L, 100L, PointReason.VOTE_CAST)).thenReturn(1L);
-        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
-                2L, 100L, PointReason.VOTE_WITHDRAWN)).thenReturn(0L);
 
         gamificationService.deductOnVoteWithdraw(voter, 100L);
 
@@ -151,21 +111,6 @@ class GamificationServiceTest {
         verify(pointEventRepository).save(ev.capture());
         assertThat(ev.getValue().getReason()).isEqualTo(PointReason.VOTE_WITHDRAWN);
         assertThat(ev.getValue().getDelta()).isEqualTo(-5);
-    }
-
-    @Test
-    void deductOnVoteWithdraw_isNoOpWhenNoActiveVote() {
-        // Defensive: never deduct for a withdraw without a paired cast.
-        RegisteredUser voter = newUser(2L, 100);
-        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
-                2L, 100L, PointReason.VOTE_CAST)).thenReturn(1L);
-        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
-                2L, 100L, PointReason.VOTE_WITHDRAWN)).thenReturn(1L);
-
-        gamificationService.deductOnVoteWithdraw(voter, 100L);
-
-        assertThat(voter.getPoints()).isEqualTo(100);
-        verify(pointEventRepository, never()).save(any(PointEvent.class));
     }
 
     // ─────────────────────── score-clamp at zero ────────────────────────

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
@@ -1,0 +1,365 @@
+package com.bounswe2026group1.backend.service;
+
+import com.bounswe2026group1.backend.model.Badge;
+import com.bounswe2026group1.backend.model.PointEvent;
+import com.bounswe2026group1.backend.model.PointReason;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.model.ReportEnvironment;
+import com.bounswe2026group1.backend.model.ReportStatus;
+import com.bounswe2026group1.backend.model.ReportType;
+import com.bounswe2026group1.backend.model.UserBadge;
+import com.bounswe2026group1.backend.model.VoteType;
+import com.bounswe2026group1.backend.repository.PointEventRepository;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.repository.ReportRepository;
+import com.bounswe2026group1.backend.repository.ReportVerificationRepository;
+import com.bounswe2026group1.backend.repository.UserBadgeRepository;
+import com.bounswe2026group1.backend.util.GeoUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GamificationServiceTest {
+
+    @Mock private RegisteredUserRepository userRepository;
+    @Mock private ReportRepository reportRepository;
+    @Mock private ReportVerificationRepository verificationRepository;
+    @Mock private PointEventRepository pointEventRepository;
+    @Mock private UserBadgeRepository userBadgeRepository;
+
+    @InjectMocks
+    private GamificationService gamificationService;
+
+    @BeforeEach
+    void setUp() {
+        // Mirror application.properties defaults so the service has live values
+        // when invoked from the unit-test container.
+        ReflectionTestUtils.setField(gamificationService, "reportSubmitDelta", 10);
+        ReflectionTestUtils.setField(gamificationService, "voteCastDelta", 5);
+        ReflectionTestUtils.setField(gamificationService, "voteWithdrawnDelta", -5);
+        ReflectionTestUtils.setField(gamificationService, "verifiedBonusDelta", 20);
+        ReflectionTestUtils.setField(gamificationService, "rejectedPenaltyDelta", -15);
+        ReflectionTestUtils.setField(gamificationService, "voteAlignedDelta", 15);
+        ReflectionTestUtils.setField(gamificationService, "voteOpposedDelta", -5);
+        ReflectionTestUtils.setField(gamificationService, "trustedReporterThreshold", 10);
+        ReflectionTestUtils.setField(gamificationService, "expertMapperThreshold", 50);
+    }
+
+    // ───────────────────── awardOnReportSubmit ──────────────────────────
+
+    @Test
+    void awardOnReportSubmit_addsTenPointsAndLogsEvent() {
+        RegisteredUser author = newUser(1L, 0);
+
+        gamificationService.awardOnReportSubmit(author, 100L);
+
+        assertThat(author.getPoints()).isEqualTo(10);
+        verify(userRepository).save(author);
+        ArgumentCaptor<PointEvent> ev = ArgumentCaptor.forClass(PointEvent.class);
+        verify(pointEventRepository).save(ev.capture());
+        assertThat(ev.getValue().getDelta()).isEqualTo(10);
+        assertThat(ev.getValue().getReason()).isEqualTo(PointReason.REPORT_SUBMIT);
+        assertThat(ev.getValue().getRelatedEntityId()).isEqualTo(100L);
+    }
+
+    @Test
+    void awardOnReportSubmit_nullAuthorIsNoOp() {
+        gamificationService.awardOnReportSubmit(null, 100L);
+        verify(userRepository, never()).save(any());
+        verify(pointEventRepository, never()).save(any());
+    }
+
+    // ───────────────────────── awardOnVoteCast ──────────────────────────
+
+    @Test
+    void awardOnVoteCast_addsFivePointsOnFreshVote() {
+        RegisteredUser voter = newUser(2L, 100);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 100L, PointReason.VOTE_CAST)).thenReturn(0L);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 100L, PointReason.VOTE_WITHDRAWN)).thenReturn(0L);
+
+        gamificationService.awardOnVoteCast(voter, 100L);
+
+        assertThat(voter.getPoints()).isEqualTo(105);
+        verify(pointEventRepository).save(any(PointEvent.class));
+    }
+
+    @Test
+    void awardOnVoteCast_isNoOpWhenAlreadyVoted_modifyVotePath() {
+        // Modify-vote (agree → disagree or vice versa) must NOT yield extra points.
+        RegisteredUser voter = newUser(2L, 100);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 100L, PointReason.VOTE_CAST)).thenReturn(1L);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 100L, PointReason.VOTE_WITHDRAWN)).thenReturn(0L);
+
+        gamificationService.awardOnVoteCast(voter, 100L);
+
+        assertThat(voter.getPoints()).isEqualTo(100);
+        verify(pointEventRepository, never()).save(any(PointEvent.class));
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void awardOnVoteCast_addsPointsAfterWithdraw_recastIsLegitimate() {
+        // cycle: cast(+5) → withdraw(-5) → cast(+5). Casts 1, withdrawals 1
+        // → currently NOT voted → fresh cast pays.
+        RegisteredUser voter = newUser(2L, 100);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 100L, PointReason.VOTE_CAST)).thenReturn(1L);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 100L, PointReason.VOTE_WITHDRAWN)).thenReturn(1L);
+
+        gamificationService.awardOnVoteCast(voter, 100L);
+
+        assertThat(voter.getPoints()).isEqualTo(105);
+        verify(pointEventRepository).save(any(PointEvent.class));
+    }
+
+    // ──────────────────────── deductOnVoteWithdraw ─────────────────────
+
+    @Test
+    void deductOnVoteWithdraw_subtractsFiveOnActiveVote() {
+        RegisteredUser voter = newUser(2L, 100);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 100L, PointReason.VOTE_CAST)).thenReturn(1L);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 100L, PointReason.VOTE_WITHDRAWN)).thenReturn(0L);
+
+        gamificationService.deductOnVoteWithdraw(voter, 100L);
+
+        assertThat(voter.getPoints()).isEqualTo(95);
+        ArgumentCaptor<PointEvent> ev = ArgumentCaptor.forClass(PointEvent.class);
+        verify(pointEventRepository).save(ev.capture());
+        assertThat(ev.getValue().getReason()).isEqualTo(PointReason.VOTE_WITHDRAWN);
+        assertThat(ev.getValue().getDelta()).isEqualTo(-5);
+    }
+
+    @Test
+    void deductOnVoteWithdraw_isNoOpWhenNoActiveVote() {
+        // Defensive: never deduct for a withdraw without a paired cast.
+        RegisteredUser voter = newUser(2L, 100);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 100L, PointReason.VOTE_CAST)).thenReturn(1L);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 100L, PointReason.VOTE_WITHDRAWN)).thenReturn(1L);
+
+        gamificationService.deductOnVoteWithdraw(voter, 100L);
+
+        assertThat(voter.getPoints()).isEqualTo(100);
+        verify(pointEventRepository, never()).save(any(PointEvent.class));
+    }
+
+    // ─────────────────────── score-clamp at zero ────────────────────────
+
+    @Test
+    void applyDelta_clampsAtZero_andLedgerRecordsActualDelta() {
+        // User has 10 points, gets a -15 penalty → clamped to 0. Ledger
+        // delta should be -10 (the amount actually applied), not -15.
+        RegisteredUser author = newUser(1L, 10);
+        Report report = stubReport(author);
+
+        when(verificationRepository.findVoteTuplesByReportId(report.getReportId()))
+                .thenReturn(List.of());
+
+        gamificationService.onReportStatusTransition(report, ReportStatus.PENDING, ReportStatus.REJECTED);
+
+        assertThat(author.getPoints()).isEqualTo(0);
+        ArgumentCaptor<PointEvent> ev = ArgumentCaptor.forClass(PointEvent.class);
+        verify(pointEventRepository).save(ev.capture());
+        assertThat(ev.getValue().getDelta()).isEqualTo(-10);
+    }
+
+    @Test
+    void applyDelta_clampedToNoOpDoesNotPersist() {
+        // User already at 0, another penalty applied → no-op, no save.
+        RegisteredUser author = newUser(1L, 0);
+        Report report = stubReport(author);
+        when(verificationRepository.findVoteTuplesByReportId(report.getReportId()))
+                .thenReturn(List.of());
+
+        gamificationService.onReportStatusTransition(report, ReportStatus.PENDING, ReportStatus.REJECTED);
+
+        assertThat(author.getPoints()).isEqualTo(0);
+        verify(pointEventRepository, never()).save(any(PointEvent.class));
+        verify(userRepository, never()).save(any());
+    }
+
+    // ────────────────────── status-transition fan-out ───────────────────
+
+    @Test
+    void onReportStatusTransition_verified_paysAuthorBonusAndAlignsVoters() {
+        RegisteredUser author = newUser(1L, 0);
+        RegisteredUser agreer = newUser(2L, 0);
+        RegisteredUser disagreer = newUser(3L, 100);
+        Report report = stubReport(author);
+
+        when(verificationRepository.findVoteTuplesByReportId(report.getReportId()))
+                .thenReturn(List.of(
+                        new Object[]{2L, VoteType.AGREE},
+                        new Object[]{3L, VoteType.DISAGREE}
+                ));
+        when(userRepository.findAllById(anyCollection()))
+                .thenReturn(List.of(agreer, disagreer));
+        // Author has 0 verified reports — milestone evaluation runs but no badge yet.
+        when(reportRepository.countByCreatedByIdAndStatus(1L, ReportStatus.VERIFIED))
+                .thenReturn(0L);
+
+        gamificationService.onReportStatusTransition(report, ReportStatus.PENDING, ReportStatus.VERIFIED);
+
+        assertThat(author.getPoints()).isEqualTo(20);    // verified-bonus
+        assertThat(agreer.getPoints()).isEqualTo(15);    // aligned (+15)
+        assertThat(disagreer.getPoints()).isEqualTo(95); // opposed (-5)
+        verify(pointEventRepository, times(3)).save(any(PointEvent.class));
+    }
+
+    @Test
+    void onReportStatusTransition_rejected_penalisesAuthorAndFlipsAlignment() {
+        RegisteredUser author = newUser(1L, 100);
+        RegisteredUser agreer = newUser(2L, 100);
+        RegisteredUser disagreer = newUser(3L, 0);
+        Report report = stubReport(author);
+
+        when(verificationRepository.findVoteTuplesByReportId(report.getReportId()))
+                .thenReturn(List.of(
+                        new Object[]{2L, VoteType.AGREE},
+                        new Object[]{3L, VoteType.DISAGREE}
+                ));
+        when(userRepository.findAllById(anyCollection()))
+                .thenReturn(List.of(agreer, disagreer));
+
+        gamificationService.onReportStatusTransition(report, ReportStatus.PENDING, ReportStatus.REJECTED);
+
+        assertThat(author.getPoints()).isEqualTo(85);    // 100 - 15
+        assertThat(agreer.getPoints()).isEqualTo(95);    // -5 opposed
+        assertThat(disagreer.getPoints()).isEqualTo(15); // +15 aligned
+    }
+
+    @Test
+    void onReportStatusTransition_skipsRevertsToPending() {
+        // VERIFIED → PENDING should NOT undo the original payout (per the
+        // agreed plan: only PENDING → terminal transitions trigger).
+        RegisteredUser author = newUser(1L, 50);
+        Report report = stubReport(author);
+
+        gamificationService.onReportStatusTransition(report, ReportStatus.VERIFIED, ReportStatus.PENDING);
+
+        assertThat(author.getPoints()).isEqualTo(50);
+        verify(pointEventRepository, never()).save(any(PointEvent.class));
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void onReportStatusTransition_skipsAuthorFromVoterFanOut() {
+        // The system blocks self-vote at the controller layer, but be
+        // defensive: if a row somehow exists, don't double-pay.
+        RegisteredUser author = newUser(1L, 0);
+        Report report = stubReport(author);
+
+        when(verificationRepository.findVoteTuplesByReportId(report.getReportId()))
+                .thenReturn(List.<Object[]>of(new Object[]{1L, VoteType.AGREE}));
+        when(reportRepository.countByCreatedByIdAndStatus(1L, ReportStatus.VERIFIED))
+                .thenReturn(0L);
+
+        gamificationService.onReportStatusTransition(report, ReportStatus.PENDING, ReportStatus.VERIFIED);
+
+        // Author paid only the +20 bonus, never the +15 voter-aligned reward.
+        assertThat(author.getPoints()).isEqualTo(20);
+        verify(pointEventRepository, times(1)).save(any(PointEvent.class));
+    }
+
+    // ─────────────────────── milestone badges ───────────────────────────
+
+    @Test
+    void evaluateMilestoneBadges_awardsTrustedAtThreshold() {
+        RegisteredUser user = newUser(1L, 0);
+        when(reportRepository.countByCreatedByIdAndStatus(1L, ReportStatus.VERIFIED))
+                .thenReturn(10L);
+        when(userBadgeRepository.existsByUserIdAndBadge(1L, Badge.TRUSTED_REPORTER))
+                .thenReturn(false);
+        // Expert-mapper threshold (50) not crossed at 10 verified — its
+        // existsBy stub would be unused, so we deliberately omit it.
+
+        List<Badge> awarded = gamificationService.evaluateMilestoneBadges(user);
+
+        assertThat(awarded).containsExactly(Badge.TRUSTED_REPORTER);
+        verify(userBadgeRepository, times(1)).save(any(UserBadge.class));
+    }
+
+    @Test
+    void evaluateMilestoneBadges_awardsBothAtExpertThreshold() {
+        RegisteredUser user = newUser(1L, 0);
+        when(reportRepository.countByCreatedByIdAndStatus(1L, ReportStatus.VERIFIED))
+                .thenReturn(50L);
+        when(userBadgeRepository.existsByUserIdAndBadge(1L, Badge.TRUSTED_REPORTER))
+                .thenReturn(false);
+        when(userBadgeRepository.existsByUserIdAndBadge(1L, Badge.EXPERT_MAPPER))
+                .thenReturn(false);
+
+        List<Badge> awarded = gamificationService.evaluateMilestoneBadges(user);
+
+        assertThat(awarded).containsExactlyInAnyOrder(Badge.TRUSTED_REPORTER, Badge.EXPERT_MAPPER);
+    }
+
+    @Test
+    void evaluateMilestoneBadges_isIdempotent_existingBadgeNotReAwarded() {
+        RegisteredUser user = newUser(1L, 0);
+        when(reportRepository.countByCreatedByIdAndStatus(1L, ReportStatus.VERIFIED))
+                .thenReturn(15L);
+        when(userBadgeRepository.existsByUserIdAndBadge(1L, Badge.TRUSTED_REPORTER))
+                .thenReturn(true); // already held
+
+        List<Badge> awarded = gamificationService.evaluateMilestoneBadges(user);
+
+        assertThat(awarded).isEmpty();
+        verify(userBadgeRepository, never()).save(any(UserBadge.class));
+    }
+
+    @Test
+    void evaluateMilestoneBadges_belowThresholdAwardsNothing() {
+        RegisteredUser user = newUser(1L, 0);
+        when(reportRepository.countByCreatedByIdAndStatus(1L, ReportStatus.VERIFIED))
+                .thenReturn(9L);
+
+        List<Badge> awarded = gamificationService.evaluateMilestoneBadges(user);
+
+        assertThat(awarded).isEmpty();
+        verify(userBadgeRepository, never()).save(any(UserBadge.class));
+    }
+
+    // ───────────────────────── helpers ──────────────────────────────────
+
+    private static RegisteredUser newUser(Long id, int initialPoints) {
+        RegisteredUser u = new RegisteredUser();
+        u.setId(id);
+        u.setName("user-" + id);
+        u.setEmail("u" + id + "@example.com");
+        u.setPoints(initialPoints);
+        return u;
+    }
+
+    private static Report stubReport(RegisteredUser author) {
+        Report r = new Report(author, GeoUtils.point4326(41.0, 29.0), "test report",
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        ReflectionTestUtils.setField(r, "reportId", 100L);
+        return r;
+    }
+}


### PR DESCRIPTION
# 📝 Description
First slice of the gamification & leaderboard rollout. Lays the
foundation that the rest of the feature builds on:

- `Badge` enum (Trusted Reporter, Expert Mapper, Top 10) with a tier
  ordering used to surface a user's highest badge.
- `UserBadge` join entity with a unique `(user, badge)` constraint and
  an `awarded_at` timestamp.
- `PointEvent` append-only ledger + `PointReason` enum, so the running
  `points` balance can always be reconstructed from the audit trail.
- `leaderboardHidden` opt-out flag on `RegisteredUser` (declared last
  so the Lombok all-args constructor keeps its existing parameter order).
- `GamificationService` centralising every point rule:
  +10 on report submit, +5 on fresh vote cast (idempotent on
  user+report; modify-vote yields no extra points; cast/withdraw
  cycles net out), -5 on vote withdraw, author bonus/penalty and voter
  alignment payout on PENDING → VERIFIED / REJECTED transitions, score
  clamped at zero, and milestone badges awarded idempotently on each
  verified-report transition.
- Two repository queries the service needs
  (`countByCreatedByIdAndStatus`, `findVoteTuplesByReportId`) and the
  configurable thresholds in `application.properties`.

No call sites yet — wiring into `ReportService` and `FixRequestService`
follows in the next PR. Top-10 dynamic badge logic and the leaderboard
endpoint will land alongside `LeaderboardService` later.

Related to #265 and #266 and #267

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A — backend-only foundation, no user-visible behaviour yet.

# ⏱️ Estimated Review Time
- [x] 5-15 min
