### PR TITLE
[Backend] Expose Gamification API

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
@@ -70,7 +70,9 @@ public class SecurityConfig {
                                 "/api/reports", "/api/reports/**",
                                 "/api/comments", "/api/comments/**",
                                 "/api/categories", "/api/categories/**",
-                                "/api/object-types", "/api/object-types/**"
+                                "/api/object-types", "/api/object-types/**",
+                                "/api/leaderboard", "/api/leaderboard/**",
+                                "/api/users/*/badges"
                         ).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/LeaderboardController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/LeaderboardController.java
@@ -1,0 +1,61 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.config.OpenApiConfig;
+import com.bounswe2026group1.backend.dto.LeaderboardResponse;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.service.LeaderboardService;
+import com.bounswe2026group1.backend.service.RankInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/leaderboard")
+@RequiredArgsConstructor
+@Tag(name = "Leaderboard", description = "Public top-N ranking and caller's own rank.")
+public class LeaderboardController {
+
+    private final LeaderboardService leaderboardService;
+    private final RegisteredUserRepository userRepository;
+
+    @GetMapping
+    @Operation(
+            summary = "Top-N leaderboard with caller's rank",
+            description = "Public endpoint. Returns the top 100 users ranked by points. " +
+                    "When the caller is authenticated and not opted out, their own rank is " +
+                    "included alongside the entries."
+    )
+    @ApiResponse(responseCode = "200", description = "Leaderboard payload.")
+    @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
+    public ResponseEntity<LeaderboardResponse> getLeaderboard() {
+        RankInfo callerRank = currentUserEmailOrNull()
+                .flatMap(email -> userRepository.findByEmail(email))
+                .map(RegisteredUser::getId)
+                .flatMap(leaderboardService::getRankFor)
+                .orElse(null);
+        return ResponseEntity.ok(new LeaderboardResponse(
+                leaderboardService.getTopN(),
+                callerRank));
+    }
+
+    private static java.util.Optional<String> currentUserEmailOrNull() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null
+                || auth instanceof AnonymousAuthenticationToken
+                || !auth.isAuthenticated()
+                || auth.getName() == null) {
+            return java.util.Optional.empty();
+        }
+        return java.util.Optional.of(auth.getName());
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
@@ -1,9 +1,13 @@
 package com.bounswe2026group1.backend.controller;
 
 import com.bounswe2026group1.backend.config.OpenApiConfig;
+import com.bounswe2026group1.backend.dto.LeaderboardVisibilityRequest;
+import com.bounswe2026group1.backend.dto.PointEventResponse;
 import com.bounswe2026group1.backend.dto.UpdateProfileRequest;
 import com.bounswe2026group1.backend.dto.UserProfileDTO;
+import com.bounswe2026group1.backend.model.Badge;
 import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.UserRole;
 import com.bounswe2026group1.backend.service.RegisteredUserService;
 import com.bounswe2026group1.backend.service.S3MediaService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +21,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -212,6 +218,96 @@ public class RegisteredUserController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    // ───── Gamification endpoints ──────────────────────────────────────────
