### PR TITLE
[Backend] Add Leaderboard Service & Top-10 Dynamic Badges

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/RegisteredUserRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/RegisteredUserRepository.java
@@ -7,8 +7,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -26,4 +29,32 @@ public interface RegisteredUserRepository extends JpaRepository<RegisteredUser, 
     // Used to enforce the "at least one admin" rule
     long countByRole(UserRole role);
     long countByStatus(UserStatus status);
+
+    // ───── Leaderboard queries ─────────────────────────────────────────────
+
+    /** Public leaderboard view — opt-outs and non-active accounts (banned,
+     *  anonymised post-deletion) are excluded. Ordered by points descending,
+     *  then id ascending so ties resolve deterministically and stably across
+     *  recomputes. Caller passes a Pageable with the desired page size
+     *  (top 100 in production). */
+    @Query("""
+            select u from RegisteredUser u
+            where u.leaderboardHidden = false
+              and u.status = com.bounswe2026group1.backend.model.UserStatus.ACTIVE
+            order by u.points desc, u.id asc
+            """)
+    List<RegisteredUser> findLeaderboardPage(Pageable pageable);
+
+    /** Counts users strictly above a given point total (same opt-out and
+     *  status filters as the leaderboard view), so a caller's rank is
+     *  {@code count + 1}. We tolerate ties by counting strictly-above-only;
+     *  the tie-break in display ordering is by id, but for "your rank" the
+     *  user is happy to share the rank with anyone on the same point total. */
+    @Query("""
+            select count(u) from RegisteredUser u
+            where u.leaderboardHidden = false
+              and u.status = com.bounswe2026group1.backend.model.UserStatus.ACTIVE
+              and u.points > :points
+            """)
+    long countAboveForRank(@Param("points") int points);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
@@ -42,6 +42,7 @@ public class GamificationService {
     private final ReportVerificationRepository verificationRepository;
     private final PointEventRepository pointEventRepository;
     private final UserBadgeRepository userBadgeRepository;
+    private final LeaderboardService leaderboardService;
 
     @Value("${app.gamification.points.report-submit:10}")
     private int reportSubmitDelta;
@@ -226,6 +227,11 @@ public class GamificationService {
         user.setPoints(after);
         userRepository.save(user);
         pointEventRepository.save(new PointEvent(user, actualDelta, reason, relatedId));
+
+        // Eager top-10 badge churn — the user may have entered or fallen
+        // out of the top cutoff with this delta, and we want the badge to
+        // track rank changes in real time rather than via a cron lag.
+        leaderboardService.onPointsChanged(user.getId());
     }
 
     private boolean awardBadgeIfMissing(RegisteredUser user, Badge badge) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/LeaderboardEntry.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/LeaderboardEntry.java
@@ -1,0 +1,20 @@
+package com.bounswe2026group1.backend.service;
+
+/**
+ * One row of the public leaderboard. Service-level result type — controllers
+ * map this to a wire DTO as needed.
+ *
+ * @param rank      1-based rank within the current top-N view
+ * @param userId    profile id, used by the UI to link to the public profile
+ * @param name      display name
+ * @param avatarUrl optional avatar URL (null if unset)
+ * @param points    accumulated points
+ */
+public record LeaderboardEntry(
+        int rank,
+        Long userId,
+        String name,
+        String avatarUrl,
+        int points
+) {
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/LeaderboardService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/LeaderboardService.java
@@ -1,0 +1,131 @@
+package com.bounswe2026group1.backend.service;
+
+import com.bounswe2026group1.backend.model.Badge;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.UserBadge;
+import com.bounswe2026group1.backend.model.UserStatus;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.repository.UserBadgeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Read view + dynamic-badge maintenance for the leaderboard.
+ *
+ * Reads (top-N, caller rank) are pure JPA queries against the user table.
+ * Top-10 badge churn is recomputed eagerly via {@link #onPointsChanged}
+ * after every point change, so a user who moves into or out of the top 10
+ * sees their badge updated within the same request.
+ */
+@Service
+@RequiredArgsConstructor
+public class LeaderboardService {
+
+    private final RegisteredUserRepository userRepository;
+    private final UserBadgeRepository userBadgeRepository;
+
+    @Value("${app.gamification.leaderboard.size:100}")
+    private int leaderboardSize;
+
+    @Value("${app.gamification.leaderboard.top-badge-rank:10}")
+    private int topBadgeRank;
+
+    /** Top-N (default 100) ranked by points desc, with opt-outs and
+     *  non-active accounts filtered out. Olympic-style rank: tied scores
+     *  share a rank, the next distinct score skips the gap. Keeps this
+     *  view consistent with {@link #getRankFor}, which uses count-above
+     *  arithmetic — both report rank 1 for two users at the same top score. */
+    @Transactional(readOnly = true)
+    public List<LeaderboardEntry> getTopN() {
+        List<RegisteredUser> users = userRepository.findLeaderboardPage(
+                PageRequest.of(0, leaderboardSize));
+        List<LeaderboardEntry> out = new ArrayList<>(users.size());
+        int currentRank = 0;
+        Integer previousPoints = null;
+        for (int i = 0; i < users.size(); i++) {
+            RegisteredUser u = users.get(i);
+            if (previousPoints == null || u.getPoints() != previousPoints) {
+                currentRank = i + 1;
+                previousPoints = u.getPoints();
+            }
+            out.add(new LeaderboardEntry(
+                    currentRank,
+                    u.getId(),
+                    u.getName(),
+                    u.getAvatarUrl(),
+                    u.getPoints()));
+        }
+        return out;
+    }
+
+    /** Rank for a single user. Returns empty when the user has opted out
+     *  or has been deactivated — the UI suppresses the rank banner in
+     *  that case rather than showing a misleading number. */
+    @Transactional(readOnly = true)
+    public Optional<RankInfo> getRankFor(Long userId) {
+        if (userId == null) return Optional.empty();
+        return userRepository.findById(userId)
+                .filter(u -> !u.isLeaderboardHidden())
+                .filter(u -> u.getStatus() == UserStatus.ACTIVE)
+                .map(u -> new RankInfo(
+                        (int) (userRepository.countAboveForRank(u.getPoints()) + 1),
+                        u.getPoints()));
+    }
+
+    /**
+     * Re-evaluates the TOP_10 badge after a user's points changed.
+     * Awards the badge to anyone who entered the current top-N-by-rank
+     * cutoff (default top 10), revokes from anyone who fell out.
+     *
+     * <p>Called eagerly from {@link GamificationService#applyDelta} so the
+     * dynamic badge tracks rank changes in real time. The work scales with
+     * the badge cutoff (10) plus the current TOP_10 holders, so worst case
+     * a few rows per call — cheap enough to avoid a scheduled cron.
+     */
+    @Transactional
+    public void onPointsChanged(Long actorUserId) {
+        // Snapshot of who SHOULD hold the badge right now.
+        List<RegisteredUser> top = userRepository.findLeaderboardPage(
+                PageRequest.of(0, topBadgeRank));
+        Set<Long> shouldHold = top.stream().map(RegisteredUser::getId)
+                .collect(Collectors.toCollection(HashSet::new));
+
+        // Snapshot of who currently holds the badge.
+        Set<Long> currentlyHolds = new HashSet<>(
+                userBadgeRepository.findUserIdsByBadge(Badge.TOP_10));
+
+        // Award to newcomers. Hydrate the user entities in a single batch
+        // so the FK on UserBadge can be set without per-row findById.
+        Set<Long> toAward = new HashSet<>(shouldHold);
+        toAward.removeAll(currentlyHolds);
+        if (!toAward.isEmpty()) {
+            Map<Long, RegisteredUser> usersById = userRepository.findAllById(toAward).stream()
+                    .collect(Collectors.toMap(RegisteredUser::getId, Function.identity()));
+            for (Long id : toAward) {
+                RegisteredUser u = usersById.get(id);
+                if (u != null) {
+                    userBadgeRepository.save(new UserBadge(u, Badge.TOP_10));
+                }
+            }
+        }
+
+        // Revoke from users who fell out of the cutoff.
+        Set<Long> toRevoke = new HashSet<>(currentlyHolds);
+        toRevoke.removeAll(shouldHold);
+        for (Long id : toRevoke) {
+            userBadgeRepository.deleteByUserIdAndBadge(id, Badge.TOP_10);
+        }
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RankInfo.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RankInfo.java
@@ -1,0 +1,15 @@
+package com.bounswe2026group1.backend.service;
+
+/**
+ * Caller's own position on the leaderboard. {@code null} is returned by
+ * {@link LeaderboardService} when the caller has opted out — the controller
+ * uses that distinction to suppress the "your rank" banner.
+ *
+ * @param rank   1-based global rank (ties share a rank)
+ * @param points accumulated points at the time of the read
+ */
+public record RankInfo(
+        int rank,
+        int points
+) {
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -84,3 +84,5 @@ app.gamification.points.vote-aligned=15
 app.gamification.points.vote-opposed=-5
 app.gamification.badges.trusted-reporter-threshold=10
 app.gamification.badges.expert-mapper-threshold=50
+app.gamification.leaderboard.size=100
+app.gamification.leaderboard.top-badge-rank=10

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
@@ -43,6 +43,7 @@ class GamificationServiceTest {
     @Mock private ReportVerificationRepository verificationRepository;
     @Mock private PointEventRepository pointEventRepository;
     @Mock private UserBadgeRepository userBadgeRepository;
+    @Mock private LeaderboardService leaderboardService;
 
     @InjectMocks
     private GamificationService gamificationService;
@@ -84,6 +85,19 @@ class GamificationServiceTest {
         gamificationService.awardOnReportSubmit(null, 100L);
         verify(userRepository, never()).save(any());
         verify(pointEventRepository, never()).save(any());
+        verify(leaderboardService, never()).onPointsChanged(any());
+    }
+
+    @Test
+    void applyDelta_triggersLeaderboardRecompute() {
+        // Top-10 badge churn must track every point change in real time —
+        // applyDelta is the single mutation point, so any award/deduct
+        // method on the public API ends up triggering this.
+        RegisteredUser author = newUser(1L, 0);
+
+        gamificationService.awardOnReportSubmit(author, 100L);
+
+        verify(leaderboardService).onPointsChanged(1L);
     }
 
     // ───────────────────────── awardOnVoteCast ──────────────────────────

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/LeaderboardServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/LeaderboardServiceTest.java
@@ -1,0 +1,227 @@
+package com.bounswe2026group1.backend.service;
+
+import com.bounswe2026group1.backend.model.Badge;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.UserBadge;
+import com.bounswe2026group1.backend.model.UserStatus;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.repository.UserBadgeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeaderboardServiceTest {
+
+    @Mock private RegisteredUserRepository userRepository;
+    @Mock private UserBadgeRepository userBadgeRepository;
+
+    @InjectMocks
+    private LeaderboardService leaderboardService;
+
+    @BeforeEach
+    void setUp() {
+        // Smaller cutoffs in unit tests so we don't have to fabricate
+        // 100 users to exercise the full pipeline.
+        ReflectionTestUtils.setField(leaderboardService, "leaderboardSize", 5);
+        ReflectionTestUtils.setField(leaderboardService, "topBadgeRank", 3);
+    }
+
+    // ─────────────────────────── getTopN ────────────────────────────────
+
+    @Test
+    void getTopN_assignsRanksOneBased_inOrder() {
+        RegisteredUser u1 = newUser(1L, "Alice", 100);
+        RegisteredUser u2 = newUser(2L, "Bob", 80);
+        RegisteredUser u3 = newUser(3L, "Carol", 50);
+        when(userRepository.findLeaderboardPage(any(Pageable.class)))
+                .thenReturn(List.of(u1, u2, u3));
+
+        List<LeaderboardEntry> result = leaderboardService.getTopN();
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).rank()).isEqualTo(1);
+        assertThat(result.get(0).userId()).isEqualTo(1L);
+        assertThat(result.get(0).points()).isEqualTo(100);
+        assertThat(result.get(2).rank()).isEqualTo(3);
+        assertThat(result.get(2).userId()).isEqualTo(3L);
+    }
+
+    @Test
+    void getTopN_emptyRepoReturnsEmptyList() {
+        when(userRepository.findLeaderboardPage(any(Pageable.class))).thenReturn(List.of());
+
+        assertThat(leaderboardService.getTopN()).isEmpty();
+    }
+
+    @Test
+    void getTopN_tiedScoresShareRank_andSkipGap() {
+        // Olympic-style: two users at 100 share rank 1, the next user at 80
+        // gets rank 3 (rank 2 is skipped). Keeps getTopN consistent with
+        // getRankFor's count-above arithmetic, so a "your rank" banner
+        // never disagrees with the user's row in the list.
+        RegisteredUser alice = newUser(1L, "Alice", 100);
+        RegisteredUser bob = newUser(2L, "Bob", 100);
+        RegisteredUser carol = newUser(3L, "Carol", 80);
+        when(userRepository.findLeaderboardPage(any(Pageable.class)))
+                .thenReturn(List.of(alice, bob, carol));
+
+        List<LeaderboardEntry> result = leaderboardService.getTopN();
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).rank()).isEqualTo(1);
+        assertThat(result.get(1).rank()).isEqualTo(1); // tied with Alice
+        assertThat(result.get(2).rank()).isEqualTo(3); // gap after the tie
+    }
+
+    // ──────────────────────────── getRankFor ────────────────────────────
+
+    @Test
+    void getRankFor_activeUserReturnsCountPlusOne() {
+        RegisteredUser u = newUser(7L, "Dora", 60);
+        when(userRepository.findById(7L)).thenReturn(Optional.of(u));
+        when(userRepository.countAboveForRank(60)).thenReturn(4L);
+
+        Optional<RankInfo> info = leaderboardService.getRankFor(7L);
+
+        assertThat(info).isPresent();
+        assertThat(info.get().rank()).isEqualTo(5);
+        assertThat(info.get().points()).isEqualTo(60);
+    }
+
+    @Test
+    void getRankFor_optedOutReturnsEmpty() {
+        RegisteredUser u = newUser(7L, "Dora", 60);
+        u.setLeaderboardHidden(true);
+        when(userRepository.findById(7L)).thenReturn(Optional.of(u));
+
+        assertThat(leaderboardService.getRankFor(7L)).isEmpty();
+    }
+
+    @Test
+    void getRankFor_bannedUserReturnsEmpty() {
+        RegisteredUser u = newUser(7L, "Dora", 60);
+        u.setStatus(UserStatus.BANNED);
+        when(userRepository.findById(7L)).thenReturn(Optional.of(u));
+
+        assertThat(leaderboardService.getRankFor(7L)).isEmpty();
+    }
+
+    @Test
+    void getRankFor_unknownUserReturnsEmpty() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThat(leaderboardService.getRankFor(99L)).isEmpty();
+    }
+
+    @Test
+    void getRankFor_nullIdReturnsEmpty() {
+        assertThat(leaderboardService.getRankFor(null)).isEmpty();
+    }
+
+    // ────────────────────── onPointsChanged (top-10 churn) ──────────────
+
+    @Test
+    void onPointsChanged_awardsBadgeToNewcomer() {
+        // Top-3 cutoff: Alice & Bob were in, Carol just rose into the cutoff.
+        // Currently held by: Alice, Bob.
+        RegisteredUser alice = newUser(1L, "Alice", 100);
+        RegisteredUser bob = newUser(2L, "Bob", 90);
+        RegisteredUser carol = newUser(3L, "Carol", 80);
+
+        when(userRepository.findLeaderboardPage(any(Pageable.class)))
+                .thenReturn(List.of(alice, bob, carol));
+        when(userBadgeRepository.findUserIdsByBadge(Badge.TOP_10))
+                .thenReturn(List.of(1L, 2L));
+        when(userRepository.findAllById(anyCollection()))
+                .thenReturn(List.of(carol));
+
+        leaderboardService.onPointsChanged(3L);
+
+        ArgumentCaptor<UserBadge> captor = ArgumentCaptor.forClass(UserBadge.class);
+        verify(userBadgeRepository).save(captor.capture());
+        assertThat(captor.getValue().getUser().getId()).isEqualTo(3L);
+        assertThat(captor.getValue().getBadge()).isEqualTo(Badge.TOP_10);
+        verify(userBadgeRepository, never()).deleteByUserIdAndBadge(any(), any());
+    }
+
+    @Test
+    void onPointsChanged_revokesBadgeFromUserWhoFellOut() {
+        // Top-3 cutoff: now Alice, Bob, Carol. Previously also Dora.
+        RegisteredUser alice = newUser(1L, "Alice", 100);
+        RegisteredUser bob = newUser(2L, "Bob", 90);
+        RegisteredUser carol = newUser(3L, "Carol", 80);
+
+        when(userRepository.findLeaderboardPage(any(Pageable.class)))
+                .thenReturn(List.of(alice, bob, carol));
+        when(userBadgeRepository.findUserIdsByBadge(Badge.TOP_10))
+                .thenReturn(List.of(1L, 2L, 3L, 4L)); // Dora (4) needs revoking
+
+        leaderboardService.onPointsChanged(4L);
+
+        verify(userBadgeRepository).deleteByUserIdAndBadge(eq(4L), eq(Badge.TOP_10));
+        verify(userBadgeRepository, never()).save(any());
+    }
+
+    @Test
+    void onPointsChanged_noChurn_noWrites() {
+        RegisteredUser alice = newUser(1L, "Alice", 100);
+        RegisteredUser bob = newUser(2L, "Bob", 90);
+
+        when(userRepository.findLeaderboardPage(any(Pageable.class)))
+                .thenReturn(List.of(alice, bob));
+        when(userBadgeRepository.findUserIdsByBadge(Badge.TOP_10))
+                .thenReturn(List.of(1L, 2L));
+
+        leaderboardService.onPointsChanged(1L);
+
+        verify(userBadgeRepository, never()).save(any());
+        verify(userBadgeRepository, never()).deleteByUserIdAndBadge(any(), any());
+    }
+
+    @Test
+    void onPointsChanged_emptyLeaderboardRevokesAllExistingHolders() {
+        // Defensive edge case: every previously-top-10 user has somehow
+        // been excluded (opt-out wave or admin ban). All TOP_10 badges revoke.
+        when(userRepository.findLeaderboardPage(any(Pageable.class)))
+                .thenReturn(List.of());
+        when(userBadgeRepository.findUserIdsByBadge(Badge.TOP_10))
+                .thenReturn(List.of(1L, 2L));
+
+        leaderboardService.onPointsChanged(1L);
+
+        verify(userBadgeRepository).deleteByUserIdAndBadge(eq(1L), eq(Badge.TOP_10));
+        verify(userBadgeRepository).deleteByUserIdAndBadge(eq(2L), eq(Badge.TOP_10));
+        verify(userBadgeRepository, never()).save(any());
+    }
+
+    // ───────────────────────── helpers ──────────────────────────────────
+
+    private static RegisteredUser newUser(Long id, String name, int points) {
+        RegisteredUser u = new RegisteredUser();
+        u.setId(id);
+        u.setName(name);
+        u.setEmail(name.toLowerCase() + "@example.com");
+        u.setPoints(points);
+        u.setStatus(UserStatus.ACTIVE);
+        u.setLeaderboardHidden(false);
+        return u;
+    }
+}


### PR DESCRIPTION
# 📝 Description
Third slice of the gamification rollout. Adds the leaderboard read view and the dynamic TOP_10 badge that tracks rank changes in real time, on top of the GamificationService introduced in #491  and wired in #492:

- `getTopN()` — top 100 ranked users, with opt-out and non-active accounts (banned, anonymised post-deletion) filtered out.
- `getRankFor(userId)` — caller's own rank, or empty when the user has opted out or is no longer active.
- Olympic-style ranking: tied scores share a rank, the next distinct score skips the gap. Same semantics in both `getTopN` and `getRankFor`, so the "your rank" banner never disagrees with the user's row in the list.
- `onPointsChanged()` — re-evaluates the TOP_10 badge after every point change. Awards to anyone who entered the cutoff, revokes from anyone who fell out. Fired eagerly from `GamificationService.applyDelta`, so badge state tracks rank churn in real time without a scheduled cron.
- Two repository queries (`findLeaderboardPage`, `countAboveForRank`) and configurable cutoffs in `application.properties` (`leaderboard.size=100`, `leaderboard.top-badge-rank=10`).

No HTTP endpoints yet — the controller and DTOs land in the next PR.

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A — backend service layer, no user-visible behaviour yet.

# ⏱️ Estimated Review Time
- [x] 5-15 min
