### PR TITLE
[Web] Show Place Name in CreateReportPanel After Dropping a Pin

### DIFF
--- a/frontend/src/components/CreateReportPanel.jsx
+++ b/frontend/src/components/CreateReportPanel.jsx
@@ -4,7 +4,7 @@ import { useAuth } from '../context/AuthContext.jsx'
 import { createReport, mapReport } from '../services/reportService.js'
 import { OBJECT_TYPES } from '../utils/objectTypeConfig.js'
 
-function CreateReportPanel({ position, onClose, onCreated }) {
+function CreateReportPanel({ position, positionLabel, onClose, onCreated }) {
   const { token, userId } = useAuth()
   const navigate = useNavigate()
 
@@ -274,13 +274,25 @@ function CreateReportPanel({ position, onClose, onCreated }) {
 
       {/* Header */}
       <div className="px-8 pt-2 lg:pt-8 pb-4 flex items-start justify-between flex-shrink-0">
-        <div>
+        <div className="min-w-0">
           <h2 className="text-2xl font-extrabold font-headline text-on-surface">New Report</h2>
-          <p className="text-sm text-on-surface-variant mt-1">
-            {position
-              ? `📍 ${position.lat.toFixed(5)}, ${position.lng.toFixed(5)}`
-              : 'Click on the map to set location'}
-          </p>
+          {position ? (
+            // Place name from reverse-geocoding sits on the primary line; raw
+            // coordinates fall to a smaller secondary line so the user always
+            // has the precise location available even when Nominatim resolves.
+            <>
+              <p className="text-sm font-semibold text-on-surface mt-1 truncate" title={positionLabel || undefined}>
+                📍 {positionLabel || `${position.lat.toFixed(5)}, ${position.lng.toFixed(5)}`}
+              </p>
+              {positionLabel && (
+                <p className="text-[11px] text-on-surface-variant mt-0.5">
+                  {position.lat.toFixed(5)}, {position.lng.toFixed(5)}
+                </p>
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-on-surface-variant mt-1">Click on the map to set location</p>
+          )}
         </div>
         <button
           onClick={onClose}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -241,6 +241,10 @@ function Home() {
   const searchDebounce = useRef(null)
   const [showCreatePanel, setShowCreatePanel] = useState(false)
   const [newReportPin, setNewReportPin] = useState(null)
+  // Reverse-geocoded place name for the new-report pin. Fetched async after
+  // the pin drops; CreateReportPanel falls back to raw coordinates while it
+  // resolves (or if Nominatim returns no result).
+  const [newReportPinLabel, setNewReportPinLabel] = useState('')
   const [userVotes, setUserVotes] = useState({})
   const [routeMode, setRouteMode] = useState(false)
   const [routeOrigin, setRouteOrigin] = useState(null)
@@ -535,8 +539,16 @@ function Home() {
             <MapClickHandler
               active={showCreatePanel || routeMode}
               onPick={(latlng) => {
-                if (routeMode) handleRouteMapClick(latlng)
-                else setNewReportPin(latlng)
+                if (routeMode) {
+                  handleRouteMapClick(latlng)
+                } else {
+                  setNewReportPin(latlng)
+                  setNewReportPinLabel('')
+                  // Resolve the human-readable place name asynchronously.
+                  // CreateReportPanel renders raw coords until this resolves,
+                  // so users see something immediately.
+                  reverseGeocode(latlng).then(setNewReportPinLabel)
+                }
               }}
             />
             {routeOrigin && <Marker position={routeOrigin} icon={pinIcon} />}
@@ -736,10 +748,12 @@ function Home() {
       {showCreatePanel && (
         <CreateReportPanel
           position={newReportPin}
-          onClose={() => { setShowCreatePanel(false); setNewReportPin(null) }}
+          positionLabel={newReportPinLabel}
+          onClose={() => { setShowCreatePanel(false); setNewReportPin(null); setNewReportPinLabel('') }}
           onCreated={() => {
             queryClient.invalidateQueries({ queryKey: reportKeys.lists() })
             setNewReportPin(null)
+            setNewReportPinLabel('')
             setToast({ message: 'Report submitted successfully!', type: 'success' })
           }}
         />


### PR DESCRIPTION
Closes #497.

The route origin/destination pickers already use Nominatim reverse geocoding to show a place name when the user clicks the map. The report-creation pin path didn't. CreateReportPanel showed only raw `lat, lng`. Wired the existing `reverseGeocode` helper from Home.jsx into the new-report pin flow:

- On pin drop, kick off `reverseGeocode(latlng)` and store the result.
- Pass the label as a new `positionLabel` prop to CreateReportPanel.
- Header shows the place name on the primary line; raw coords drop to a small secondary line so users still have precise coordinates if they need them.
- If Nominatim returns nothing or errors out, the header stays on raw coords.

## 📊 Type of Change
- [x] Bug fix
- [x] New feature

## ✅ Checklist
- [x] All tests passed (267/267)

## 📸 Screenshot

<img width="1006" height="638" alt="Ekran Resmi 2026-05-09 22 40 29" src="https://github.com/user-attachments/assets/730ed367-17ca-4ef7-b6c7-42804fc930a0" />

## 🧪 How to Test
1. Click **Report an Issue**.
2. Drop a pin somewhere with OSM coverage. The header swaps from raw coords to the place name within a second; raw coords appear as a small secondary line.
3. Drop a pin in the middle of the ocean. The header stays on raw coords (Nominatim returns no result).

## ⏱️ Estimated Review Time
- [x] < 5 min