### PR TITLE
[Web][Backend] User Search by Name or Email (closes #307, #501)

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
@@ -17,6 +17,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -46,6 +49,32 @@ public class RegisteredUserController {
     @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
     public List<UserProfileDTO> getAll() {
         return registeredUserService.getAllProfiles();
+    }
+
+    @GetMapping("/search")
+    @Operation(
+            summary = "Search users by name or email",
+            description = "Case-insensitive substring match across name OR email. " +
+                    "Authenticated users only. Email is omitted from the response (privacy)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of matching profiles."),
+            @ApiResponse(responseCode = "400", description = "Empty or missing query parameter.")
+    })
+    @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
+    public ResponseEntity<Page<UserProfileDTO>> search(
+            @RequestParam("q") String query,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size) {
+        // Cap page size so a malicious/clumsy caller can't ask for everything at once.
+        int safeSize = Math.min(Math.max(size, 1), 50);
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+        try {
+            return ResponseEntity.ok(registeredUserService.searchUsers(query, pageable));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/RegisteredUserRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/RegisteredUserRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -27,7 +29,8 @@ public interface RegisteredUserRepository extends JpaRepository<RegisteredUser, 
     long countByRole(UserRole role);
     long countByStatus(UserStatus status);
 
-    // User search (#306 / #501): case-insensitive substring match across name OR email.
-    Page<RegisteredUser> findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(
-            String name, String email, Pageable pageable);
+    // User search (#306 / #501): case-insensitive substring match across name OR email, regular users only.
+    @Query("SELECT u FROM RegisteredUser u WHERE u.role = com.bounswe2026group1.backend.model.UserRole.USER " +
+           "AND (LOWER(u.name) LIKE LOWER(CONCAT('%', :q, '%')) OR LOWER(u.email) LIKE LOWER(CONCAT('%', :q, '%')))")
+    Page<RegisteredUser> searchRegularUsersByNameOrEmail(@Param("q") String q, Pageable pageable);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/RegisteredUserRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/RegisteredUserRepository.java
@@ -26,4 +26,8 @@ public interface RegisteredUserRepository extends JpaRepository<RegisteredUser, 
     // Used to enforce the "at least one admin" rule
     long countByRole(UserRole role);
     long countByStatus(UserStatus status);
+
+    // User search (#306 / #501): case-insensitive substring match across name OR email.
+    Page<RegisteredUser> findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(
+            String name, String email, Pageable pageable);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
@@ -13,6 +13,8 @@ import com.bounswe2026group1.backend.repository.ReportRepository;
 import com.bounswe2026group1.backend.repository.RouteRepository;
 import com.bounswe2026group1.backend.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -122,6 +124,29 @@ public class RegisteredUserService {
                         reportCounts.getOrDefault(u.getId(), 0L),
                         routeCounts.getOrDefault(u.getId(), 0L)))
                 .toList();
+    }
+
+    /** User search (#306 / #501): paginated, case-insensitive substring match
+     *  across name OR email. Empty / blank query is rejected with
+     *  IllegalArgumentException so the controller can return 400.
+     *  Email is omitted in the DTO (privacy) — search results are public. */
+    public Page<UserProfileDTO> searchUsers(String query, Pageable pageable) {
+        if (query == null || query.isBlank()) {
+            throw new IllegalArgumentException("Search query must not be empty.");
+        }
+        String trimmed = query.trim();
+        Page<RegisteredUser> page = registeredUserRepository
+                .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(trimmed, trimmed, pageable);
+        if (page.isEmpty()) return page.map(u -> buildDTO(u, false, 0L, 0L));
+
+        // Batch the contribution-stats queries so we stay flat at 3 queries
+        // total regardless of page size — same pattern as getAllProfiles.
+        List<Long> ids = page.getContent().stream().map(RegisteredUser::getId).toList();
+        Map<Long, Long> reportCounts = toCountMap(reportRepository.countByCreatedByIdIn(ids));
+        Map<Long, Long> routeCounts = toCountMap(routeRepository.countByCreatedByIdIn(ids));
+        return page.map(u -> buildDTO(u, false,
+                reportCounts.getOrDefault(u.getId(), 0L),
+                routeCounts.getOrDefault(u.getId(), 0L)));
     }
 
     private static Map<Long, Long> toCountMap(List<Object[]> rows) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
@@ -136,7 +136,7 @@ public class RegisteredUserService {
         }
         String trimmed = query.trim();
         Page<RegisteredUser> page = registeredUserRepository
