### PR TITLE
[Backend] Wire Gamification into Reports & Votes

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -43,6 +43,7 @@ public class ReportService {
     private final FixRequestVoteRepository fixRequestVoteRepository;
     private final PublicSseService publicSseService;
     private final NotificationService notificationService;
+    private final GamificationService gamificationService;
     private final S3MediaService s3MediaService;
     private final MeasurementValidator measurementValidator;
     private final OverpassService overpassService;
@@ -182,6 +183,8 @@ public class ReportService {
         Report finalSaved = saved;
         broadcastAfterCommit(() -> publicSseService.broadcastReportCreated(finalSaved));
 
+        gamificationService.awardOnReportSubmit(user, saved.getReportId());
+
         return ReportResponse.fromEntity(saved, null, buildObjectResponses(saved),
                 resolveActiveFixRequest(user.getId(), saved.getReportId()));
     }
@@ -297,10 +300,15 @@ public class ReportService {
 
         var existing = verificationRepository.findByUserIdAndReportReportId(user.getId(), id);
 
+        // Three branches: same-direction toggle = withdraw (delete row),
+        // opposite-direction = modify (no extra points), absent = fresh cast.
+        boolean fresh = false;
+        boolean withdrawn = false;
         if (existing.isPresent()) {
             if (existing.get().getVoteType() == VoteType.AGREE) {
                 report.decrementAgrees();
                 verificationRepository.delete(existing.get());
+                withdrawn = true;
             } else {
                 report.decrementDisagrees();
                 report.incrementAgrees();
@@ -310,16 +318,23 @@ public class ReportService {
         } else {
             report.incrementAgrees();
             verificationRepository.save(new ReportVerification(user, report, VoteType.AGREE));
+            fresh = true;
         }
 
         ReportStatus previousStatus = report.getStatus();
         ReportStatus newStatus = evaluateStatus(report);
 
         Report saved = reportRepository.save(report);
+        if (fresh) {
+            gamificationService.awardOnVoteCast(user, saved.getReportId());
+        } else if (withdrawn) {
+            gamificationService.deductOnVoteWithdraw(user, saved.getReportId());
+        }
         String op = switch (newStatus) { case VERIFIED -> "verify"; case REJECTED -> "reject"; default -> "pending"; };
         broadcastAfterCommit(() -> publicSseService.broadcastReportUpdated(saved, op));
         if (newStatus != previousStatus) {
             notificationService.notifyStatusChange(saved, user.getId());
+            gamificationService.onReportStatusTransition(saved, previousStatus, newStatus);
         }
         return ReportResponse.fromEntity(saved,
                 resolveUserVote(user.getId(), saved.getReportId()),
@@ -340,10 +355,15 @@ public class ReportService {
 
         var existing = verificationRepository.findByUserIdAndReportReportId(user.getId(), id);
 
+        // Three branches: same-direction toggle = withdraw (delete row),
+        // opposite-direction = modify (no extra points), absent = fresh cast.
+        boolean fresh = false;
+        boolean withdrawn = false;
         if (existing.isPresent()) {
             if (existing.get().getVoteType() == VoteType.DISAGREE) {
                 report.decrementDisagrees();
                 verificationRepository.delete(existing.get());
+                withdrawn = true;
             } else {
                 report.decrementAgrees();
                 report.incrementDisagrees();
@@ -353,16 +373,23 @@ public class ReportService {
         } else {
             report.incrementDisagrees();
             verificationRepository.save(new ReportVerification(user, report, VoteType.DISAGREE));
+            fresh = true;
         }
 
         ReportStatus previousStatus = report.getStatus();
         ReportStatus newStatus = evaluateStatus(report);
 
         Report saved = reportRepository.save(report);
+        if (fresh) {
+            gamificationService.awardOnVoteCast(user, saved.getReportId());
+        } else if (withdrawn) {
+            gamificationService.deductOnVoteWithdraw(user, saved.getReportId());
+        }
         String op = switch (newStatus) { case VERIFIED -> "verify"; case REJECTED -> "reject"; default -> "pending"; };
         broadcastAfterCommit(() -> publicSseService.broadcastReportUpdated(saved, op));
         if (newStatus != previousStatus) {
             notificationService.notifyStatusChange(saved, user.getId());
+            gamificationService.onReportStatusTransition(saved, previousStatus, newStatus);
         }
         return ReportResponse.fromEntity(saved,
                 resolveUserVote(user.getId(), saved.getReportId()),

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -40,6 +40,7 @@ class ReportServiceTest {
     @Mock private MeasurementValidator measurementValidator;
     @Mock private OverpassService overpassService;
     @Mock private NotificationService notificationService;
+    @Mock private GamificationService gamificationService;
 
     @InjectMocks
     private ReportService reportService;
@@ -718,6 +719,119 @@ class ReportServiceTest {
 
         assertEquals(2, result.size());
         assertTrue(result.stream().anyMatch(r -> r.getStatus() == ReportStatus.REJECTED));
+    }
+
+    // ───────────────────────── Gamification wiring ──────────────────────────
+
+    @Test
+    void create_awardsReportSubmitPoints() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(reportRepository.save(any(Report.class))).thenReturn(testReport);
+
+        reportService.create(testRequest);
+
+        verify(gamificationService).awardOnReportSubmit(eq(testUser), any());
+    }
+
+    @Test
+    void verifyReport_freshCast_awardsVoteCastPoints() {
+        ReflectionTestUtils.setField(reportService, "verificationThreshold", 5);
+        testUser.setEmail("user@test.com");
+
+        when(registeredUserRepository.findByEmail("user@test.com")).thenReturn(Optional.of(testUser));
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(verificationRepository.findByUserIdAndReportReportId(1L, 1L)).thenReturn(Optional.empty());
+        when(reportRepository.save(any(Report.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        reportService.verifyReport(1L, "user@test.com");
+
+        verify(gamificationService).awardOnVoteCast(eq(testUser), any());
+        verify(gamificationService, never()).deductOnVoteWithdraw(any(), any());
+    }
+
+    @Test
+    void verifyReport_toggleOffSameDirection_deductsWithdrawPoints() {
+        ReflectionTestUtils.setField(testReport, "agrees", 1);
+        ReflectionTestUtils.setField(reportService, "verificationThreshold", 5);
+        testUser.setEmail("user@test.com");
+        ReportVerification existing = new ReportVerification(testUser, testReport, VoteType.AGREE);
+
+        when(registeredUserRepository.findByEmail("user@test.com")).thenReturn(Optional.of(testUser));
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(verificationRepository.findByUserIdAndReportReportId(1L, 1L)).thenReturn(Optional.of(existing));
+        when(reportRepository.save(any(Report.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        reportService.verifyReport(1L, "user@test.com");
+
+        verify(gamificationService).deductOnVoteWithdraw(eq(testUser), any());
+        verify(gamificationService, never()).awardOnVoteCast(any(), any());
+    }
+
+    @Test
+    void verifyReport_modifyOppositeVote_doesNotAwardOrDeduct() {
+        // Switching DISAGREE → AGREE is a modify, not a fresh cast or withdraw —
+        // gamification stays out of the picture (vote-modify yields no extra points).
+        ReflectionTestUtils.setField(testReport, "disagrees", 1);
+        ReflectionTestUtils.setField(reportService, "verificationThreshold", 5);
+        testUser.setEmail("user@test.com");
+        ReportVerification existing = new ReportVerification(testUser, testReport, VoteType.DISAGREE);
+
+        when(registeredUserRepository.findByEmail("user@test.com")).thenReturn(Optional.of(testUser));
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(verificationRepository.findByUserIdAndReportReportId(1L, 1L)).thenReturn(Optional.of(existing));
+        when(reportRepository.save(any(Report.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        reportService.verifyReport(1L, "user@test.com");
+
+        verify(gamificationService, never()).awardOnVoteCast(any(), any());
+        verify(gamificationService, never()).deductOnVoteWithdraw(any(), any());
+    }
+
+    @Test
+    void verifyReport_statusTransition_invokesOnReportStatusTransition() {
+        ReflectionTestUtils.setField(testReport, "agrees", 4);
+        ReflectionTestUtils.setField(reportService, "verificationThreshold", 5);
+        testUser.setEmail("user@test.com");
+
+        when(registeredUserRepository.findByEmail("user@test.com")).thenReturn(Optional.of(testUser));
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(verificationRepository.findByUserIdAndReportReportId(1L, 1L)).thenReturn(Optional.empty());
+        when(reportRepository.save(any(Report.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        reportService.verifyReport(1L, "user@test.com");
+
+        verify(gamificationService).onReportStatusTransition(testReport, ReportStatus.PENDING, ReportStatus.VERIFIED);
+    }
+
+    @Test
+    void verifyReport_belowThreshold_doesNotInvokeStatusTransition() {
+        ReflectionTestUtils.setField(testReport, "agrees", 1);
+        ReflectionTestUtils.setField(reportService, "verificationThreshold", 5);
+        testUser.setEmail("user@test.com");
+
+        when(registeredUserRepository.findByEmail("user@test.com")).thenReturn(Optional.of(testUser));
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(verificationRepository.findByUserIdAndReportReportId(1L, 1L)).thenReturn(Optional.empty());
+        when(reportRepository.save(any(Report.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        reportService.verifyReport(1L, "user@test.com");
+
+        verify(gamificationService, never()).onReportStatusTransition(any(), any(), any());
+    }
+
+    @Test
+    void unverifyReport_freshCast_awardsVoteCastPoints() {
+        ReflectionTestUtils.setField(reportService, "verificationThreshold", 5);
+        testUser.setEmail("user@test.com");
+
+        when(registeredUserRepository.findByEmail("user@test.com")).thenReturn(Optional.of(testUser));
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(verificationRepository.findByUserIdAndReportReportId(1L, 1L)).thenReturn(Optional.empty());
+        when(reportRepository.save(any(Report.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        reportService.unverifyReport(1L, "user@test.com");
+
+        verify(gamificationService).awardOnVoteCast(eq(testUser), any());
     }
 
 }


### PR DESCRIPTION
# 📝 Description
Second slice of the gamification rollout. Wires the
GamificationService introduced in #491  into the report flow:

- `ReportService.create` awards the author +10 on every new report.
- `verifyReport` / `unverifyReport` distinguish three vote paths:
  - **Fresh cast** → `awardOnVoteCast` (+5)
  - **Same-direction toggle** → `deductOnVoteWithdraw` (-5)
  - **Opposite-direction modify** → no extra points
- `onReportStatusTransition` fires alongside `notifyStatusChange`
  whenever a report crosses a terminal status, paying the author
  bonus/penalty and the voter alignment payout in one shot.

All hooks run inside the existing `@Transactional` boundary, so a
gamification failure rolls the vote back too — no half-applied state.

Self-vote guard is intentionally out of scope (pre-existing behaviour;
will be addressed separately).

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A — backend wiring, no user-visible behaviour yet (UI lands in PR-5/6).

# ⏱️ Estimated Review Time
- [x] 5-15 min
