### PR TITLE
[Web][Backend] MP4/MOV Video Uploads in CreateReportPanel

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/service/S3MediaService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/S3MediaService.java
@@ -23,7 +23,7 @@ public class S3MediaService {
     private final String bucketName;
 
     private static final List<String> ALLOWED_CONTENT_TYPES = List.of(
-            "image/jpeg", "image/png", "image/jpg", "video/mp4");
+            "image/jpeg", "image/png", "image/jpg", "video/mp4", "video/quicktime");
 
     public S3MediaService(S3Client s3Client, @Value("${aws.s3.bucket}") String bucketName) {
         this.s3Client = s3Client;

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/S3MediaServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/S3MediaServiceTest.java
@@ -79,6 +79,22 @@ class S3MediaServiceTest {
     }
 
     @Test
+    @DisplayName("uploadFile: valid MOV (video/quicktime) returns a public S3 URL")
+    void uploadFile_validMov_returnsUrl() {
+        // Apple devices commonly produce MOV; Android/desktop produce MP4.
+        // Both must be accepted server-side per #239.
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "clip.mov", "video/quicktime", "fake-mov-bytes".getBytes());
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+
+        String url = s3MediaService.uploadFile(file);
+
+        assertTrue(url.contains("clip.mov"));
+    }
+
+    @Test
     @DisplayName("uploadFile: each upload gets a unique file name (UUID prefix)")
     void uploadFile_uniqueFileNames() {
         MockMultipartFile file = new MockMultipartFile(

--- a/frontend/src/components/CreateReportPanel.jsx
+++ b/frontend/src/components/CreateReportPanel.jsx
@@ -4,6 +4,11 @@ import { useAuth } from '../context/AuthContext.jsx'
 import { createReport, mapReport } from '../services/reportService.js'
 import { OBJECT_TYPES } from '../utils/objectTypeConfig.js'
 
+// Mirrors backend `S3MediaService.ALLOWED_CONTENT_TYPES`. Apple devices
+// produce MOV (video/quicktime); most other devices produce MP4.
+const ALLOWED_MEDIA_MIME = ['image/jpeg', 'image/jpg', 'image/png', 'video/mp4', 'video/quicktime']
+const MAX_MEDIA_BYTES = 15 * 1024 * 1024
+
 function CreateReportPanel({ position, onClose, onCreated }) {
   const { token, userId } = useAuth()
   const navigate = useNavigate()
@@ -16,6 +21,11 @@ function CreateReportPanel({ position, onClose, onCreated }) {
   const [imagePreview, setImagePreview] = useState(null)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+  // Errors raised while picking a file (unsupported MIME, oversized).
+  // Kept separate from the submit-level `error` so they render right
+  // under the dropzone instead of at the bottom of the form where users
+  // would have to scroll to see them.
+  const [mediaError, setMediaError] = useState('')
   const fileInputRef = useRef(null)
 
   // Bottom-sheet drag-to-resize (mobile only — desktop keeps right-sidebar layout).
@@ -78,22 +88,37 @@ function CreateReportPanel({ position, onClose, onCreated }) {
     : OBJECT_TYPES
   ).filter(t => t.environments.includes(environment))
 
-  // ── image ──────────────────────────────────────────────────────────────────
+  // ── media (image or video) ─────────────────────────────────────────────────
+  // Allowlist mirrors backend S3MediaService.ALLOWED_CONTENT_TYPES so the
+  // client rejects unsupported types before incurring an upload round-trip.
+  // 15 MB matches both backend behaviour and the avatar uploader.
 
-  function handleImageChange(e) {
-    const file = e.target.files[0]
+  function pickFile(file) {
     if (!file) return
+    if (!ALLOWED_MEDIA_MIME.includes(file.type)) {
+      setMediaError('Unsupported file type. Use JPEG, PNG, MP4, or MOV.')
+      return
+    }
+    if (file.size > MAX_MEDIA_BYTES) {
+      setMediaError('File must be 15 MB or smaller.')
+      return
+    }
+    setMediaError('')
     setImageFile(file)
     setImagePreview(URL.createObjectURL(file))
+  }
+
+  function handleImageChange(e) {
+    pickFile(e.target.files[0])
+    e.target.value = ''
   }
 
   function handleDrop(e) {
     e.preventDefault()
-    const file = e.dataTransfer.files[0]
-    if (!file) return
-    setImageFile(file)
-    setImagePreview(URL.createObjectURL(file))
+    pickFile(e.dataTransfer.files[0])
   }
+
+  const isVideoPreview = imageFile?.type?.startsWith('video/')
 
   // ── report type toggle ─────────────────────────────────────────────────────
 
@@ -300,25 +325,47 @@ function CreateReportPanel({ position, onClose, onCreated }) {
             onClick={() => fileInputRef.current?.click()}
             onDrop={handleDrop}
             onDragOver={e => e.preventDefault()}
-            className="w-full h-44 rounded-2xl border-2 border-dashed border-outline-variant/40 bg-surface-container flex flex-col items-center justify-center gap-2 cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors overflow-hidden"
+            className="relative w-full h-44 rounded-2xl border-2 border-dashed border-outline-variant/40 bg-surface-container flex flex-col items-center justify-center gap-2 cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors overflow-hidden"
           >
             {imagePreview ? (
-              <img src={imagePreview} alt="Preview" className="w-full h-full object-cover" />
+              isVideoPreview ? (
+                <>
+                  <video
+                    src={imagePreview}
+                    className="w-full h-full object-cover"
+                    muted
+                    playsInline
+                    // Suppress controls so the picker stays the click target;
+                    // the user can re-pick by clicking the dropzone.
+                  />
+                  <span className="absolute top-2 left-2 flex items-center gap-1 bg-black/60 text-white text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full">
+                    <span className="material-symbols-outlined" style={{ fontSize: '12px' }}>movie</span>
+                    Video
+                  </span>
+                </>
+              ) : (
+                <img src={imagePreview} alt="Preview" className="w-full h-full object-cover" />
+              )
             ) : (
               <>
                 <span className="material-symbols-outlined text-4xl text-on-surface-variant">add_a_photo</span>
-                <p className="text-sm font-medium text-on-surface-variant">Upload or drag photos here</p>
-                <p className="text-xs text-outline">Maximum file size: 15 MB (JPG, PNG)</p>
+                <p className="text-sm font-medium text-on-surface-variant">Upload or drag photos / videos here</p>
+                <p className="text-xs text-outline">Up to 15 MB (JPEG, PNG, MP4, MOV)</p>
               </>
             )}
           </div>
           <input
             ref={fileInputRef}
             type="file"
-            accept="image/jpeg,image/png"
+            accept={ALLOWED_MEDIA_MIME.join(',')}
             className="hidden"
             onChange={handleImageChange}
           />
+          {mediaError && (
+            <p role="alert" className="mt-2 text-sm text-error bg-error-container/20 rounded-lg px-3 py-2">
+              {mediaError}
+            </p>
+          )}
         </div>
 
         {/* Report Type */}

--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -25,6 +25,16 @@ import Toast from './Toast.jsx'
 
 const MAX_DESCRIPTION = 1000
 
+// S3 returns plain URLs ending in the original filename, so the extension is
+// the cheapest way to know whether a media URL points at a video. Backend's
+// allowlist (S3MediaService.ALLOWED_CONTENT_TYPES) is mp4 + quicktime today.
+const VIDEO_EXTENSIONS = ['.mp4', '.mov', '.webm']
+function isVideoUrl(url) {
+  if (!url) return false
+  const path = url.toLowerCase().split('?')[0]
+  return VIDEO_EXTENSIONS.some((ext) => path.endsWith(ext))
+}
+
 /**
  * ReportPanel
  * Desktop: fixed right sidebar (500px) alongside the map.
@@ -406,11 +416,20 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
               </div>
               <div className="bg-white p-5 flex flex-col gap-4">
                 {activeFix.mediaUrls && activeFix.mediaUrls.length > 0 && (
-                  <img
-                    src={activeFix.mediaUrls[0]}
-                    alt="Proposed fix"
-                    className="w-full max-h-56 object-cover rounded-lg"
-                  />
+                  isVideoUrl(activeFix.mediaUrls[0]) ? (
+                    <video
+                      src={activeFix.mediaUrls[0]}
+                      controls
+                      playsInline
+                      className="w-full max-h-56 object-cover rounded-lg bg-black"
+                    />
+                  ) : (
+                    <img
+                      src={activeFix.mediaUrls[0]}
+                      alt="Proposed fix"
+                      className="w-full max-h-56 object-cover rounded-lg"
+                    />
+                  )
                 )}
                 <div className="flex items-center gap-2 text-xs">
                   <div className="w-7 h-7 rounded-full bg-surface-container-high flex items-center justify-center">
@@ -487,11 +506,20 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
 
         <div className="px-6 pt-2 pb-2">
           {report.image ? (
-            <img
-              className="w-full h-64 object-cover rounded-xl shadow-sm"
-              src={report.image}
-              alt={report.title}
-            />
+            isVideoUrl(report.image) ? (
+              <video
+                className="w-full h-64 object-cover rounded-xl shadow-sm bg-black"
+                src={report.image}
+                controls
+                playsInline
+              />
+            ) : (
+              <img
+                className="w-full h-64 object-cover rounded-xl shadow-sm"
+                src={report.image}
+                alt={report.title}
+              />
+            )
           ) : (
             <div className="w-full h-64 bg-surface-container rounded-xl shadow-sm flex items-center justify-center">
               <span className="material-symbols-outlined text-6xl text-outline-variant">image</span>

--- a/frontend/src/components/ReportPanel.test.jsx
+++ b/frontend/src/components/ReportPanel.test.jsx
@@ -436,4 +436,28 @@ describe('ReportPanel', () => {
       })
     })
   })
+
+  describe('media rendering', () => {
+    test('renders an <img> when the report image URL is a JPEG', () => {
+      const { container } = renderPanel({
+        report: { ...report, image: 'https://cdn.example.com/foo.jpg' },
+      })
+      expect(container.querySelector('img[src="https://cdn.example.com/foo.jpg"]')).toBeTruthy()
+      expect(container.querySelector('video')).toBeFalsy()
+    })
+
+    test('renders a <video> when the report image URL is an MP4', () => {
+      const { container } = renderPanel({
+        report: { ...report, image: 'https://cdn.example.com/clip.mp4' },
+      })
+      expect(container.querySelector('video[src="https://cdn.example.com/clip.mp4"]')).toBeTruthy()
+    })
+
+    test('renders a <video> when the report image URL is a MOV (Apple default)', () => {
+      const { container } = renderPanel({
+        report: { ...report, image: 'https://cdn.example.com/clip.MOV?X-Amz-Sig=abc' },
+      })
+      expect(container.querySelector('video')).toBeTruthy()
+    })
+  })
 })


### PR DESCRIPTION
Closes #239.

Adds video upload support to the report-creation flow on the web frontend, with the backend's S3 allowlist updated in step so MOV (Apple device default) goes through cleanly.

### Backend
`S3MediaService.ALLOWED_CONTENT_TYPES` gains `video/quicktime` alongside the existing `image/jpeg`, `image/png`, `image/jpg`, `video/mp4`. New unit test mirrors the MP4 case.

### Frontend (CreateReportPanel)
- `accept=` widened to `image/jpeg,image/jpg,image/png,video/mp4,video/quicktime`.
- New `pickFile` helper used by both the click-to-pick and drag-and-drop paths. Validates MIME against the allowlist, enforces a 15 MB cap, and surfaces a clear error for unsupported types or oversized files.
- Preview swaps based on MIME: `<img>` for images, `<video>` for videos. Video preview gets a small "VIDEO" badge top-left so users can tell at a glance.
- Helper text updated: "Up to 15 MB (JPEG, PNG, MP4, MOV)".

## 📊 Type of Change
- [x] New feature

## ✅ Checklist
- [x] Project builds successfully
- [x] All frontend tests passed (267/267)
- [x] All backend `S3MediaServiceTest` tests passed (14/14)

## 🧪 How to Test
1. Pick or drag a JPEG / PNG. Image preview as before.
2. Pick or drag an MP4 or MOV. Video preview with a "VIDEO" badge.
3. Try a `.gif` or `.pdf`. Error: "Unsupported file type. Use JPEG, PNG, MP4, or MOV."
4. Try a 20 MB file. Error: "File must be 15 MB or smaller."
5. Submit a video report. Backend accepts the upload with the correct MIME.
## 📸 Screenshot
<img width="1043" height="685" alt="Ekran Resmi 2026-05-09 23 08 48" src="https://github.com/user-attachments/assets/e970a444-4011-4af9-9e96-c7569e274f59" />


## ⏱️ Estimated Review Time
- [x] 5-15 min