-                .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(trimmed, trimmed, pageable);
+                .searchRegularUsersByNameOrEmail(trimmed, pageable);
         if (page.isEmpty()) return page.map(u -> buildDTO(u, false, 0L, 0L));
 
         // Batch the contribution-stats queries so we stay flat at 3 queries

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -465,11 +465,12 @@ class RegisteredUserServiceTest {
         when(registeredUserRepository
                 .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase("test", "test", page))
                 .thenReturn(results);
-        // doReturn(...).when(...) bypasses Mockito's generic inference, which
-        // otherwise resolves thenReturn(List<Object[]>) to the varargs overload.
-        org.mockito.Mockito.doReturn(List.of(new Object[]{1L, 4L}))
+        // singletonList — List.of(Object[]) gets varargs-unpacked into a
+        // List<Long>, and doReturn skips compile-time checking, so the cast
+        // inside toCountMap blows up at runtime.
+        org.mockito.Mockito.doReturn(java.util.Collections.singletonList(new Object[]{1L, 4L}))
                 .when(reportRepository).countByCreatedByIdIn(anyCollection());
-        org.mockito.Mockito.doReturn(List.of(new Object[]{1L, 1L}))
+        org.mockito.Mockito.doReturn(java.util.Collections.singletonList(new Object[]{1L, 1L}))
                 .when(routeRepository).countByCreatedByIdIn(anyCollection());
 
         org.springframework.data.domain.Page<UserProfileDTO> dtos =

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -463,7 +463,7 @@ class RegisteredUserServiceTest {
         org.springframework.data.domain.Page<RegisteredUser> results =
                 new org.springframework.data.domain.PageImpl<>(List.of(mockUser));
         when(registeredUserRepository
-                .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase("test", "test", page))
+                .searchRegularUsersByNameOrEmail("test", page))
                 .thenReturn(results);
         // singletonList — List.of(Object[]) gets varargs-unpacked into a
         // List<Long>, and doReturn skips compile-time checking, so the cast
@@ -490,7 +490,7 @@ class RegisteredUserServiceTest {
         org.springframework.data.domain.Page<RegisteredUser> results =
                 new org.springframework.data.domain.PageImpl<>(List.of());
         when(registeredUserRepository
-                .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase("foo", "foo", page))
+                .searchRegularUsersByNameOrEmail("foo", page))
                 .thenReturn(results);
 
         registeredUserService.searchUsers("  foo  ", page);
@@ -498,14 +498,14 @@ class RegisteredUserServiceTest {
         // Whitespace stripped before passing to the repo. The repo method itself
         // is case-insensitive, so we don't need to lowercase here.
         verify(registeredUserRepository)
-                .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase("foo", "foo", page);
+                .searchRegularUsersByNameOrEmail("foo", page);
     }
 
     @Test
     void searchUsers_emptyResults_returnsEmptyPage() {
         org.springframework.data.domain.Pageable page = org.springframework.data.domain.PageRequest.of(0, 20);
         when(registeredUserRepository
-                .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase("zzz", "zzz", page))
+                .searchRegularUsersByNameOrEmail("zzz", page))
                 .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of()));
 
         org.springframework.data.domain.Page<UserProfileDTO> dtos =

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -446,4 +446,69 @@ class RegisteredUserServiceTest {
         verify(routeRepository, never()).countByCreatedById(any());
         verify(jwtUtil, never()).generateToken(any(), any(), any());
     }
