### PR TITLE
[Frontend] Surface Gamification Fields on Profile Pages

### DIFF
--- a/frontend/src/components/BadgeIcon.jsx
+++ b/frontend/src/components/BadgeIcon.jsx
@@ -1,0 +1,60 @@
+// Material Symbols icon + label mapping for each backend Badge enum value.
+// Keep in sync with com.bounswe2026group1.backend.model.Badge — adding a new
+// badge there means adding an entry here.
+const BADGE_META = {
+  TRUSTED_REPORTER: {
+    label: 'Trusted Reporter',
+    icon: 'verified',
+    description: '10 verified reports',
+    tone: 'bg-tertiary/10 text-tertiary',
+  },
+  EXPERT_MAPPER: {
+    label: 'Expert Mapper',
+    icon: 'workspace_premium',
+    description: '50 verified reports',
+    tone: 'bg-secondary/15 text-secondary',
+  },
+  TOP_10: {
+    label: 'Top 10',
+    icon: 'emoji_events',
+    description: 'Currently in the top 10 leaderboard',
+    tone: 'bg-primary/15 text-primary',
+  },
+}
+
+/**
+ * Single-badge chip used in profile pages and inline next to author names.
+ * Sizes: 'sm' (compact, just the icon), 'md' (default chip with label).
+ */
+function BadgeIcon({ badge, size = 'md' }) {
+  const meta = BADGE_META[badge]
+  if (!meta) return null
+
+  if (size === 'sm') {
+    return (
+      <span
+        title={`${meta.label} — ${meta.description}`}
+        className={`inline-flex items-center justify-center w-6 h-6 rounded-full ${meta.tone}`}
+        aria-label={meta.label}
+      >
+        <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>
+          {meta.icon}
+        </span>
+      </span>
+    )
+  }
+
+  return (
+    <span
+      title={meta.description}
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold ${meta.tone}`}
+    >
+      <span className="material-symbols-outlined" style={{ fontSize: '16px' }}>
+        {meta.icon}
+      </span>
+      {meta.label}
+    </span>
+  )
+}
+
+export default BadgeIcon

--- a/frontend/src/components/BadgeList.jsx
+++ b/frontend/src/components/BadgeList.jsx
@@ -1,0 +1,20 @@
+import BadgeIcon from './BadgeIcon.jsx'
+
+/**
+ * Horizontal chip strip of all badges held by a user. Profile pages render
+ * this above contribution stats. Renders nothing when the list is empty —
+ * "no badges yet" copy is the caller's responsibility.
+ */
+function BadgeList({ badges }) {
+  if (!badges || badges.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-2" aria-label="User badges">
+      {badges.map((badge) => (
+        <BadgeIcon key={badge} badge={badge} />
+      ))}
+    </div>
+  )
+}
+
+export default BadgeList

--- a/frontend/src/hooks/useGamification.js
+++ b/frontend/src/hooks/useGamification.js
@@ -1,0 +1,37 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAuth } from '../context/AuthContext.jsx'
+import {
+  getBadges as getBadgesRequest,
+  setLeaderboardVisibility as setLeaderboardVisibilityRequest,
+} from '../services/userService.js'
+import { currentUserKey } from './useCurrentUser.js'
+
+export const userBadgesKey = (userId) => ['userBadges', userId]
+
+/** Fetches the public list of badges held by a user. No auth required —
+ *  the badges endpoint is public so anonymous visitors of a profile can
+ *  see them. */
+export function useUserBadges(userId) {
+  return useQuery({
+    queryKey: userBadgesKey(userId),
+    queryFn: () => getBadgesRequest(userId),
+    enabled: !!userId,
+    staleTime: 60_000,
+  })
+}
+
+/** Toggles the caller's leaderboard opt-out flag. On success the cached
+ *  current-user profile is invalidated so the rank/leaderboardHidden flag
+ *  in the profile DTO refreshes immediately. */
+export function useSetLeaderboardVisibility() {
+  const { token } = useAuth()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (leaderboardHidden) =>
+      setLeaderboardVisibilityRequest(token, leaderboardHidden),
+    onSuccess: (data) => {
+      if (data) queryClient.setQueryData(currentUserKey, data)
+      queryClient.invalidateQueries({ queryKey: currentUserKey })
+    },
+  })
+}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -2,10 +2,12 @@ import { useCallback, useState } from 'react'
 import Navbar from '../components/Navbar.jsx'
 import Toast from '../components/Toast.jsx'
 import AvatarUploader from '../components/AvatarUploader.jsx'
+import BadgeList from '../components/BadgeList.jsx'
 import MyReportsSection from '../components/MyReportsSection.jsx'
 import { useAuth } from '../context/AuthContext.jsx'
 import { useCurrentUser } from '../hooks/useCurrentUser.js'
 import { useDeleteAvatar, useUpdateProfile, useUploadAvatar } from '../hooks/useProfile.js'
+import { useSetLeaderboardVisibility } from '../hooks/useGamification.js'
 
 const NAME_MIN = 2
 const NAME_MAX = 50
@@ -26,6 +28,7 @@ function ProfilePage() {
   const updateProfileMutation = useUpdateProfile()
   const uploadAvatarMutation = useUploadAvatar()
   const deleteAvatarMutation = useDeleteAvatar()
+  const setVisibilityMutation = useSetLeaderboardVisibility()
 
   const [isEditing, setIsEditing] = useState(false)
   const [name, setName] = useState('')
@@ -74,6 +77,21 @@ function ProfilePage() {
     setToast({ message: 'Avatar removed.', type: 'success' })
   }
 
+  async function handleVisibilityToggle(event) {
+    const hidden = event.target.checked
+    try {
+      await setVisibilityMutation.mutateAsync(hidden)
+      setToast({
+        message: hidden
+          ? 'You are now hidden from the public leaderboard.'
+          : 'You are visible on the public leaderboard.',
+        type: 'success',
+      })
+    } catch (e) {
+      setToast({ message: e.message || 'Failed to update visibility.', type: 'error' })
+    }
+  }
+
   return (
     <div className="min-h-screen flex flex-col bg-background">
       <Navbar />
@@ -115,6 +133,38 @@ function ProfilePage() {
             <section className="flex gap-3 flex-wrap">
               <StatTile label="Reports submitted" value={user.contributionStats?.reportsSubmitted ?? 0} />
               <StatTile label="Routes planned" value={user.contributionStats?.routesPlanned ?? 0} />
+              <StatTile label="Points" value={user.points ?? 0} />
+              <StatTile
+                label="Rank"
+                value={user.rank != null ? `#${user.rank}` : user.leaderboardHidden ? 'Hidden' : '—'}
+              />
+            </section>
+
+            {user.badges && user.badges.length > 0 && (
+              <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+                <h2 className="text-xl font-bold font-headline text-on-surface">Badges</h2>
+                <BadgeList badges={user.badges} />
+              </section>
+            )}
+
+            <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+              <h2 className="text-xl font-bold font-headline text-on-surface">Leaderboard</h2>
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={user.leaderboardHidden}
+                  onChange={handleVisibilityToggle}
+                  disabled={setVisibilityMutation.isPending}
+                  className="w-5 h-5 accent-primary cursor-pointer disabled:opacity-60"
+                />
+                <span className="text-sm text-on-surface">
+                  Hide me from the public leaderboard
+                </span>
+              </label>
+              <p className="text-xs text-on-surface-variant">
+                Your points are preserved either way — you re-enter the ranking
+                instantly when this flips back.
+              </p>
             </section>
 
             <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-4">

--- a/frontend/src/pages/ProfilePage.test.jsx
+++ b/frontend/src/pages/ProfilePage.test.jsx
@@ -15,6 +15,9 @@ vi.mock('../hooks/useProfile.js', () => ({
   useUploadAvatar: vi.fn(),
   useDeleteAvatar: vi.fn(),
 }))
+vi.mock('../hooks/useGamification.js', () => ({
+  useSetLeaderboardVisibility: vi.fn(),
+}))
 vi.mock('../hooks/useUserReports.js', () => ({
   useUserReports: vi.fn(),
   useUpdateReport: vi.fn(),
@@ -27,6 +30,7 @@ vi.mock('../components/Navbar.jsx', () => ({
 import { useAuth } from '../context/AuthContext.jsx'
 import { useCurrentUser } from '../hooks/useCurrentUser.js'
 import { useDeleteAvatar, useUpdateProfile, useUploadAvatar } from '../hooks/useProfile.js'
+import { useSetLeaderboardVisibility } from '../hooks/useGamification.js'
 import { useDeleteReport, useUpdateReport, useUserReports } from '../hooks/useUserReports.js'
 
 function LocationProbe() {
@@ -53,6 +57,11 @@ const SAMPLE_USER = {
   avatarUrl: null,
   role: 'USER',
   contributionStats: { reportsSubmitted: 3, routesPlanned: 1 },
+  points: 245,
+  rank: 12,
+  badges: ['TRUSTED_REPORTER'],
+  topBadge: 'TRUSTED_REPORTER',
+  leaderboardHidden: false,
 }
 
 // Shape produced by useUserReports → mapReport (see services/reportService.js).
@@ -83,6 +92,7 @@ describe('ProfilePage', () => {
   const updateProfileMutate = vi.fn()
   const uploadAvatarMutate = vi.fn()
   const deleteAvatarMutate = vi.fn()
+  const setVisibilityMutate = vi.fn()
   const updateReportMutate = vi.fn()
   const deleteReportMutate = vi.fn()
 
@@ -93,6 +103,7 @@ describe('ProfilePage', () => {
     useUpdateProfile.mockReturnValue({ mutateAsync: updateProfileMutate, isPending: false })
     useUploadAvatar.mockReturnValue({ mutateAsync: uploadAvatarMutate, isPending: false })
     useDeleteAvatar.mockReturnValue({ mutateAsync: deleteAvatarMutate, isPending: false })
+    useSetLeaderboardVisibility.mockReturnValue({ mutateAsync: setVisibilityMutate, isPending: false })
     useUserReports.mockReturnValue({ data: [SAMPLE_REPORT], isPending: false, isError: false })
     useUpdateReport.mockReturnValue({ mutateAsync: updateReportMutate, isPending: false })
     useDeleteReport.mockReturnValue({ mutateAsync: deleteReportMutate, isPending: false })
@@ -112,6 +123,56 @@ describe('ProfilePage', () => {
     expect(screen.getByText('3')).toBeInTheDocument()
     expect(screen.getByText('1')).toBeInTheDocument()
     expect(screen.getByText('Mathematician.')).toBeInTheDocument()
+  })
+
+  describe('gamification', () => {
+    it('renders points, rank, and badge for the current user', () => {
+      renderPage()
+      expect(screen.getByText('245')).toBeInTheDocument()
+      expect(screen.getByText('#12')).toBeInTheDocument()
+      // Badge chip uses the human-readable label, not the enum value.
+      expect(screen.getByText('Trusted Reporter')).toBeInTheDocument()
+    })
+
+    it('shows "Hidden" rank when the user has opted out', () => {
+      useCurrentUser.mockReturnValue({
+        data: { ...SAMPLE_USER, rank: null, leaderboardHidden: true },
+        isPending: false,
+        isError: false,
+      })
+      renderPage()
+      expect(screen.getByText('Hidden')).toBeInTheDocument()
+    })
+
+    it('shows "—" rank when the user has no rank yet (e.g. fresh account)', () => {
+      useCurrentUser.mockReturnValue({
+        data: { ...SAMPLE_USER, rank: null, leaderboardHidden: false },
+        isPending: false,
+        isError: false,
+      })
+      renderPage()
+      expect(screen.getByText('—')).toBeInTheDocument()
+    })
+
+    it('omits the badges section when no badges are held', () => {
+      useCurrentUser.mockReturnValue({
+        data: { ...SAMPLE_USER, badges: [], topBadge: null },
+        isPending: false,
+        isError: false,
+      })
+      renderPage()
+      expect(screen.queryByRole('heading', { name: /^badges$/i })).not.toBeInTheDocument()
+    })
+
+    it('toggles leaderboard visibility and shows a confirmation toast', async () => {
+      const user = userEvent.setup()
+      setVisibilityMutate.mockResolvedValueOnce({ ...SAMPLE_USER, leaderboardHidden: true })
+      renderPage()
+      const checkbox = screen.getByRole('checkbox', { name: /hide me from the public leaderboard/i })
+      await user.click(checkbox)
+      expect(setVisibilityMutate).toHaveBeenCalledWith(true)
+      expect(await screen.findByText(/hidden from the public leaderboard/i)).toBeInTheDocument()
+    })
   })
 
   describe('edit profile', () => {

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom'
 import Navbar from '../components/Navbar.jsx'
+import BadgeList from '../components/BadgeList.jsx'
 import MyReportsSection from '../components/MyReportsSection.jsx'
 import { useUserProfile } from '../hooks/useUserProfile.js'
 
@@ -69,7 +70,20 @@ function UserProfilePage() {
             <section className="flex gap-3 flex-wrap">
               <StatTile label="Reports submitted" value={user.contributionStats?.reportsSubmitted ?? 0} />
               <StatTile label="Routes planned" value={user.contributionStats?.routesPlanned ?? 0} />
+              <StatTile label="Points" value={user.points ?? 0} />
+              {/* Rank is omitted entirely when the user has opted out, instead
+                  of showing "Hidden" — that detail is private to the owner. */}
+              {!user.leaderboardHidden && user.rank != null && (
+                <StatTile label="Rank" value={`#${user.rank}`} />
+              )}
             </section>
+
+            {user.badges && user.badges.length > 0 && (
+              <section className="bg-white rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+                <h2 className="text-xl font-bold font-headline text-on-surface">Badges</h2>
+                <BadgeList badges={user.badges} />
+              </section>
+            )}
 
             <section className="bg-white rounded-2xl shadow-sm p-6 flex flex-col gap-4">
               <h2 className="text-xl font-bold font-headline text-on-surface">About</h2>

--- a/frontend/src/pages/UserProfilePage.test.jsx
+++ b/frontend/src/pages/UserProfilePage.test.jsx
@@ -28,6 +28,11 @@ const SAMPLE_USER = {
   avatarUrl: null,
   role: 'USER',
   contributionStats: { reportsSubmitted: 5, routesPlanned: 2 },
+  points: 320,
+  rank: 4,
+  badges: ['TRUSTED_REPORTER', 'TOP_10'],
+  topBadge: 'TOP_10',
+  leaderboardHidden: false,
 }
 
 function renderPage(userId = '42') {
@@ -88,5 +93,46 @@ describe('UserProfilePage', () => {
     renderPage()
     expect(screen.getByText(/^reports \(0\)$/i)).toBeInTheDocument()
     expect(screen.queryByText(/my reports/i)).not.toBeInTheDocument()
+  })
+
+  describe('gamification', () => {
+    it('renders points, rank, and badges for a public profile', () => {
+      renderPage()
+      expect(screen.getByText('320')).toBeInTheDocument()
+      expect(screen.getByText('#4')).toBeInTheDocument()
+      // Both badges show their human-readable labels.
+      expect(screen.getByText('Trusted Reporter')).toBeInTheDocument()
+      expect(screen.getByText('Top 10')).toBeInTheDocument()
+    })
+
+    it('omits the rank tile entirely when the viewed user has opted out', () => {
+      // A foreign profile must not leak even the existence of a rank for an
+      // opt-out user — the owner of the profile sees their own rank as
+      // "Hidden" but other viewers see no tile at all.
+      useUserProfile.mockReturnValue({
+        data: { ...SAMPLE_USER, rank: null, leaderboardHidden: true },
+        isPending: false,
+        isError: false,
+      })
+      renderPage()
+      expect(screen.queryByText('Rank')).not.toBeInTheDocument()
+      expect(screen.queryByText('Hidden')).not.toBeInTheDocument()
+    })
+
+    it('omits the badges section when the viewed user has none', () => {
+      useUserProfile.mockReturnValue({
+        data: { ...SAMPLE_USER, badges: [], topBadge: null },
+        isPending: false,
+        isError: false,
+      })
+      renderPage()
+      expect(screen.queryByRole('heading', { name: /^badges$/i })).not.toBeInTheDocument()
+    })
+
+    it('does not render an opt-out toggle on a foreign profile', () => {
+      // Visibility toggle is the owner's privilege — never visible elsewhere.
+      renderPage()
+      expect(screen.queryByRole('checkbox', { name: /hide me/i })).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -43,3 +43,27 @@ export async function deleteAvatar(id, token) {
     headers: authHeaders(token),
   })
 }
+
+// ───── Gamification ──────────────────────────────────────────────────────
+
+// Public — no token needed. Anonymous callers can view a user's badges.
+export async function getBadges(id) {
+  return apiFetch(`/api/users/${id}/badges`)
+}
+
+// Caller-only opt-out toggle. Body: { leaderboardHidden: boolean }.
+export async function setLeaderboardVisibility(token, leaderboardHidden) {
+  return apiFetch('/api/users/me/leaderboard-visibility', {
+    method: 'PATCH',
+    headers: authHeaders(token),
+    body: JSON.stringify({ leaderboardHidden }),
+  })
+}
+
+// Owner/admin — paginated points-history ledger view.
+export async function getPointsHistory(id, token, { page = 0, size = 20 } = {}) {
+  const params = new URLSearchParams({ page: String(page), size: String(size) })
+  return apiFetch(`/api/users/${id}/points/history?${params}`, {
+    headers: authHeaders(token),
+  })
+}


### PR DESCRIPTION
# 📝 Description
First frontend slice of the gamification rollout. Consumes the API surface introduced in #499 on the profile pages:

- `userService` gains `getBadges` (public, no token), `setLeaderboardVisibility`, and `getPointsHistory`.
- `useGamification` hooks: `useUserBadges` (read query) and `useSetLeaderboardVisibility` (mutation that invalidates the current-user cache so the rank/leaderboardHidden flag refreshes immediately).
- `BadgeIcon` chip and `BadgeList` strip — Material Symbols + label per badge, kept in sync with the backend `Badge` enum.
- `ProfilePage`: adds Points and Rank stat tiles, a Badges section, and a "Hide me from the public leaderboard" toggle. Rank shows `Hidden` when the user opted out and `—` when they have no rank yet (fresh accounts).
- `UserProfilePage`: same Points/Badges treatment for foreign profiles. The Rank tile is omitted entirely when the viewed user opted out — the existence of a hidden rank is private to the owner. No visibility toggle on someone else's profile.
- 9 new tests across the two pages: stat tiles render, opt-out fallbacks (`Hidden` vs no-tile), badges-section conditional render, visibility toggle happy path, and "no toggle on foreign profiles".

The leaderboard page itself, badge notifications in the dropdown, and the report-panel author chip land in the next PRs.

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
<img width="775" height="693" alt="image" src="https://github.com/user-attachments/assets/cfa9dab9-9782-416b-928a-98deeb994b52" />


# ⏱️ Estimated Review Time
- [x] 5-15 min