+
+    @GetMapping("/{id}/badges")
+    @Operation(summary = "List badges held by a user")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Badges list (possibly empty)."),
+            @ApiResponse(responseCode = "404", description = "No user with that id.")
+    })
+    @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
+    public ResponseEntity<Object> getBadges(@PathVariable Long id) {
+        try {
+            List<Badge> badges = registeredUserService.getBadges(id);
+            return ResponseEntity.ok(badges);
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @GetMapping("/{id}/points/history")
+    @Operation(
+            summary = "Paginated points history for a user",
+            description = "Returns the user's gamification ledger entries, most recent first. " +
+                    "Restricted to the user themselves and admins — leaks point-level audit detail otherwise."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of ledger entries."),
+            @ApiResponse(responseCode = "401", description = "Authentication required."),
+            @ApiResponse(responseCode = "403", description = "Caller is neither the owner nor an admin."),
+            @ApiResponse(responseCode = "404", description = "No user with that id.")
+    })
+    @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
+    public ResponseEntity<Object> getPointsHistory(@PathVariable Long id, Pageable pageable) {
+        try {
+            requireOwnerOrAdmin(id);
+            Page<PointEventResponse> page = registeredUserService.listPointEvents(id, pageable);
+            return ResponseEntity.ok(page);
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @PatchMapping("/me/leaderboard-visibility")
+    @Operation(
+            summary = "Toggle the caller's leaderboard opt-out flag",
+            description = "Hides or unhides the authenticated user from the public leaderboard. " +
+                    "Their points are preserved either way."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Updated profile."),
+            @ApiResponse(responseCode = "400", description = "Body missing the leaderboardHidden flag."),
+            @ApiResponse(responseCode = "401", description = "Authentication required."),
+            @ApiResponse(responseCode = "404", description = "Authenticated user no longer exists.")
+    })
+    @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
+    public ResponseEntity<Object> setLeaderboardVisibility(
+            @RequestBody @Valid LeaderboardVisibilityRequest request) {
+        String email = currentUserEmailOrNull();
+        if (email == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Authentication required.");
+        }
+        try {
+            UserProfileDTO me = registeredUserService.getProfileByEmail(email);
+            UserProfileDTO updated = registeredUserService.setLeaderboardHidden(
+                    me.getId(), request.leaderboardHidden());
+            return ResponseEntity.ok(updated);
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    /**
+     * Owner OR admin authorisation gate — used by the points history view,
+     * which leaks ledger detail and shouldn't be readable by other users.
+     * Throws 401 if no auth, 403 if neither owner nor admin.
+     */
+    private void requireOwnerOrAdmin(Long pathId) {
+        String email = currentUserEmailOrNull();
+        if (email == null) {
+            throw new AccessDeniedException("Authentication required.");
+        }
+        UserProfileDTO me = registeredUserService.getProfileByEmail(email);
+        boolean isOwner = me.getId().equals(pathId);
+        boolean isAdmin = UserRole.ADMIN.name().equals(me.getRole());
+        if (!isOwner && !isAdmin) {
+            throw new AccessDeniedException("You can only view your own points history.");
         }
     }
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/LeaderboardResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/LeaderboardResponse.java
@@ -1,0 +1,20 @@
+package com.bounswe2026group1.backend.dto;
+
+import com.bounswe2026group1.backend.service.LeaderboardEntry;
+import com.bounswe2026group1.backend.service.RankInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "Leaderboard payload — top-N entries plus the caller's own rank when authenticated.")
+public record LeaderboardResponse(
+
+        @Schema(description = "Top-ranked users (default top 100), olympic-style rank ordering.")
+        List<LeaderboardEntry> entries,
+
+        @Schema(description = "Caller's own rank and points. Null when the caller is anonymous, " +
+                "has opted out of the public leaderboard, or is no longer active.",
+                nullable = true)
+        RankInfo callerRank
+) {
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/LeaderboardVisibilityRequest.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/LeaderboardVisibilityRequest.java
@@ -1,0 +1,15 @@
+package com.bounswe2026group1.backend.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "Body for the leaderboard opt-out toggle.")
+public record LeaderboardVisibilityRequest(
+
+        @NotNull
+        @Schema(description = "True when the user wants to be hidden from the public leaderboard. " +
+                "Their points are preserved; they re-enter the ranking instantly when this flips back.",
+                example = "true")
+        Boolean leaderboardHidden
+) {
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/PointEventResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/PointEventResponse.java
@@ -1,0 +1,38 @@
+package com.bounswe2026group1.backend.dto;
+
+import com.bounswe2026group1.backend.model.PointEvent;
+import com.bounswe2026group1.backend.model.PointReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(description = "One row of a user's gamification points ledger.")
+public record PointEventResponse(
+
+        @Schema(description = "Ledger entry id.")
+        Long id,
+
+        @Schema(description = "Signed point change applied to the user's balance " +
+                "(post-clamp — the running balance never drops below 0).",
+                example = "-5")
+        int delta,
+
+        @Schema(description = "Why the change happened.")
+        PointReason reason,
+
+        @Schema(description = "Report id that triggered this entry, if applicable.",
+                nullable = true)
+        Long relatedEntityId,
+
+        @Schema(description = "When the entry was recorded.")
+        Instant createdAt
+) {
+    public static PointEventResponse fromEntity(PointEvent event) {
+        return new PointEventResponse(
+                event.getId(),
+                event.getDelta(),
+                event.getReason(),
+                event.getRelatedEntityId(),
+                event.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
@@ -90,6 +90,11 @@ public class ReportResponse {
             example = "42", nullable = true)
     private Long lastEditedByUserId;
 
+    @Schema(description = "Highest-tier badge held by the report author — surfaced as a chip next " +
+            "to their name. Null when the author has no badges yet.",
+            nullable = true)
+    private Badge authorTopBadge;
+
     public static ReportResponse fromEntity(Report report) {
         return fromEntity(report, null, Collections.emptyList(), null);
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/UserProfileDTO.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/UserProfileDTO.java
@@ -1,10 +1,13 @@
 package com.bounswe2026group1.backend.dto;
 
+import com.bounswe2026group1.backend.model.Badge;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @Builder
@@ -37,6 +40,27 @@ public class UserProfileDTO {
 
     @Schema(description = "Aggregate contribution counters (reports submitted, routes planned).")
     private ContributionStatsDTO contributionStats;
+
+    @Schema(description = "Total accumulated gamification points.", example = "245")
+    private int points;
+
+    @Schema(description = "Global leaderboard rank (1-based). Null when the user has opted out " +
+            "of the public leaderboard or is no longer active.",
+            example = "12", nullable = true)
+    private Integer rank;
+
+    @Schema(description = "All badges currently held by the user.")
+    private List<Badge> badges;
+
+    @Schema(description = "Highest-tier badge held — surfaced next to the user's name in report " +
+            "panels. Null when the user has no badges yet.",
+            nullable = true)
+    private Badge topBadge;
+
+    @Schema(description = "True when the user has opted out of the public leaderboard. Hides " +
+            "their points/rank from the global ranking but does not erase the points themselves.",
+            example = "false")
+    private boolean leaderboardHidden;
 
     @Data
     @Builder

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/Badge.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/Badge.java
@@ -1,5 +1,8 @@
 package com.bounswe2026group1.backend.model;
 
+import java.util.Collection;
+import java.util.Comparator;
+
 /**
  * Gamification badges.
  *
@@ -29,5 +32,13 @@ public enum Badge {
 
     public int getTier() {
         return tier;
+    }
+
+    /** Highest-tier badge in a collection, or null if the collection is null
+     *  or empty. Used wherever a UI surfaces a single "primary" badge for
+     *  a user (profile DTO, report-panel author chip). */
+    public static Badge pickHighestTier(Collection<Badge> badges) {
+        if (badges == null || badges.isEmpty()) return null;
+        return badges.stream().max(Comparator.comparingInt(Badge::getTier)).orElse(null);
     }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/NotificationType.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/NotificationType.java
@@ -3,5 +3,6 @@ package com.bounswe2026group1.backend.model;
 public enum NotificationType {
     STATUS_CHANGE,
     NEW_COMMENT,
-    NAV_ALERT
+    NAV_ALERT,
+    BADGE_AWARDED
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
@@ -43,6 +43,7 @@ public class GamificationService {
     private final PointEventRepository pointEventRepository;
     private final UserBadgeRepository userBadgeRepository;
     private final LeaderboardService leaderboardService;
+    private final NotificationService notificationService;
 
     @Value("${app.gamification.points.report-submit:10}")
     private int reportSubmitDelta;
@@ -201,6 +202,9 @@ public class GamificationService {
             if (awardBadgeIfMissing(user, Badge.EXPERT_MAPPER)) {
                 newlyAwarded.add(Badge.EXPERT_MAPPER);
             }
+        }
+        for (Badge badge : newlyAwarded) {
+            notificationService.notifyBadgeAwarded(user, badge);
         }
         return newlyAwarded;
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/LeaderboardService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/LeaderboardService.java
@@ -35,6 +35,7 @@ public class LeaderboardService {
 
     private final RegisteredUserRepository userRepository;
     private final UserBadgeRepository userBadgeRepository;
+    private final NotificationService notificationService;
 
     @Value("${app.gamification.leaderboard.size:100}")
     private int leaderboardSize;
@@ -117,6 +118,7 @@ public class LeaderboardService {
                 RegisteredUser u = usersById.get(id);
                 if (u != null) {
                     userBadgeRepository.save(new UserBadge(u, Badge.TOP_10));
+                    notificationService.notifyBadgeAwarded(u, Badge.TOP_10);
                 }
             }
         }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/NotificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/NotificationService.java
@@ -2,6 +2,7 @@ package com.bounswe2026group1.backend.service;
 
 import com.bounswe2026group1.backend.dto.NotificationResponse;
 import com.bounswe2026group1.backend.dto.NotificationSseEvent;
+import com.bounswe2026group1.backend.model.Badge;
 import com.bounswe2026group1.backend.model.Comment;
 import com.bounswe2026group1.backend.model.Notification;
 import com.bounswe2026group1.backend.model.NotificationType;
@@ -93,6 +94,21 @@ public class NotificationService {
             String message = buildStatusMessage(recipientId, authorId, reportId, status);
             create(recipient, message, NotificationType.STATUS_CHANGE, reportId);
         }
+    }
+
+    /** Trigger: a gamification badge was awarded to a user. Notifies just
+     *  that user — badges are individual achievements, no fan-out audience. */
+    public void notifyBadgeAwarded(RegisteredUser recipient, Badge badge) {
+        if (recipient == null || badge == null) return;
+        create(recipient, buildBadgeMessage(badge), NotificationType.BADGE_AWARDED, null);
+    }
+
+    private static String buildBadgeMessage(Badge badge) {
+        return switch (badge) {
+            case TRUSTED_REPORTER -> "You earned the Trusted Reporter badge!";
+            case EXPERT_MAPPER -> "You earned the Expert Mapper badge!";
+            case TOP_10 -> "You broke into the Top 10 — congrats!";
+        };
     }
 
     /** Trigger: someone commented on a report. Notifies the report author,

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
@@ -6,17 +6,24 @@ import com.bounswe2026group1.backend.dto.RegisterRequest;
 import com.bounswe2026group1.backend.dto.RegisterResponse;
 import com.bounswe2026group1.backend.dto.UpdateProfileRequest;
 import com.bounswe2026group1.backend.dto.UserProfileDTO;
+import com.bounswe2026group1.backend.model.Badge;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.model.UserRole;
+import com.bounswe2026group1.backend.dto.PointEventResponse;
+import com.bounswe2026group1.backend.repository.PointEventRepository;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.repository.ReportRepository;
 import com.bounswe2026group1.backend.repository.RouteRepository;
+import com.bounswe2026group1.backend.repository.UserBadgeRepository;
 import com.bounswe2026group1.backend.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +38,9 @@ public class RegisteredUserService {
     private final RegisteredUserRepository registeredUserRepository;
     private final ReportRepository reportRepository;
     private final RouteRepository routeRepository;
+    private final UserBadgeRepository userBadgeRepository;
+    private final PointEventRepository pointEventRepository;
+    private final LeaderboardService leaderboardService;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
 
@@ -106,8 +116,10 @@ public class RegisteredUserService {
 
     // ───── Profile (issue #302) ─────────────────────────────────────────────
 
-    /** Public listing — uses batched count queries so this stays at 3 queries
-     *  total regardless of user count, instead of 1 + 3N. */
+    /** Public listing — uses batched count queries so this stays at a small
+     *  fixed query count regardless of user size, instead of N+1. Rank is
+     *  intentionally null for list views: filling it in would require a
+     *  count-above query per user, and admin/listing UIs only need points. */
     public List<UserProfileDTO> getAllProfiles() {
         List<RegisteredUser> users = registeredUserRepository.findAll();
         if (users.isEmpty()) return List.of();
@@ -115,11 +127,14 @@ public class RegisteredUserService {
         List<Long> ids = users.stream().map(RegisteredUser::getId).toList();
         Map<Long, Long> reportCounts = toCountMap(reportRepository.countByCreatedByIdIn(ids));
         Map<Long, Long> routeCounts = toCountMap(routeRepository.countByCreatedByIdIn(ids));
+        Map<Long, List<Badge>> badgesByUser = toBadgeMap(userBadgeRepository.findBadgesByUserIds(ids));
 
         return users.stream()
                 .map(u -> buildDTO(u, false,
                         reportCounts.getOrDefault(u.getId(), 0L),
-                        routeCounts.getOrDefault(u.getId(), 0L)))
+                        routeCounts.getOrDefault(u.getId(), 0L),
+                        badgesByUser.getOrDefault(u.getId(), List.of()),
+                        null))
                 .toList();
     }
 
@@ -127,6 +142,14 @@ public class RegisteredUserService {
         Map<Long, Long> map = new HashMap<>(rows.size());
         for (Object[] row : rows) {
             map.put((Long) row[0], (Long) row[1]);
+        }
+        return map;
+    }
+
+    private static Map<Long, List<Badge>> toBadgeMap(List<Object[]> rows) {
+        Map<Long, List<Badge>> map = new HashMap<>();
+        for (Object[] row : rows) {
+            map.computeIfAbsent((Long) row[0], k -> new ArrayList<>()).add((Badge) row[1]);
         }
         return map;
     }
@@ -166,15 +189,59 @@ public class RegisteredUserService {
         return toProfileDTO(saved, true);
     }
 
+    /** Toggles the user's leaderboard opt-out flag. Their accumulated points
+     *  stay intact — they re-enter the ranking instantly when this flips back. */
+    public UserProfileDTO setLeaderboardHidden(Long id, boolean hidden) {
+        RegisteredUser user = registeredUserRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("User not found with id: " + id));
+        user.setLeaderboardHidden(hidden);
+        RegisteredUser saved = registeredUserRepository.save(user);
+        return toProfileDTO(saved, true);
+    }
+
+    /** All badges currently held by a user — exposed as its own endpoint so
+     *  the public profile page can fetch badges without going through the
+     *  full profile DTO. */
+    public List<Badge> getBadges(Long id) {
+        if (!registeredUserRepository.existsById(id)) {
+            throw new NoSuchElementException("User not found with id: " + id);
+        }
+        return userBadgeRepository.findByUserId(id).stream()
+                .map(ub -> ub.getBadge())
+                .toList();
+    }
+
+    /** Paginated points-history view (most recent first). Surfaced through
+     *  the points history endpoint, gated to the user themselves and admins. */
+    public Page<PointEventResponse> listPointEvents(Long userId, Pageable pageable) {
+        if (!registeredUserRepository.existsById(userId)) {
+            throw new NoSuchElementException("User not found with id: " + userId);
+        }
+        return pointEventRepository
+                .findByUserIdOrderByCreatedAtDesc(userId, pageable)
+                .map(PointEventResponse::fromEntity);
+    }
+
     // includeEmail=true is reserved for self-views (/me, login, owner-only mutations).
     // Public lookups must pass false to avoid leaking another user's email.
     private UserProfileDTO toProfileDTO(RegisteredUser user, boolean includeEmail) {
         long reports = reportRepository.countByCreatedById(user.getId());
         long routes = routeRepository.countByCreatedById(user.getId());
-        return buildDTO(user, includeEmail, reports, routes);
+        List<Badge> badges = userBadgeRepository.findByUserId(user.getId()).stream()
+                .map(ub -> ub.getBadge())
+                .toList();
+        Integer rank = leaderboardService.getRankFor(user.getId())
+                .map(RankInfo::rank)
+                .orElse(null);
+        return buildDTO(user, includeEmail, reports, routes, badges, rank);
     }
 
-    private UserProfileDTO buildDTO(RegisteredUser user, boolean includeEmail, long reports, long routes) {
+    private UserProfileDTO buildDTO(RegisteredUser user,
+                                    boolean includeEmail,
+                                    long reports,
+                                    long routes,
+                                    List<Badge> badges,
+                                    Integer rank) {
         return UserProfileDTO.builder()
                 .id(user.getId())
                 .name(user.getName())
@@ -186,6 +253,11 @@ public class RegisteredUserService {
                         .reportsSubmitted(reports)
                         .routesPlanned(routes)
                         .build())
+                .points(user.getPoints())
+                .rank(rank)
+                .badges(badges)
+                .topBadge(Badge.pickHighestTier(badges))
+                .leaderboardHidden(user.isLeaderboardHidden())
                 .build();
     }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -41,6 +41,7 @@ public class ReportService {
     private final ReportVerificationRepository verificationRepository;
     private final FixRequestRepository fixRequestRepository;
     private final FixRequestVoteRepository fixRequestVoteRepository;
+    private final UserBadgeRepository userBadgeRepository;
     private final PublicSseService publicSseService;
     private final NotificationService notificationService;
     private final GamificationService gamificationService;
@@ -59,32 +60,43 @@ public class ReportService {
         List<Report> reports = reportRepository.findAll();
         Map<Long, VoteType> votesByReportId = resolveUserVotes(userId, reports);
         Map<Long, FixRequestResponse> activeFixByReportId = resolveActiveFixRequests(userId, reports);
+        Map<Long, Badge> topBadgesByAuthor = resolveAuthorTopBadges(reports);
         return reports.stream()
-                .map(r -> ReportResponse.fromEntity(
-                        r,
-                        votesByReportId.get(r.getReportId()),
-                        buildObjectResponses(r),
-                        activeFixByReportId.get(r.getReportId())))
+                .map(r -> withAuthorTopBadge(
+                        ReportResponse.fromEntity(
+                                r,
+                                votesByReportId.get(r.getReportId()),
+                                buildObjectResponses(r),
+                                activeFixByReportId.get(r.getReportId())),
+                        r, topBadgesByAuthor))
                 .toList();
     }
 
     public Optional<ReportResponse> getById(Long id, String email) {
         Long userId = resolveUserId(email);
         return reportRepository.findById(id)
-                .map(r -> ReportResponse.fromEntity(
-                        r,
-                        resolveUserVote(userId, r.getReportId()),
-                        buildObjectResponses(r),
-                        resolveActiveFixRequest(userId, r.getReportId())));
+                .map(r -> {
+                    ReportResponse resp = ReportResponse.fromEntity(
+                            r,
+                            resolveUserVote(userId, r.getReportId()),
+                            buildObjectResponses(r),
+                            resolveActiveFixRequest(userId, r.getReportId()));
+                    resp.setAuthorTopBadge(resolveAuthorTopBadge(r.getCreatedBy().getId()));
+                    return resp;
+                });
     }
 
     public List<ReportResponse> getByUserId(Long userId) {
-        return reportRepository.findByCreatedById(userId).stream()
-                .map(r -> ReportResponse.fromEntity(
-                        r,
-                        resolveUserVote(userId, r.getReportId()),
-                        buildObjectResponses(r),
-                        resolveActiveFixRequest(userId, r.getReportId())))
+        List<Report> reports = reportRepository.findByCreatedById(userId);
+        Map<Long, Badge> topBadgesByAuthor = resolveAuthorTopBadges(reports);
+        return reports.stream()
+                .map(r -> withAuthorTopBadge(
+                        ReportResponse.fromEntity(
+                                r,
+                                resolveUserVote(userId, r.getReportId()),
+                                buildObjectResponses(r),
+                                resolveActiveFixRequest(userId, r.getReportId())),
+                        r, topBadgesByAuthor))
                 .toList();
     }
 
@@ -123,12 +135,15 @@ public class ReportService {
 
         Map<Long, VoteType> votesByReportId = resolveUserVotes(userId, page.getContent());
         Map<Long, FixRequestResponse> activeFixByReportId = resolveActiveFixRequests(userId, page.getContent());
+        Map<Long, Badge> topBadgesByAuthor = resolveAuthorTopBadges(page.getContent());
         List<ReportResponse> responses = page.getContent().stream()
-                .map(r -> ReportResponse.fromEntity(
-                        r,
-                        votesByReportId.get(r.getReportId()),
-                        buildObjectResponses(r),
-                        activeFixByReportId.get(r.getReportId())))
+                .map(r -> withAuthorTopBadge(
+                        ReportResponse.fromEntity(
+                                r,
+                                votesByReportId.get(r.getReportId()),
+                                buildObjectResponses(r),
+                                activeFixByReportId.get(r.getReportId())),
+                        r, topBadgesByAuthor))
                 .toList();
         return new PageImpl<>(responses, paged, page.getTotalElements());
     }
@@ -185,8 +200,10 @@ public class ReportService {
 
         gamificationService.awardOnReportSubmit(user, saved.getReportId());
 
-        return ReportResponse.fromEntity(saved, null, buildObjectResponses(saved),
+        ReportResponse response = ReportResponse.fromEntity(saved, null, buildObjectResponses(saved),
                 resolveActiveFixRequest(user.getId(), saved.getReportId()));
+        response.setAuthorTopBadge(resolveAuthorTopBadge(user.getId()));
+        return response;
     }
 
     @Transactional
@@ -248,10 +265,12 @@ public class ReportService {
         Report saved = reportRepository.save(report);
         broadcastAfterCommit(() -> publicSseService.broadcastReportUpdated(saved, "update"));
 
-        return ReportResponse.fromEntity(saved,
+        ReportResponse response = ReportResponse.fromEntity(saved,
                 resolveUserVote(editor.getId(), saved.getReportId()),
                 buildObjectResponses(saved),
                 resolveActiveFixRequest(editor.getId(), saved.getReportId()));
+        response.setAuthorTopBadge(resolveAuthorTopBadge(saved.getCreatedBy().getId()));
+        return response;
     }
 
     @Transactional
@@ -336,10 +355,12 @@ public class ReportService {
             notificationService.notifyStatusChange(saved, user.getId());
             gamificationService.onReportStatusTransition(saved, previousStatus, newStatus);
         }
-        return ReportResponse.fromEntity(saved,
+        ReportResponse response = ReportResponse.fromEntity(saved,
                 resolveUserVote(user.getId(), saved.getReportId()),
                 buildObjectResponses(saved),
                 resolveActiveFixRequest(user.getId(), saved.getReportId()));
+        response.setAuthorTopBadge(resolveAuthorTopBadge(saved.getCreatedBy().getId()));
+        return response;
     }
 
     @Transactional
@@ -391,10 +412,12 @@ public class ReportService {
             notificationService.notifyStatusChange(saved, user.getId());
             gamificationService.onReportStatusTransition(saved, previousStatus, newStatus);
         }
-        return ReportResponse.fromEntity(saved,
+        ReportResponse response = ReportResponse.fromEntity(saved,
                 resolveUserVote(user.getId(), saved.getReportId()),
                 buildObjectResponses(saved),
                 resolveActiveFixRequest(user.getId(), saved.getReportId()));
+        response.setAuthorTopBadge(resolveAuthorTopBadge(saved.getCreatedBy().getId()));
+        return response;
     }
 
     private ReportStatus evaluateStatus(Report report) {
@@ -512,6 +535,49 @@ public class ReportService {
                 .collect(Collectors.toMap(
                         row -> (Long) row[0],
                         row -> (VoteType) row[1]));
+    }
+
+    /** Inline setter used inside list-stream callsites — picks the author's
+     *  top badge from the prefetched map and attaches it to the response.
+     *  Returns the same response so it can chain inside a {@code map(...)}. */
+    private static ReportResponse withAuthorTopBadge(ReportResponse response,
+                                                     Report report,
+                                                     Map<Long, Badge> topBadgesByAuthor) {
+        if (report.getCreatedBy() != null) {
+            response.setAuthorTopBadge(topBadgesByAuthor.get(report.getCreatedBy().getId()));
+        }
+        return response;
+    }
+
+    /** Single-author lookup — used after create/update/vote where we already
+     *  have the author entity in scope. Picks the highest-tier badge to surface
+     *  next to the author chip on the report panel. */
+    private Badge resolveAuthorTopBadge(Long authorId) {
+        if (authorId == null) return null;
+        List<Badge> badges = userBadgeRepository.findByUserId(authorId).stream()
+                .map(UserBadge::getBadge)
+                .toList();
+        return Badge.pickHighestTier(badges);
+    }
+
+    /** Batch variant for list/feed paths — single query for all distinct
+     *  author ids, then a tier-pick per author. Avoids N+1 on /api/reports
+     *  and the feed paginator. */
+    private Map<Long, Badge> resolveAuthorTopBadges(Collection<Report> reports) {
+        if (reports.isEmpty()) return Map.of();
+        Set<Long> authorIds = reports.stream()
+                .map(r -> r.getCreatedBy() != null ? r.getCreatedBy().getId() : null)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        if (authorIds.isEmpty()) return Map.of();
+
+        Map<Long, List<Badge>> byUser = new HashMap<>();
+        for (Object[] row : userBadgeRepository.findBadgesByUserIds(authorIds)) {
+            byUser.computeIfAbsent((Long) row[0], k -> new ArrayList<>()).add((Badge) row[1]);
+        }
+        Map<Long, Badge> result = new HashMap<>();
+        byUser.forEach((id, list) -> result.put(id, Badge.pickHighestTier(list)));
+        return result;
     }
 
     private FixRequestResponse resolveActiveFixRequest(Long userId, Long reportId) {

--- a/backend/src/main/resources/db/migration/V3__drop_legacy_notification_type_check.sql
+++ b/backend/src/main/resources/db/migration/V3__drop_legacy_notification_type_check.sql
@@ -1,0 +1,15 @@
+-- Drop the legacy CHECK constraint on notifications.type. Hibernate generated
+-- it from the original 3 NotificationType values (STATUS_CHANGE, NEW_COMMENT,
+-- NAV_ALERT) when ddl-auto=update first ran against this schema. The
+-- gamification rollout adds a fourth value (BADGE_AWARDED), and ddl-auto does
+-- NOT extend existing CHECK constraints when new enum values are added later,
+-- so inserts using BADGE_AWARDED fail at the DB layer with a 23514 violation.
+--
+-- Same pattern as V2: the column stays plain VARCHAR; enum validation is
+-- enforced application-side via @Enumerated(EnumType.STRING) and Spring's
+-- JSON deserialization, which already rejects unknown values at the request
+-- layer with a 400 before any DB write.
+--
+-- IF EXISTS keeps this safe on fresh environments where the constraint never
+-- existed in the first place.
+ALTER TABLE IF EXISTS notifications DROP CONSTRAINT IF EXISTS notifications_type_check;

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/LeaderboardControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/LeaderboardControllerTest.java
@@ -1,0 +1,102 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
+import com.bounswe2026group1.backend.service.LeaderboardEntry;
+import com.bounswe2026group1.backend.service.LeaderboardService;
+import com.bounswe2026group1.backend.service.RankInfo;
+import com.bounswe2026group1.backend.util.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = LeaderboardController.class)
+class LeaderboardControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private LeaderboardService leaderboardService;
+    @MockitoBean private RegisteredUserRepository userRepository;
+    @MockitoBean private JwtUtil jwtUtil;
+
+    @Value("${app.api.key}")
+    private String validApiKey;
+
+    private static final String CALLER_EMAIL = "caller@test.com";
+
+    @Test
+    @DisplayName("GET /api/leaderboard returns top-N anonymously, no caller rank")
+    void getLeaderboard_anonymous_returnsEntriesAndNullRank() throws Exception {
+        when(leaderboardService.getTopN()).thenReturn(List.of(
+                new LeaderboardEntry(1, 10L, "Alice", null, 200),
+                new LeaderboardEntry(2, 11L, "Bob", null, 150)
+        ));
+
+        mockMvc.perform(get("/api/leaderboard").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.entries.length()").value(2))
+                .andExpect(jsonPath("$.entries[0].rank").value(1))
+                .andExpect(jsonPath("$.entries[0].userId").value(10))
+                .andExpect(jsonPath("$.entries[0].points").value(200))
+                .andExpect(jsonPath("$.callerRank").doesNotExist());
+
+        // Anonymous caller — no user lookup, no rank fetch.
+        verify(userRepository, never()).findByEmail(any());
+        verify(leaderboardService, never()).getRankFor(any());
+    }
+
+    @Test
+    @WithMockUser(username = CALLER_EMAIL)
+    @DisplayName("GET /api/leaderboard includes callerRank when authenticated")
+    void getLeaderboard_authenticated_includesCallerRank() throws Exception {
+        RegisteredUser caller = new RegisteredUser();
+        caller.setId(42L);
+        caller.setEmail(CALLER_EMAIL);
+
+        when(leaderboardService.getTopN()).thenReturn(List.of(
+                new LeaderboardEntry(1, 10L, "Alice", null, 200)
+        ));
+        when(userRepository.findByEmail(CALLER_EMAIL)).thenReturn(Optional.of(caller));
+        when(leaderboardService.getRankFor(42L)).thenReturn(Optional.of(new RankInfo(7, 95)));
+
+        mockMvc.perform(get("/api/leaderboard").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.entries.length()").value(1))
+                .andExpect(jsonPath("$.callerRank.rank").value(7))
+                .andExpect(jsonPath("$.callerRank.points").value(95));
+    }
+
+    @Test
+    @WithMockUser(username = CALLER_EMAIL)
+    @DisplayName("GET /api/leaderboard yields null callerRank when caller has opted out")
+    void getLeaderboard_authenticatedButOptedOut_callerRankNull() throws Exception {
+        RegisteredUser caller = new RegisteredUser();
+        caller.setId(42L);
+        caller.setEmail(CALLER_EMAIL);
+        caller.setLeaderboardHidden(true);
+
+        when(leaderboardService.getTopN()).thenReturn(List.of());
+        when(userRepository.findByEmail(CALLER_EMAIL)).thenReturn(Optional.of(caller));
+        when(leaderboardService.getRankFor(42L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/leaderboard").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.callerRank").doesNotExist());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/model/BadgeTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/model/BadgeTest.java
@@ -1,0 +1,33 @@
+package com.bounswe2026group1.backend.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BadgeTest {
+
+    @Test
+    void pickHighestTier_returnsHighestTierBadge() {
+        // Tiers are TRUSTED_REPORTER(1) < EXPERT_MAPPER(2) < TOP_10(3).
+        Badge top = Badge.pickHighestTier(List.of(Badge.TRUSTED_REPORTER, Badge.TOP_10, Badge.EXPERT_MAPPER));
+        assertThat(top).isEqualTo(Badge.TOP_10);
+    }
+
+    @Test
+    void pickHighestTier_singleBadgeReturnsItself() {
+        assertThat(Badge.pickHighestTier(List.of(Badge.TRUSTED_REPORTER)))
+                .isEqualTo(Badge.TRUSTED_REPORTER);
+    }
+
+    @Test
+    void pickHighestTier_emptyCollectionReturnsNull() {
+        assertThat(Badge.pickHighestTier(List.of())).isNull();
+    }
+
+    @Test
+    void pickHighestTier_nullReturnsNull() {
+        assertThat(Badge.pickHighestTier(null)).isNull();
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
@@ -44,6 +44,7 @@ class GamificationServiceTest {
     @Mock private PointEventRepository pointEventRepository;
     @Mock private UserBadgeRepository userBadgeRepository;
     @Mock private LeaderboardService leaderboardService;
+    @Mock private NotificationService notificationService;
 
     @InjectMocks
     private GamificationService gamificationService;
@@ -316,6 +317,22 @@ class GamificationServiceTest {
 
         assertThat(awarded).containsExactly(Badge.TRUSTED_REPORTER);
         verify(userBadgeRepository, times(1)).save(any(UserBadge.class));
+        // Each newly awarded milestone fires a BADGE_AWARDED notification.
+        verify(notificationService).notifyBadgeAwarded(user, Badge.TRUSTED_REPORTER);
+    }
+
+    @Test
+    void evaluateMilestoneBadges_existingBadgeDoesNotReFireNotification() {
+        // Idempotent path: badge already held → no save, no notification.
+        RegisteredUser user = newUser(1L, 0);
+        when(reportRepository.countByCreatedByIdAndStatus(1L, ReportStatus.VERIFIED))
+                .thenReturn(15L);
+        when(userBadgeRepository.existsByUserIdAndBadge(1L, Badge.TRUSTED_REPORTER))
+                .thenReturn(true);
+
+        gamificationService.evaluateMilestoneBadges(user);
+
+        verify(notificationService, never()).notifyBadgeAwarded(any(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/LeaderboardServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/LeaderboardServiceTest.java
@@ -32,6 +32,7 @@ class LeaderboardServiceTest {
 
     @Mock private RegisteredUserRepository userRepository;
     @Mock private UserBadgeRepository userBadgeRepository;
+    @Mock private NotificationService notificationService;
 
     @InjectMocks
     private LeaderboardService leaderboardService;
@@ -137,6 +138,43 @@ class LeaderboardServiceTest {
     }
 
     // ────────────────────── onPointsChanged (top-10 churn) ──────────────
+
+    @Test
+    void onPointsChanged_notifiesNewcomerOfTop10Badge() {
+        // Carol just rose into the cutoff — she should both receive the badge
+        // row AND be notified.
+        RegisteredUser alice = newUser(1L, "Alice", 100);
+        RegisteredUser bob = newUser(2L, "Bob", 90);
+        RegisteredUser carol = newUser(3L, "Carol", 80);
+
+        when(userRepository.findLeaderboardPage(any(Pageable.class)))
+                .thenReturn(List.of(alice, bob, carol));
+        when(userBadgeRepository.findUserIdsByBadge(Badge.TOP_10))
+                .thenReturn(List.of(1L, 2L));
+        when(userRepository.findAllById(anyCollection()))
+                .thenReturn(List.of(carol));
+
+        leaderboardService.onPointsChanged(3L);
+
+        verify(notificationService).notifyBadgeAwarded(carol, Badge.TOP_10);
+    }
+
+    @Test
+    void onPointsChanged_doesNotNotifyOnRevoke() {
+        // Falling out of the top-10 is a silent revoke — no notification.
+        RegisteredUser alice = newUser(1L, "Alice", 100);
+        RegisteredUser bob = newUser(2L, "Bob", 90);
+        RegisteredUser carol = newUser(3L, "Carol", 80);
+
+        when(userRepository.findLeaderboardPage(any(Pageable.class)))
+                .thenReturn(List.of(alice, bob, carol));
+        when(userBadgeRepository.findUserIdsByBadge(Badge.TOP_10))
+                .thenReturn(List.of(1L, 2L, 3L, 4L)); // Dora (4) needs revoking
+
+        leaderboardService.onPointsChanged(4L);
+
+        verify(notificationService, never()).notifyBadgeAwarded(any(), any());
+    }
 
     @Test
     void onPointsChanged_awardsBadgeToNewcomer() {

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/NotificationServiceTest.java
@@ -353,6 +353,43 @@ class NotificationServiceTest {
     }
 
     @Test
+    void notifyBadgeAwarded_persistsBadgeNotificationForRecipient() {
+        stubSaveAssignsId();
+
+        notificationService.notifyBadgeAwarded(author, com.bounswe2026group1.backend.model.Badge.TRUSTED_REPORTER);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+
+        Notification saved = captor.getValue();
+        assertEquals(NotificationType.BADGE_AWARDED, saved.getType());
+        assertEquals(author, saved.getRecipient());
+        assertTrue(saved.getMessage().contains("Trusted Reporter"),
+                "Message should mention the badge name: " + saved.getMessage());
+    }
+
+    @Test
+    void notifyBadgeAwarded_top10HasDistinctMessage() {
+        stubSaveAssignsId();
+
+        notificationService.notifyBadgeAwarded(author, com.bounswe2026group1.backend.model.Badge.TOP_10);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        // TOP_10 is dynamic so its phrasing differs from the milestone-style
+        // "you earned" copy used for the permanent badges.
+        assertTrue(captor.getValue().getMessage().contains("Top 10"),
+                "Message should mention Top 10: " + captor.getValue().getMessage());
+    }
+
+    @Test
+    void notifyBadgeAwarded_isNoOpOnNullArgs() {
+        notificationService.notifyBadgeAwarded(null, com.bounswe2026group1.backend.model.Badge.TOP_10);
+        notificationService.notifyBadgeAwarded(author, null);
+        verify(notificationRepository, never()).save(any());
+    }
+
+    @Test
     void listForUser_returnsRecipientNotifications() {
         Notification n = new Notification();
         ReflectionTestUtils.setField(n, "id", 11L);

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -9,9 +9,11 @@ import com.bounswe2026group1.backend.dto.UserProfileDTO;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.model.UserRole;
 import com.bounswe2026group1.backend.model.UserStatus;
+import com.bounswe2026group1.backend.repository.PointEventRepository;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.repository.ReportRepository;
 import com.bounswe2026group1.backend.repository.RouteRepository;
+import com.bounswe2026group1.backend.repository.UserBadgeRepository;
 import com.bounswe2026group1.backend.util.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,9 @@ class RegisteredUserServiceTest {
     @Mock private RegisteredUserRepository registeredUserRepository;
     @Mock private ReportRepository reportRepository;
     @Mock private RouteRepository routeRepository;
+    @Mock private UserBadgeRepository userBadgeRepository;
+    @Mock private PointEventRepository pointEventRepository;
+    @Mock private LeaderboardService leaderboardService;
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private JwtUtil jwtUtil;
 
@@ -445,5 +450,96 @@ class RegisteredUserServiceTest {
         verify(reportRepository, never()).countByCreatedById(any());
         verify(routeRepository, never()).countByCreatedById(any());
         verify(jwtUtil, never()).generateToken(any(), any(), any());
+    }
+
+    // ───── Gamification — profile DTO enrichment + new endpoints ────────────
+
+    @Test
+    void getProfileById_populatesPointsBadgesRankAndTopBadge() {
+        com.bounswe2026group1.backend.model.UserBadge ub1 = new com.bounswe2026group1.backend.model.UserBadge(
+                mockUser, com.bounswe2026group1.backend.model.Badge.TRUSTED_REPORTER);
+        com.bounswe2026group1.backend.model.UserBadge ub2 = new com.bounswe2026group1.backend.model.UserBadge(
+                mockUser, com.bounswe2026group1.backend.model.Badge.TOP_10);
+        mockUser.setPoints(245);
+
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(userBadgeRepository.findByUserId(1L)).thenReturn(List.of(ub1, ub2));
+        when(leaderboardService.getRankFor(1L))
+                .thenReturn(Optional.of(new RankInfo(7, 245)));
+
+        UserProfileDTO dto = registeredUserService.getProfileById(1L);
+
+        assertEquals(245, dto.getPoints());
+        assertEquals(7, dto.getRank());
+        assertEquals(2, dto.getBadges().size());
+        // Top badge surfaces the highest tier (TOP_10 > TRUSTED_REPORTER).
+        assertEquals(com.bounswe2026group1.backend.model.Badge.TOP_10, dto.getTopBadge());
+        assertFalse(dto.isLeaderboardHidden());
+    }
+
+    @Test
+    void getProfileById_optedOutUserHasNullRank() {
+        // Service.getRankFor returns empty for opt-out users — DTO should
+        // surface that as a null rank so the UI can hide the banner.
+        mockUser.setLeaderboardHidden(true);
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(leaderboardService.getRankFor(1L)).thenReturn(Optional.empty());
+
+        UserProfileDTO dto = registeredUserService.getProfileById(1L);
+
+        assertNull(dto.getRank());
+        assertTrue(dto.isLeaderboardHidden());
+    }
+
+    @Test
+    void getBadges_returnsAllBadgesHeld() {
+        com.bounswe2026group1.backend.model.UserBadge ub = new com.bounswe2026group1.backend.model.UserBadge(
+                mockUser, com.bounswe2026group1.backend.model.Badge.TRUSTED_REPORTER);
+        when(registeredUserRepository.existsById(1L)).thenReturn(true);
+        when(userBadgeRepository.findByUserId(1L)).thenReturn(List.of(ub));
+
+        var badges = registeredUserService.getBadges(1L);
+
+        assertEquals(1, badges.size());
+        assertEquals(com.bounswe2026group1.backend.model.Badge.TRUSTED_REPORTER, badges.get(0));
+    }
+
+    @Test
+    void getBadges_unknownUserThrows() {
+        when(registeredUserRepository.existsById(99L)).thenReturn(false);
+
+        assertThrows(NoSuchElementException.class,
+                () -> registeredUserService.getBadges(99L));
+    }
+
+    @Test
+    void setLeaderboardHidden_persistsFlag() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        UserProfileDTO dto = registeredUserService.setLeaderboardHidden(1L, true);
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertTrue(captor.getValue().isLeaderboardHidden());
+        assertTrue(dto.isLeaderboardHidden());
+    }
+
+    @Test
+    void setLeaderboardHidden_unknownUserThrows() {
+        when(registeredUserRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class,
+                () -> registeredUserService.setLeaderboardHidden(99L, true));
+        verify(registeredUserRepository, never()).save(any());
+    }
+
+    @Test
+    void listPointEvents_unknownUserThrows() {
+        when(registeredUserRepository.existsById(99L)).thenReturn(false);
+
+        assertThrows(NoSuchElementException.class,
+                () -> registeredUserService.listPointEvents(
+                        99L, org.springframework.data.domain.PageRequest.of(0, 20)));
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -41,6 +41,7 @@ class ReportServiceTest {
     @Mock private OverpassService overpassService;
     @Mock private NotificationService notificationService;
     @Mock private GamificationService gamificationService;
+    @Mock private UserBadgeRepository userBadgeRepository;
 
     @InjectMocks
     private ReportService reportService;
@@ -817,6 +818,35 @@ class ReportServiceTest {
         reportService.verifyReport(1L, "user@test.com");
 
         verify(gamificationService, never()).onReportStatusTransition(any(), any(), any());
+    }
+
+    @Test
+    void getById_attachesAuthorTopBadge() {
+        UserBadge ub = new UserBadge(testUser, Badge.TRUSTED_REPORTER);
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(userBadgeRepository.findByUserId(1L)).thenReturn(List.of(ub));
+
+        Optional<ReportResponse> result = reportService.getById(1L, "owner@test.com");
+
+        assertTrue(result.isPresent());
+        assertEquals(Badge.TRUSTED_REPORTER, result.get().getAuthorTopBadge());
+    }
+
+    @Test
+    void getAll_batchFetchesAuthorTopBadges() {
+        // Two reports by the same author should result in a single batch
+        // query, not one findByUserId per report.
+        when(reportRepository.findAll()).thenReturn(List.of(testReport, testReport));
+        when(userBadgeRepository.findBadgesByUserIds(any()))
+                .thenReturn(List.<Object[]>of(new Object[]{1L, Badge.EXPERT_MAPPER}));
+
+        List<ReportResponse> result = reportService.getAll(null);
+
+        assertEquals(2, result.size());
+        assertEquals(Badge.EXPERT_MAPPER, result.get(0).getAuthorTopBadge());
+        assertEquals(Badge.EXPERT_MAPPER, result.get(1).getAuthorTopBadge());
+        // Single batch query — never falls back to per-report fetches.
+        verify(userBadgeRepository, never()).findByUserId(any());
     }
 
     @Test

--- a/frontend/src/components/BadgeIcon.jsx
+++ b/frontend/src/components/BadgeIcon.jsx
@@ -1,0 +1,60 @@
+// Material Symbols icon + label mapping for each backend Badge enum value.
+// Keep in sync with com.bounswe2026group1.backend.model.Badge — adding a new
+// badge there means adding an entry here.
+const BADGE_META = {
+  TRUSTED_REPORTER: {
+    label: 'Trusted Reporter',
+    icon: 'verified',
+    description: '10 verified reports',
+    tone: 'bg-tertiary/10 text-tertiary',
+  },
+  EXPERT_MAPPER: {
+    label: 'Expert Mapper',
+    icon: 'workspace_premium',
+    description: '50 verified reports',
+    tone: 'bg-secondary/15 text-secondary',
+  },
+  TOP_10: {
+    label: 'Top 10',
+    icon: 'emoji_events',
+    description: 'Currently in the top 10 leaderboard',
+    tone: 'bg-primary/15 text-primary',
+  },
+}
+
+/**
+ * Single-badge chip used in profile pages and inline next to author names.
+ * Sizes: 'sm' (compact, just the icon), 'md' (default chip with label).
+ */
+function BadgeIcon({ badge, size = 'md' }) {
+  const meta = BADGE_META[badge]
+  if (!meta) return null
+
+  if (size === 'sm') {
+    return (
+      <span
+        title={`${meta.label} — ${meta.description}`}
+        className={`inline-flex items-center justify-center w-6 h-6 rounded-full ${meta.tone}`}
+        aria-label={meta.label}
+      >
+        <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>
+          {meta.icon}
+        </span>
+      </span>
+    )
+  }
+
+  return (
+    <span
+      title={meta.description}
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold ${meta.tone}`}
+    >
+      <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>
+        {meta.icon}
+      </span>
+      {meta.label}
+    </span>
+  )
+}
+
+export default BadgeIcon

--- a/frontend/src/components/BadgeList.jsx
+++ b/frontend/src/components/BadgeList.jsx
@@ -1,0 +1,20 @@
+import BadgeIcon from './BadgeIcon.jsx'
+
+/**
+ * Horizontal chip strip of all badges held by a user. Profile pages render
+ * this above contribution stats. Renders nothing when the list is empty —
+ * "no badges yet" copy is the caller's responsibility.
+ */
+function BadgeList({ badges }) {
+  if (!badges || badges.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-2" aria-label="User badges">
+      {badges.map((badge) => (
+        <BadgeIcon key={badge} badge={badge} />
+      ))}
+    </div>
+  )
+}
+
+export default BadgeList

--- a/frontend/src/hooks/useGamification.js
+++ b/frontend/src/hooks/useGamification.js
@@ -1,0 +1,37 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAuth } from '../context/AuthContext.jsx'
+import {
+  getBadges as getBadgesRequest,
+  setLeaderboardVisibility as setLeaderboardVisibilityRequest,
+} from '../services/userService.js'
+import { currentUserKey } from './useCurrentUser.js'
+
+export const userBadgesKey = (userId) => ['userBadges', userId]
+
+/** Fetches the public list of badges held by a user. No auth required —
+ *  the badges endpoint is public so anonymous visitors of a profile can
+ *  see them. */
+export function useUserBadges(userId) {
+  return useQuery({
+    queryKey: userBadgesKey(userId),
+    queryFn: () => getBadgesRequest(userId),
+    enabled: !!userId,
+    staleTime: 60_000,
+  })
+}
+
+/** Toggles the caller's leaderboard opt-out flag. On success the cached
+ *  current-user profile is invalidated so the rank/leaderboardHidden flag
+ *  in the profile DTO refreshes immediately. */
+export function useSetLeaderboardVisibility() {
+  const { token } = useAuth()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (leaderboardHidden) =>
+      setLeaderboardVisibilityRequest(token, leaderboardHidden),
+    onSuccess: (data) => {
+      if (data) queryClient.setQueryData(currentUserKey, data)
+      queryClient.invalidateQueries({ queryKey: currentUserKey })
+    },
+  })
+}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -2,10 +2,12 @@ import { useCallback, useState } from 'react'
 import Navbar from '../components/Navbar.jsx'
 import Toast from '../components/Toast.jsx'
 import AvatarUploader from '../components/AvatarUploader.jsx'
+import BadgeList from '../components/BadgeList.jsx'
 import MyReportsSection from '../components/MyReportsSection.jsx'
 import { useAuth } from '../context/AuthContext.jsx'
 import { useCurrentUser } from '../hooks/useCurrentUser.js'
 import { useDeleteAvatar, useUpdateProfile, useUploadAvatar } from '../hooks/useProfile.js'
+import { useSetLeaderboardVisibility } from '../hooks/useGamification.js'
 
 const NAME_MIN = 2
 const NAME_MAX = 50
@@ -26,6 +28,7 @@ function ProfilePage() {
   const updateProfileMutation = useUpdateProfile()
   const uploadAvatarMutation = useUploadAvatar()
   const deleteAvatarMutation = useDeleteAvatar()
+  const setVisibilityMutation = useSetLeaderboardVisibility()
 
   const [isEditing, setIsEditing] = useState(false)
   const [name, setName] = useState('')
@@ -74,6 +77,21 @@ function ProfilePage() {
     setToast({ message: 'Avatar removed.', type: 'success' })
   }
 
+  async function handleVisibilityToggle(event) {
+    const hidden = event.target.checked
+    try {
+      await setVisibilityMutation.mutateAsync(hidden)
+      setToast({
+        message: hidden
+          ? 'You are now hidden from the public leaderboard.'
+          : 'You are visible on the public leaderboard.',
+        type: 'success',
+      })
+    } catch (e) {
+      setToast({ message: e.message || 'Failed to update visibility.', type: 'error' })
+    }
+  }
+
   return (
     <div className="min-h-screen flex flex-col bg-background">
       <Navbar />
@@ -115,6 +133,38 @@ function ProfilePage() {
             <section className="flex gap-3 flex-wrap">
               <StatTile label="Reports submitted" value={user.contributionStats?.reportsSubmitted ?? 0} />
               <StatTile label="Routes planned" value={user.contributionStats?.routesPlanned ?? 0} />
+              <StatTile label="Points" value={user.points ?? 0} />
+              <StatTile
+                label="Rank"
+                value={user.rank != null ? `#${user.rank}` : user.leaderboardHidden ? 'Hidden' : '—'}
+              />
+            </section>
+
+            {user.badges && user.badges.length > 0 && (
+              <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+                <h2 className="text-xl font-bold font-headline text-on-surface">Badges</h2>
+                <BadgeList badges={user.badges} />
+              </section>
+            )}
+
+            <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+              <h2 className="text-xl font-bold font-headline text-on-surface">Leaderboard</h2>
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={user.leaderboardHidden}
+                  onChange={handleVisibilityToggle}
+                  disabled={setVisibilityMutation.isPending}
+                  className="w-5 h-5 accent-primary cursor-pointer disabled:opacity-60"
+                />
+                <span className="text-sm text-on-surface">
+                  Hide me from the public leaderboard
+                </span>
+              </label>
+              <p className="text-xs text-on-surface-variant">
+                Your points are preserved either way — you re-enter the ranking
+                instantly when this flips back.
+              </p>
             </section>
 
             <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-4">

--- a/frontend/src/pages/ProfilePage.test.jsx
+++ b/frontend/src/pages/ProfilePage.test.jsx
@@ -15,6 +15,9 @@ vi.mock('../hooks/useProfile.js', () => ({
   useUploadAvatar: vi.fn(),
   useDeleteAvatar: vi.fn(),
 }))
+vi.mock('../hooks/useGamification.js', () => ({
+  useSetLeaderboardVisibility: vi.fn(),
+}))
 vi.mock('../hooks/useUserReports.js', () => ({
   useUserReports: vi.fn(),
   useUpdateReport: vi.fn(),
@@ -27,6 +30,7 @@ vi.mock('../components/Navbar.jsx', () => ({
 import { useAuth } from '../context/AuthContext.jsx'
 import { useCurrentUser } from '../hooks/useCurrentUser.js'
 import { useDeleteAvatar, useUpdateProfile, useUploadAvatar } from '../hooks/useProfile.js'
+import { useSetLeaderboardVisibility } from '../hooks/useGamification.js'
 import { useDeleteReport, useUpdateReport, useUserReports } from '../hooks/useUserReports.js'
 
 function LocationProbe() {
@@ -53,6 +57,11 @@ const SAMPLE_USER = {
   avatarUrl: null,
   role: 'USER',
   contributionStats: { reportsSubmitted: 3, routesPlanned: 1 },
+  points: 245,
+  rank: 12,
+  badges: ['TRUSTED_REPORTER'],
+  topBadge: 'TRUSTED_REPORTER',
+  leaderboardHidden: false,
 }
 
 // Shape produced by useUserReports → mapReport (see services/reportService.js).
@@ -83,6 +92,7 @@ describe('ProfilePage', () => {
   const updateProfileMutate = vi.fn()
   const uploadAvatarMutate = vi.fn()
   const deleteAvatarMutate = vi.fn()
+  const setVisibilityMutate = vi.fn()
   const updateReportMutate = vi.fn()
   const deleteReportMutate = vi.fn()
 
@@ -93,6 +103,7 @@ describe('ProfilePage', () => {
     useUpdateProfile.mockReturnValue({ mutateAsync: updateProfileMutate, isPending: false })
     useUploadAvatar.mockReturnValue({ mutateAsync: uploadAvatarMutate, isPending: false })
     useDeleteAvatar.mockReturnValue({ mutateAsync: deleteAvatarMutate, isPending: false })
+    useSetLeaderboardVisibility.mockReturnValue({ mutateAsync: setVisibilityMutate, isPending: false })
     useUserReports.mockReturnValue({ data: [SAMPLE_REPORT], isPending: false, isError: false })
     useUpdateReport.mockReturnValue({ mutateAsync: updateReportMutate, isPending: false })
     useDeleteReport.mockReturnValue({ mutateAsync: deleteReportMutate, isPending: false })
@@ -112,6 +123,56 @@ describe('ProfilePage', () => {
     expect(screen.getByText('3')).toBeInTheDocument()
     expect(screen.getByText('1')).toBeInTheDocument()
     expect(screen.getByText('Mathematician.')).toBeInTheDocument()
+  })
+
+  describe('gamification', () => {
+    it('renders points, rank, and badge for the current user', () => {
+      renderPage()
+      expect(screen.getByText('245')).toBeInTheDocument()
+      expect(screen.getByText('#12')).toBeInTheDocument()
+      // Badge chip uses the human-readable label, not the enum value.
+      expect(screen.getByText('Trusted Reporter')).toBeInTheDocument()
+    })
+
+    it('shows "Hidden" rank when the user has opted out', () => {
+      useCurrentUser.mockReturnValue({
+        data: { ...SAMPLE_USER, rank: null, leaderboardHidden: true },
+        isPending: false,
+        isError: false,
+      })
+      renderPage()
+      expect(screen.getByText('Hidden')).toBeInTheDocument()
+    })
+
+    it('shows "—" rank when the user has no rank yet (e.g. fresh account)', () => {
+      useCurrentUser.mockReturnValue({
+        data: { ...SAMPLE_USER, rank: null, leaderboardHidden: false },
+        isPending: false,
+        isError: false,
+      })
+      renderPage()
+      expect(screen.getByText('—')).toBeInTheDocument()
+    })
+
+    it('omits the badges section when no badges are held', () => {
+      useCurrentUser.mockReturnValue({
+        data: { ...SAMPLE_USER, badges: [], topBadge: null },
+        isPending: false,
+        isError: false,
+      })
+      renderPage()
+      expect(screen.queryByRole('heading', { name: /^badges$/i })).not.toBeInTheDocument()
+    })
+
+    it('toggles leaderboard visibility and shows a confirmation toast', async () => {
+      const user = userEvent.setup()
+      setVisibilityMutate.mockResolvedValueOnce({ ...SAMPLE_USER, leaderboardHidden: true })
+      renderPage()
+      const checkbox = screen.getByRole('checkbox', { name: /hide me from the public leaderboard/i })
+      await user.click(checkbox)
+      expect(setVisibilityMutate).toHaveBeenCalledWith(true)
+      expect(await screen.findByText(/hidden from the public leaderboard/i)).toBeInTheDocument()
+    })
   })
 
   describe('edit profile', () => {

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom'
 import Navbar from '../components/Navbar.jsx'
+import BadgeList from '../components/BadgeList.jsx'
 import MyReportsSection from '../components/MyReportsSection.jsx'
 import { useUserProfile } from '../hooks/useUserProfile.js'
 
@@ -69,7 +70,20 @@ function UserProfilePage() {
             <section className="flex gap-3 flex-wrap">
               <StatTile label="Reports submitted" value={user.contributionStats?.reportsSubmitted ?? 0} />
               <StatTile label="Routes planned" value={user.contributionStats?.routesPlanned ?? 0} />
+              <StatTile label="Points" value={user.points ?? 0} />
+              {/* Rank is omitted entirely when the user has opted out, instead
+                  of showing "Hidden" — that detail is private to the owner. */}
+              {!user.leaderboardHidden && user.rank != null && (
+                <StatTile label="Rank" value={`#${user.rank}`} />
+              )}
             </section>
+
+            {user.badges && user.badges.length > 0 && (
+              <section className="bg-white rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+                <h2 className="text-xl font-bold font-headline text-on-surface">Badges</h2>
+                <BadgeList badges={user.badges} />
+              </section>
+            )}
 
             <section className="bg-white rounded-2xl shadow-sm p-6 flex flex-col gap-4">
               <h2 className="text-xl font-bold font-headline text-on-surface">About</h2>

--- a/frontend/src/pages/UserProfilePage.test.jsx
+++ b/frontend/src/pages/UserProfilePage.test.jsx
@@ -28,6 +28,11 @@ const SAMPLE_USER = {
   avatarUrl: null,
   role: 'USER',
   contributionStats: { reportsSubmitted: 5, routesPlanned: 2 },
+  points: 320,
+  rank: 4,
+  badges: ['TRUSTED_REPORTER', 'TOP_10'],
+  topBadge: 'TOP_10',
+  leaderboardHidden: false,
 }
 
 function renderPage(userId = '42') {
@@ -88,5 +93,46 @@ describe('UserProfilePage', () => {
     renderPage()
     expect(screen.getByText(/^reports \(0\)$/i)).toBeInTheDocument()
     expect(screen.queryByText(/my reports/i)).not.toBeInTheDocument()
+  })
+
+  describe('gamification', () => {
+    it('renders points, rank, and badges for a public profile', () => {
+      renderPage()
+      expect(screen.getByText('320')).toBeInTheDocument()
+      expect(screen.getByText('#4')).toBeInTheDocument()
+      // Both badges show their human-readable labels.
+      expect(screen.getByText('Trusted Reporter')).toBeInTheDocument()
+      expect(screen.getByText('Top 10')).toBeInTheDocument()
+    })
+
+    it('omits the rank tile entirely when the viewed user has opted out', () => {
+      // A foreign profile must not leak even the existence of a rank for an
+      // opt-out user — the owner of the profile sees their own rank as
+      // "Hidden" but other viewers see no tile at all.
+      useUserProfile.mockReturnValue({
+        data: { ...SAMPLE_USER, rank: null, leaderboardHidden: true },
+        isPending: false,
+        isError: false,
+      })
+      renderPage()
+      expect(screen.queryByText('Rank')).not.toBeInTheDocument()
+      expect(screen.queryByText('Hidden')).not.toBeInTheDocument()
+    })
+
+    it('omits the badges section when the viewed user has none', () => {
+      useUserProfile.mockReturnValue({
+        data: { ...SAMPLE_USER, badges: [], topBadge: null },
+        isPending: false,
+        isError: false,
+      })
+      renderPage()
+      expect(screen.queryByRole('heading', { name: /^badges$/i })).not.toBeInTheDocument()
+    })
+
+    it('does not render an opt-out toggle on a foreign profile', () => {
+      // Visibility toggle is the owner's privilege — never visible elsewhere.
+      renderPage()
+      expect(screen.queryByRole('checkbox', { name: /hide me/i })).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -43,3 +43,27 @@ export async function deleteAvatar(id, token) {
     headers: authHeaders(token),
   })
 }
+
+// ───── Gamification ──────────────────────────────────────────────────────
+
+// Public — no token needed. Anonymous callers can view a user's badges.
+export async function getBadges(id) {
+  return apiFetch(`/api/users/${id}/badges`)
+}
+
+// Caller-only opt-out toggle. Body: { leaderboardHidden: boolean }.
+export async function setLeaderboardVisibility(token, leaderboardHidden) {
+  return apiFetch('/api/users/me/leaderboard-visibility', {
+    method: 'PATCH',
+    headers: authHeaders(token),
+    body: JSON.stringify({ leaderboardHidden }),
+  })
+}
+
+// Owner/admin — paginated points-history ledger view.
+export async function getPointsHistory(id, token, { page = 0, size = 20 } = {}) {
+  const params = new URLSearchParams({ page: String(page), size: String(size) })
+  return apiFetch(`/api/users/${id}/points/history?${params}`, {
+    headers: authHeaders(token),
+  })
+}


### PR DESCRIPTION
# 📝 Description
Final backend slice of the gamification rollout. Builds on the foundation #491, wiring #492, and leaderboard service #494 to expose the public API the frontend will consume:

- `BADGE_AWARDED` notification type and `NotificationService.notifyBadgeAwarded` helper. Fired from `GamificationService` on every milestone badge (Trusted Reporter, Expert Mapper) and from `LeaderboardService.onPointsChanged` on every TOP_10 newcomer. TOP_10 revoke stays silent.
- `UserProfileDTO` gains `points`, `rank`, `badges`, `topBadge`, and `leaderboardHidden`. List views (`getAllProfiles`) batch-fetch badges in a single query and intentionally leave `rank` null — listing UIs only need points.
- `ReportResponse.authorTopBadge` — surfaces the highest-tier badge next to the author chip on report panels. Multi-report paths use a batched `findBadgesByUserIds` query so the feed stays N+1-free.
- New endpoints:
  - `GET /api/leaderboard` (public) — top-100 entries plus the caller's rank when authenticated.
  - `GET /api/users/{id}/badges` (public) — badges held by a user.
  - `GET /api/users/{id}/points/history` (owner / admin) — paginated ledger view.
  - `PATCH /api/users/me/leaderboard-visibility` (auth) — opt-out toggle.
- `SecurityConfig` permitAll for the two public GET paths.
- 22 new tests across 7 suites, covering badge tier ordering, milestone notifications, top-10 churn, profile DTO enrichment, report author top badge, and the leaderboard controller end-to-end (MockMvc).
- V3 Flyway migration drops the legacy `notifications.type` CHECK
  constraint that didn't extend to cover the new BADGE_AWARDED value
  (same drop-only pattern as V2).

The frontend wiring (profile page badges, leaderboard view, badge notifications) lands in subsequent PRs.


# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A — backend API surface, no user-visible behaviour yet (UI lands in PR-5/6/7).

# ⏱️ Estimated Review Time
- [x] > 15 min