+
+    // --- SEARCH USERS TESTS (#306 / #501) ---
+
+    @Test
+    void searchUsers_emptyQuery_throwsIllegalArgument() {
+        org.springframework.data.domain.Pageable page = org.springframework.data.domain.PageRequest.of(0, 20);
+        assertThrows(IllegalArgumentException.class, () -> registeredUserService.searchUsers("", page));
+        assertThrows(IllegalArgumentException.class, () -> registeredUserService.searchUsers("   ", page));
+        assertThrows(IllegalArgumentException.class, () -> registeredUserService.searchUsers(null, page));
+    }
+
+    @Test
+    void searchUsers_match_returnsDtosWithoutEmail() {
+        org.springframework.data.domain.Pageable page = org.springframework.data.domain.PageRequest.of(0, 20);
+        org.springframework.data.domain.Page<RegisteredUser> results =
+                new org.springframework.data.domain.PageImpl<>(List.of(mockUser));
+        when(registeredUserRepository
+                .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase("test", "test", page))
+                .thenReturn(results);
+        when(reportRepository.countByCreatedByIdIn(anyCollection()))
+                .thenReturn(List.of(new Object[]{1L, 4L}));
+        when(routeRepository.countByCreatedByIdIn(anyCollection()))
+                .thenReturn(List.of(new Object[]{1L, 1L}));
+
+        org.springframework.data.domain.Page<UserProfileDTO> dtos =
+                registeredUserService.searchUsers("test", page);
+
+        assertEquals(1, dtos.getTotalElements());
+        UserProfileDTO dto = dtos.getContent().get(0);
+        assertEquals("Test User", dto.getName());
+        assertNull(dto.getEmail(), "Email must be omitted from search results for privacy");
+        assertEquals(4L, dto.getContributionStats().getReportsSubmitted());
+        assertEquals(1L, dto.getContributionStats().getRoutesPlanned());
+    }
+
+    @Test
+    void searchUsers_trimsAndLowercasesArgs() {
+        org.springframework.data.domain.Pageable page = org.springframework.data.domain.PageRequest.of(0, 20);
+        org.springframework.data.domain.Page<RegisteredUser> results =
+                new org.springframework.data.domain.PageImpl<>(List.of());
+        when(registeredUserRepository
+                .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase("foo", "foo", page))
+                .thenReturn(results);
+
+        registeredUserService.searchUsers("  foo  ", page);
+
+        // Whitespace stripped before passing to the repo. The repo method itself
+        // is case-insensitive, so we don't need to lowercase here.
+        verify(registeredUserRepository)
+                .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase("foo", "foo", page);
+    }
+
+    @Test
+    void searchUsers_emptyResults_returnsEmptyPage() {
+        org.springframework.data.domain.Pageable page = org.springframework.data.domain.PageRequest.of(0, 20);
+        when(registeredUserRepository
+                .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase("zzz", "zzz", page))
+                .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of()));
+
+        org.springframework.data.domain.Page<UserProfileDTO> dtos =
+                registeredUserService.searchUsers("zzz", page);
+
+        assertEquals(0, dtos.getTotalElements());
+        verify(reportRepository, never()).countByCreatedByIdIn(anyCollection());
+    }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -465,10 +465,12 @@ class RegisteredUserServiceTest {
         when(registeredUserRepository
                 .findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase("test", "test", page))
                 .thenReturn(results);
-        when(reportRepository.countByCreatedByIdIn(anyCollection()))
-                .thenReturn(List.of(new Object[]{1L, 4L}));
-        when(routeRepository.countByCreatedByIdIn(anyCollection()))
-                .thenReturn(List.of(new Object[]{1L, 1L}));
+        // doReturn(...).when(...) bypasses Mockito's generic inference, which
+        // otherwise resolves thenReturn(List<Object[]>) to the varargs overload.
+        org.mockito.Mockito.doReturn(List.of(new Object[]{1L, 4L}))
+                .when(reportRepository).countByCreatedByIdIn(anyCollection());
+        org.mockito.Mockito.doReturn(List.of(new Object[]{1L, 1L}))
+                .when(routeRepository).countByCreatedByIdIn(anyCollection());
 
         org.springframework.data.domain.Page<UserProfileDTO> dtos =
                 registeredUserService.searchUsers("test", page);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import Login from './pages/Login.jsx'
 import Feed from './pages/Feed.jsx'
 import ProfilePage from './pages/ProfilePage.jsx'
 import UserProfilePage from './pages/UserProfilePage.jsx'
+import UserSearchPage from './pages/UserSearchPage.jsx'
 import RequireAdmin from './components/RequireAdmin.jsx'
 import RequireAuth from './components/RequireAuth.jsx'
 import AdminLayout from './components/admin/AdminLayout.jsx'
@@ -29,6 +30,7 @@ function App() {
       <Route element={<RequireAuth />}>
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/profile/:userId" element={<UserProfilePage />} />
+        <Route path="/search/users" element={<UserSearchPage />} />
       </Route>
       <Route element={<RequireAdmin />}>
         <Route element={<AdminLayout />}>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -124,6 +124,15 @@ function Navbar() {
         <SseStatusIndicator />
         <ThemeToggleButton />
         {isAuthenticated && (
+          <Link
+            to="/search/users"
+            aria-label="Search users"
+            className="hidden sm:flex shrink-0 w-10 h-10 rounded-full items-center justify-center hover:bg-surface-container transition-colors"
+          >
+            <span className="material-symbols-outlined text-on-surface-variant">search</span>
+          </Link>
+        )}
+        {isAuthenticated && (
           <div className="relative hidden sm:block">
             <button
               ref={notifButtonRef}

--- a/frontend/src/hooks/useUserSearch.js
+++ b/frontend/src/hooks/useUserSearch.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useAuth } from '../context/AuthContext.jsx'
+import { searchUsers } from '../services/userService.js'
+
+const MIN_QUERY_LENGTH = 2
+const DEBOUNCE_MS = 300
+
+function useDebouncedValue(value, delay) {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(id)
+  }, [value, delay])
+  return debounced
+}
+
+export function useUserSearch(query, { page = 0, size = 20 } = {}) {
+  const { token, isAuthenticated } = useAuth()
+  const debouncedQuery = useDebouncedValue(query.trim(), DEBOUNCE_MS)
+  const enabled = isAuthenticated && debouncedQuery.length >= MIN_QUERY_LENGTH
+
+  return useQuery({
+    queryKey: ['userSearch', debouncedQuery, page, size],
+    queryFn: () => searchUsers(debouncedQuery, { page, size }, token),
+    enabled,
+    keepPreviousData: true,
+    staleTime: 30_000,
+  })
+}
+
+export const USER_SEARCH_MIN_LENGTH = MIN_QUERY_LENGTH

--- a/frontend/src/hooks/useUserSearch.test.jsx
+++ b/frontend/src/hooks/useUserSearch.test.jsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useUserSearch } from './useUserSearch.js'
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: vi.fn(),
+}))
+vi.mock('../services/userService.js', () => ({
+  searchUsers: vi.fn(),
+}))
+
+import { useAuth } from '../context/AuthContext.jsx'
+import { searchUsers } from '../services/userService.js'
+
+function makeWrapper(queryClient) {
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useUserSearch', () => {
+  let queryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    useAuth.mockReturnValue({ token: 'tok', isAuthenticated: true })
+  })
+
+  it('does not call searchUsers when query is shorter than minimum length', async () => {
+    renderHook(() => useUserSearch('a'), { wrapper: makeWrapper(queryClient) })
+    await new Promise((r) => setTimeout(r, 350))
+    expect(searchUsers).not.toHaveBeenCalled()
+  })
+
+  it('does not call searchUsers when not authenticated', async () => {
+    useAuth.mockReturnValue({ token: null, isAuthenticated: false })
+    renderHook(() => useUserSearch('alice'), { wrapper: makeWrapper(queryClient) })
+    await new Promise((r) => setTimeout(r, 350))
+    expect(searchUsers).not.toHaveBeenCalled()
+  })
+
+  it('debounces typing and forwards the trimmed query, page, and size', async () => {
+    searchUsers.mockResolvedValue({ content: [], totalElements: 0 })
+    const { rerender } = renderHook(
+      ({ q }) => useUserSearch(q, { page: 1, size: 5 }),
+      { wrapper: makeWrapper(queryClient), initialProps: { q: '' } },
+    )
+
+    rerender({ q: '  alice  ' })
+    expect(searchUsers).not.toHaveBeenCalled()
+
+    await waitFor(
+      () => expect(searchUsers).toHaveBeenCalledWith('alice', { page: 1, size: 5 }, 'tok'),
+      { timeout: 1000 },
+    )
+  })
+})

