### PR TITLE
[Web] Colour Map Markers by Report Type, Fade Unverified

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -29,9 +29,22 @@ function decodePolyline(encoded) {
   return coords
 }
 
-function makeMarkerIcon(status, objectType, selected = false) {
-  const cfg = OBJECT_TYPE_MAP[objectType] ?? { icon: 'warning', markerColor: '#767777' }
-  const borderColor = status === 'verified' ? '#176a21' : cfg.markerColor
+// Map marker colour rule (issue #362):
+//   FEATURE  reports = positive   → green
+//   OBSTACLE reports = negative   → red
+// Verified pins render at full opacity; unverified pins are visually faded
+// so the eye is drawn to confirmed reports first. Selected pins always
+// render at full opacity regardless so the user sees what they clicked.
+const MARKER_GREEN = '#2E7D32'
+const MARKER_RED   = '#C62828'
+const MARKER_NEUTRAL = '#767777'
+const MARKER_ICON_FALLBACK = 'warning'
+
+function makeMarkerIcon(status, objectType, reportType, selected = false) {
+  const cfg = OBJECT_TYPE_MAP[objectType] ?? { icon: MARKER_ICON_FALLBACK, markerColor: MARKER_NEUTRAL }
+  const borderColor = reportType === 'FEATURE' ? MARKER_GREEN : MARKER_RED
+  const isVerified = status === 'verified'
+  const opacity = !isVerified && !selected ? 0.55 : 1
   const size = selected ? 56 : 40
   const iconFontSize = selected ? 28 : 20
   const borderWidth = selected ? 3.5 : 2.5

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -64,7 +64,8 @@ function makeMarkerIcon(status, objectType, reportType, selected = false) {
         box-shadow:${shadow};
         display:flex;align-items:center;justify-content:center;
         cursor:pointer;
-        transition:width 150ms ease, height 150ms ease;
+        opacity:${opacity};
+        transition:width 150ms ease, height 150ms ease, opacity 150ms ease;
       ">
         <span class="material-symbols-outlined" style="
           font-size:${iconFontSize}px;
@@ -527,7 +528,7 @@ function Home() {
               <Marker
                 key={report.id}
                 position={[report.latitude, report.longitude]}
-                icon={makeMarkerIcon(report.status, report.primaryObjectType, report.id === selectedReportId)}
+                icon={makeMarkerIcon(report.status, report.primaryObjectType, report.reportType, report.id === selectedReportId)}
                 zIndexOffset={report.id === selectedReportId ? 1000 : 0}
                 eventHandlers={{
                   click: () => {


### PR DESCRIPTION
Closes #362.

Marker pins now reflect both the report's positive/negative axis and its verification state:
- **FEATURE** (positive) → green pin
- **OBSTACLE** (negative) → red pin
- **Unverified** → 55% opacity (faded)
- **Verified** → 100% opacity (vivid)
- Selected pin always renders at 100% opacity so a clicked unverified pin is clearly highlighted

Replaces the previous `verified ? green : objectTypeColour` rule, which ignored `reportType` entirely and rendered every unverified pin in muted browns/blues.

Out of scope (deliberately):
- "Reusable ReportIcon component" deliverable from the issue. Existing list views use status pills (text) instead of icons; not worth the refactor for cosmetic parity.

## 📊 Type of Change
- [x] Bug fix
- [x] New feature

## ✅ Checklist
- [x] All tests passed (255/255)


## 📸 Screenshot
<img width="1103" height="751" alt="Ekran Resmi 2026-05-09 21 28 32" src="https://github.com/user-attachments/assets/f95440a4-fba6-4d90-9ab8-d25acf5e44d1" />


## 🧪 How to Test
1. Create one Feature report and one Obstacle report. Pins appear faded green / faded red.
2. Verify them (admin endpoint or vote-up). Pins become vivid.
3. Click any unverified pin, it goes full opacity while selected.

## ⏱️ Estimated Review Time
- [x] < 5 min