### PR TITLE
[Web] Fix routing preferences cards in dark mode 

### DIFF
--- a/frontend/src/components/RoutingPreferencesSection.jsx
+++ b/frontend/src/components/RoutingPreferencesSection.jsx
@@ -60,7 +60,7 @@ function PresetCard({
       className={`relative text-left p-4 rounded-2xl border-2 transition-colors flex flex-col gap-2 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary/40 ${
         active
           ? 'border-primary bg-primary/5'
-          : 'border-outline-variant bg-white hover:border-primary/40'
+          : 'border-outline-variant bg-surface-container-lowest hover:border-primary/40'
       } ${disabled ? 'opacity-60 cursor-wait' : ''}`}
     >
       {active && (
@@ -127,7 +127,7 @@ function RoutingPreferencesSection() {
 
   if (isPending) {
     return (
-      <section className="bg-white rounded-2xl shadow-sm p-6">
+      <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6">
         <p className="text-sm text-on-surface-variant">Loading routing preferences…</p>
       </section>
     )
@@ -135,7 +135,7 @@ function RoutingPreferencesSection() {
 
   if (isError) {
     return (
-      <section className="bg-white rounded-2xl shadow-sm p-6 flex flex-col gap-2">
+      <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-2">
         <p role="alert" className="text-sm text-error">
           Failed to load routing preferences{error?.message ? `: ${error.message}` : '.'}
         </p>
@@ -244,7 +244,7 @@ function RoutingPreferencesSection() {
     createCustom.isPending || updateCustom.isPending || deleteCustom.isPending
 
   return (
-    <section className="bg-white rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+    <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-4">
       <div className="flex items-baseline justify-between gap-2 flex-wrap">
         <h2 className="text-xl font-bold font-headline text-on-surface">Routing preferences</h2>
         <span className="text-xs text-on-surface-variant">


### PR DESCRIPTION
## 📝 Description
Closes #506 . Routing Preferences section had hardcoded `bg-white` on the outer cards and preset tiles, leaving them white in dark mode with light text on white background.

Swapped 4 occurrences of `bg-white` to the M3 token `bg-surface-container-lowest` in `RoutingPreferencesSection.jsx`. No logic, no tests changed , same fix pattern used elsewhere in the app.

## 📊 Type of Change
- [x] Bug fix

## ✅ Acceptance Criteria
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] All tests passed (12/12 in `RoutingPreferencesSection.test.jsx`)

Issue acceptance criteria:
- [x] Routing Preferences section is readable in dark mode
- [x] Light mode looks identical to before
- [x] All existing tests pass


## 🧪 How to Test
1. Sign in, open `/profile`, scroll to Routing Preferences.
2. Toggle theme between light and dark ,cards should adopt the surface color in both.

## ⏱️ Estimated Review Time
- [x] < 5 min