--- a/frontend/src/pages/UserSearchPage.jsx
+++ b/frontend/src/pages/UserSearchPage.jsx
@@ -1,0 +1,138 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import Navbar from '../components/Navbar.jsx'
+import { USER_SEARCH_MIN_LENGTH, useUserSearch } from '../hooks/useUserSearch.js'
+
+function UserCard({ user }) {
+  const reports = user.contributionStats?.reportsSubmitted ?? 0
+  const routes = user.contributionStats?.routesPlanned ?? 0
+  return (
+    <Link
+      to={`/profile/${user.id}`}
+      className="flex items-center gap-3 bg-white rounded-2xl shadow-sm p-4 hover:shadow-md transition-shadow"
+    >
+      <div className="w-12 h-12 rounded-full bg-surface-container-high flex items-center justify-center flex-shrink-0 overflow-hidden">
+        {user.avatarUrl ? (
+          <img src={user.avatarUrl} alt={user.name} className="w-full h-full object-cover" />
+        ) : (
+          <span className="material-symbols-outlined text-on-surface-variant" style={{ fontSize: '24px' }}>
+            person
+          </span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-on-surface truncate">{user.name}</p>
+        <p className="text-xs text-on-surface-variant">
+          {reports} report{reports === 1 ? '' : 's'} · {routes} route{routes === 1 ? '' : 's'}
+        </p>
+      </div>
+      <span className="text-xs font-bold px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+        {user.role}
+      </span>
+    </Link>
+  )
+}
+
+function UserSearchPage() {
+  const [query, setQuery] = useState('')
+  const [page, setPage] = useState(0)
+  const trimmed = query.trim()
+  const tooShort = trimmed.length > 0 && trimmed.length < USER_SEARCH_MIN_LENGTH
+
+  const { data, isPending, isFetching, isError, error } = useUserSearch(query, { page })
+
+  const results = data?.content ?? []
+  const totalElements = data?.totalElements ?? 0
+  const totalPages = data?.totalPages ?? 0
+  const isFirstPage = page === 0
+  const isLastPage = data ? data.last : true
+
+  function onChange(e) {
+    setQuery(e.target.value)
+    setPage(0)
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background">
+      <Navbar />
+      <main className="flex-1 max-w-3xl w-full mx-auto p-4 md:p-8 flex flex-col gap-4">
+        <h1 className="text-2xl font-bold font-headline text-on-surface">Find people</h1>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-xs uppercase tracking-wide text-on-surface-variant">
+            Search by name or email
+          </span>
+          <input
+            type="search"
+            value={query}
+            onChange={onChange}
+            placeholder="e.g. alice"
+            autoFocus
+            className="bg-white rounded-2xl shadow-sm px-4 py-3 text-sm text-on-surface outline-none focus:ring-2 focus:ring-primary"
+            aria-label="Search users by name or email"
+          />
+        </label>
+
+        {tooShort && (
+          <p className="text-sm text-on-surface-variant">
+            Type at least {USER_SEARCH_MIN_LENGTH} characters to search.
+          </p>
+        )}
+
+        {trimmed.length >= USER_SEARCH_MIN_LENGTH && isPending && (
+          <p className="text-sm text-on-surface-variant">Searching…</p>
+        )}
+
+        {isError && (
+          <p role="alert" className="text-sm text-error">
+            {error?.message || 'Search failed.'}
+          </p>
+        )}
+
+        {!isPending && !isError && data && (
+          <>
+            <p className="text-xs text-on-surface-variant" aria-live="polite">
+              {totalElements === 0
+                ? 'No users found.'
+                : `${totalElements} match${totalElements === 1 ? '' : 'es'}.`}
+            </p>
+
+            <ul className="flex flex-col gap-2">
+              {results.map((u) => (
+                <li key={u.id}>
+                  <UserCard user={u} />
+                </li>
+              ))}
+            </ul>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-3 mt-2">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(p - 1, 0))}
+                  disabled={isFirstPage || isFetching}
+                  className="px-3 py-1.5 rounded-full bg-surface-container-low text-on-surface text-sm font-semibold disabled:opacity-50 cursor-pointer"
+                >
+                  Previous
+                </button>
+                <span className="text-xs text-on-surface-variant">
+                  Page {page + 1} of {totalPages}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={isLastPage || isFetching}
+                  className="px-3 py-1.5 rounded-full bg-primary text-on-primary text-sm font-semibold disabled:opacity-50 cursor-pointer"
+                >
+                  Next
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default UserSearchPage

--- a/frontend/src/pages/UserSearchPage.jsx
+++ b/frontend/src/pages/UserSearchPage.jsx
@@ -9,7 +9,7 @@ function UserCard({ user }) {
   return (
     <Link
       to={`/profile/${user.id}`}
-      className="flex items-center gap-3 bg-white rounded-2xl shadow-sm p-4 hover:shadow-md transition-shadow"
+      className="flex items-center gap-3 bg-surface-container-lowest rounded-2xl shadow-sm p-4 hover:shadow-md transition-shadow"
     >
       <div className="w-12 h-12 rounded-full bg-surface-container-high flex items-center justify-center flex-shrink-0 overflow-hidden">
         {user.avatarUrl ? (
@@ -68,7 +68,7 @@ function UserSearchPage() {
             onChange={onChange}
             placeholder="e.g. alice"
             autoFocus
-            className="bg-white rounded-2xl shadow-sm px-4 py-3 text-sm text-on-surface outline-none focus:ring-2 focus:ring-primary"
+            className="bg-surface-container-lowest rounded-2xl shadow-sm px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant outline-none focus:ring-2 focus:ring-primary"
             aria-label="Search users by name or email"
           />
         </label>

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -12,6 +12,11 @@ export async function getUserById(id, token) {
   return apiFetch(`/api/users/${id}`, { headers: authHeaders(token) })
 }
 
+export async function searchUsers(query, { page = 0, size = 20 } = {}, token) {
+  const params = new URLSearchParams({ q: query, page: String(page), size: String(size) })
+  return apiFetch(`/api/users/search?${params.toString()}`, { headers: authHeaders(token) })
+}
+
 export async function updateProfile(id, body, token) {
   return apiFetch(`/api/users/${id}/profile`, {
     method: 'PUT',

--- a/frontend/src/services/userService.test.js
+++ b/frontend/src/services/userService.test.js
@@ -1,4 +1,4 @@
-import { getCurrentUser, getUserById } from './userService.js'
+import { getCurrentUser, getUserById, searchUsers } from './userService.js'
 import { apiFetch } from './api.js'
 
 vi.mock('./api.js', () => ({ apiFetch: vi.fn() }))
@@ -23,6 +23,35 @@ describe('userService', () => {
       expect(apiFetch).toHaveBeenCalledWith('/api/users/5', {
         headers: { Authorization: 'Bearer jwt' },
       })
+    })
+  })
+
+  describe('searchUsers', () => {
+    it('GETs /api/users/search with q, page, size and bearer token', async () => {
+      apiFetch.mockResolvedValue({ content: [], totalElements: 0 })
+      await searchUsers('alice', { page: 2, size: 10 }, 'jwt')
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/api/users/search?q=alice&page=2&size=10',
+        { headers: { Authorization: 'Bearer jwt' } },
+      )
+    })
+
+    it('defaults page to 0 and size to 20 when options omitted', async () => {
+      apiFetch.mockResolvedValue({ content: [], totalElements: 0 })
+      await searchUsers('bob', undefined, 'jwt')
+      expect(apiFetch).toHaveBeenCalledWith(
+        '/api/users/search?q=bob&page=0&size=20',
+        { headers: { Authorization: 'Bearer jwt' } },
+      )
+    })
+
+    it('URL-encodes the query parameter', async () => {
+      apiFetch.mockResolvedValue({ content: [], totalElements: 0 })
+      await searchUsers('a b@c', {}, 'jwt')
+      expect(apiFetch).toHaveBeenCalledWith(
+        expect.stringContaining('q=a+b%40c'),
+        expect.any(Object),
+      )
     })
   })
 })


### PR DESCRIPTION
## 📝 Description
Closes #307 (web) and #501 (backend). Implements parent epic #306.

Adds a user-search endpoint and a search page wired to it. Authenticated users can find others by name or email substring, click through to a profile.

Backend: `GET /api/users/search?q=&page=&size=` returns a paged list of public profiles, filtered by case-insensitive substring across name OR email. Empty/blank `q` returns 400. Page size capped at 50. Email is omitted from the DTOs (privacy, same rule the existing `getAllProfiles` uses).

Frontend: `/search/users` page (auth-gated) with a debounced input, prev/next pagination, loading/empty/error states, and an aria-live result count. Cards show avatar, name, role, and contribution counts. A search icon in the navbar takes you there.

## 📊 Type of Change
- [x] New feature
- [x] Backend change
- [x] Tests added

## ✅ Acceptance Criteria
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have added/updated tests (4 backend service tests + 6 frontend tests)
- [x] All tests passed (273/273 frontend; backend covered by CI)

Issue acceptance criteria:
- [x] Authenticated users can search by name or email
- [x] Results paginate
- [x] Email is not exposed in search results
- [x] Empty query returns 400 from the backend
- [x] Frontend debounces input (300 ms) and gates on a 2-character minimum
- [x] Clicking a result lands on that user's profile

## 📸 Screenshots
<img width="1211" height="673" alt="Ekran Resmi 2026-05-10 00 18 21" src="https://github.com/user-attachments/assets/cfd0f03d-863b-4444-9024-8ca8f80a4798" />


## 🧪 How to Test
1. Sign in.
2. Click the search icon in the navbar (next to the bell on `≥sm`), or visit `/search/users`.
3. Type at least 2 characters. Results appear after the debounce.
4. Click a card to land on `/profile/:id`.
5. With more than 20 matches, prev/next pagination works.
6. Backend probe: `curl "$API/api/users/search?q=ali" -H "Authorization: Bearer $TOKEN"` returns a `Page<UserProfileDTO>`; verify each `email` is `null`.

## ⏱️ Estimated Review Time
- [x] 5–15 min