### PR TITLE
[Web] Implement Uploading Multiple Media File

### DIFF
--- a/frontend/src/components/CreateReportPanel.jsx
+++ b/frontend/src/components/CreateReportPanel.jsx
@@ -12,8 +12,8 @@ function CreateReportPanel({ position, onClose, onCreated }) {
   const [environment, setEnvironment] = useState('OUTDOOR')
   const [objects, setObjects] = useState([])
   const [description, setDescription] = useState('')
-  const [imageFile, setImageFile] = useState(null)
-  const [imagePreview, setImagePreview] = useState(null)
+  const [imageFiles, setImageFiles] = useState([])
+  const [imagePreviews, setImagePreviews] = useState([])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const fileInputRef = useRef(null)
@@ -81,18 +81,33 @@ function CreateReportPanel({ position, onClose, onCreated }) {
   // ── image ──────────────────────────────────────────────────────────────────
 
   function handleImageChange(e) {
-    const file = e.target.files[0]
-    if (!file) return
-    setImageFile(file)
-    setImagePreview(URL.createObjectURL(file))
+    const files = Array.from(e.target.files)
+    if (!files.length) return
+    addFiles(files)
   }
 
   function handleDrop(e) {
     e.preventDefault()
-    const file = e.dataTransfer.files[0]
-    if (!file) return
-    setImageFile(file)
-    setImagePreview(URL.createObjectURL(file))
+    const files = Array.from(e.dataTransfer.files)
+    if (!files.length) return
+    addFiles(files)
+  }
+
+  function addFiles(newFiles) {
+    setImageFiles(prev => {
+      const combined = [...prev, ...newFiles].slice(0, 5) // Max 5 files
+      setImagePreviews(combined.map(f => URL.createObjectURL(f)))
+      return combined
+    })
+  }
+
+  function removeImage(index) {
+    setImageFiles(prev => {
+      const next = [...prev]
+      next.splice(index, 1)
+      setImagePreviews(next.map(f => URL.createObjectURL(f)))
+      return next
+    })
   }
 
   // ── report type toggle ─────────────────────────────────────────────────────
@@ -203,23 +218,26 @@ function CreateReportPanel({ position, onClose, onCreated }) {
       }
       const created = await createReport(body)
 
-      let imageUrl = null
-      if (imageFile) {
+      let uploadedMedia = []
+      if (imageFiles.length > 0) {
         const formData = new FormData()
-        formData.append('file', imageFile)
+        imageFiles.forEach(file => formData.append('file', file))
         const mediaRes = await fetch(`${import.meta.env.VITE_API_URL}/api/reports/${created.reportId}/media`, {
           method: 'POST',
           headers: { Authorization: `Bearer ${token}` },
           body: formData,
         })
         if (mediaRes.ok) {
-          const mediaData = await mediaRes.json()
-          imageUrl = mediaData.mediaUrl
+          // Get the json directly, do not map it
+          uploadedMedia = await mediaRes.json()
         }
       }
 
       const mapped = mapReport(created)
-      if (imageUrl) mapped.image = imageUrl
+      if (uploadedMedia.length > 0) {
+        mapped.image = uploadedMedia[0].url // Use the first photo URL for the map preview
+        mapped.media = uploadedMedia
+      }
       onCreated(mapped)
       onClose()
     } catch (err) {
@@ -236,20 +254,20 @@ function CreateReportPanel({ position, onClose, onCreated }) {
       <aside
         style={isMobileSheet
           ? {
-              height: `${sheetHeightDvh}dvh`,
-              maxHeight: `${sheetHeightDvh}dvh`,
-              width: '100%',
-              borderTopLeftRadius: '32px',
-              borderTopRightRadius: '32px',
-              borderTop: '1px solid rgba(172,173,173,.2)',
-              boxShadow: '0 -10px 40px rgba(0,0,0,0.2)',
-            }
+            height: `${sheetHeightDvh}dvh`,
+            maxHeight: `${sheetHeightDvh}dvh`,
+            width: '100%',
+            borderTopLeftRadius: '32px',
+            borderTopRightRadius: '32px',
+            borderTop: '1px solid rgba(172,173,173,.2)',
+            boxShadow: '0 -10px 40px rgba(0,0,0,0.2)',
+          }
           : {
-              width: '500px',
-              height: '100%',
-              maxHeight: '100%',
-              borderLeft: '1px solid rgba(172,173,173,.1)',
-            }}
+            width: '500px',
+            height: '100%',
+            maxHeight: '100%',
+            borderLeft: '1px solid rgba(172,173,173,.1)',
+          }}
         className={`pointer-events-auto bg-surface-container-low flex flex-col relative overflow-y-auto ${isDragging ? '' : 'transition-[height,max-height] duration-200 ease-out'}`}
       >
 
@@ -272,300 +290,320 @@ function CreateReportPanel({ position, onClose, onCreated }) {
           </div>
         )}
 
-      {/* Header */}
-      <div className="px-8 pt-2 lg:pt-8 pb-4 flex items-start justify-between flex-shrink-0">
-        <div>
-          <h2 className="text-2xl font-extrabold font-headline text-on-surface">New Report</h2>
-          <p className="text-sm text-on-surface-variant mt-1">
-            {position
-              ? `📍 ${position.lat.toFixed(5)}, ${position.lng.toFixed(5)}`
-              : 'Click on the map to set location'}
-          </p>
-        </div>
-        <button
-          onClick={onClose}
-          className="w-9 h-9 rounded-full bg-surface-container flex items-center justify-center hover:bg-surface-container-high transition-colors"
-          aria-label="Close"
-        >
-          <span className="material-symbols-outlined text-base">close</span>
-        </button>
-      </div>
-
-      <div className="px-8 pb-10 flex flex-col gap-6">
-
-        {/* Visual Evidence */}
-        <div>
-          <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">Visual Evidence</p>
-          <div
-            onClick={() => fileInputRef.current?.click()}
-            onDrop={handleDrop}
-            onDragOver={e => e.preventDefault()}
-            className="w-full h-44 rounded-2xl border-2 border-dashed border-outline-variant/40 bg-surface-container flex flex-col items-center justify-center gap-2 cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors overflow-hidden"
+        {/* Header */}
+        <div className="px-8 pt-2 lg:pt-8 pb-4 flex items-start justify-between flex-shrink-0">
+          <div>
+            <h2 className="text-2xl font-extrabold font-headline text-on-surface">New Report</h2>
+            <p className="text-sm text-on-surface-variant mt-1">
+              {position
+                ? `📍 ${position.lat.toFixed(5)}, ${position.lng.toFixed(5)}`
+                : 'Click on the map to set location'}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-9 h-9 rounded-full bg-surface-container flex items-center justify-center hover:bg-surface-container-high transition-colors"
+            aria-label="Close"
           >
-            {imagePreview ? (
-              <img src={imagePreview} alt="Preview" className="w-full h-full object-cover" />
-            ) : (
-              <>
-                <span className="material-symbols-outlined text-4xl text-on-surface-variant">add_a_photo</span>
-                <p className="text-sm font-medium text-on-surface-variant">Upload or drag photos here</p>
-                <p className="text-xs text-outline">Maximum file size: 15 MB (JPG, PNG)</p>
-              </>
-            )}
-          </div>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/jpeg,image/png"
-            className="hidden"
-            onChange={handleImageChange}
-          />
+            <span className="material-symbols-outlined text-base">close</span>
+          </button>
         </div>
 
-        {/* Report Type */}
-        <div>
-          <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">Report Type</p>
-          <div className="grid grid-cols-2 gap-2">
-            {[
-              { value: 'OBSTACLE', icon: 'construction',      label: 'Obstacle', desc: 'Something broken or missing' },
-              { value: 'FEATURE',  icon: 'accessible_forward', label: 'Feature',  desc: 'Something helpful that exists' },
-            ].map(t => (
-              <button
-                key={t.value}
-                aria-label={t.label}
-                onClick={() => handleReportTypeChange(t.value)}
-                className="flex flex-col items-center gap-1.5 p-3 rounded-xl border-2 transition-all text-xs font-semibold"
-                style={reportType === t.value
-                  ? { borderColor: '#176a21', backgroundColor: 'rgba(23,106,33,.07)', color: '#176a21' }
-                  : { borderColor: 'rgba(172,173,173,.25)', backgroundColor: '', color: '#5a5c5c' }}
-              >
-                <span className="material-symbols-outlined text-xl">{t.icon}</span>
-                <span className="font-bold text-xs">{t.label}</span>
-                <span className="text-[10px] opacity-70 text-center leading-tight">{t.desc}</span>
-              </button>
-            ))}
-          </div>
-        </div>
+        <div className="px-8 pb-10 flex flex-col gap-6">
 
-        {/* Environment */}
-        <div>
-          <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">Environment</p>
-          <div className="grid grid-cols-2 gap-2">
-            {[
-              { value: 'OUTDOOR', icon: 'wb_sunny', label: 'Outdoor' },
-              { value: 'INDOOR',  icon: 'home',     label: 'Indoor' },
-            ].map(e => (
-              <button
-                key={e.value}
-                aria-label={e.label}
-                onClick={() => handleEnvironmentChange(e.value)}
-                className="flex items-center justify-center gap-2 py-2.5 rounded-xl border-2 text-xs font-semibold transition-all"
-                style={environment === e.value
-                  ? { borderColor: '#176a21', backgroundColor: 'rgba(23,106,33,.07)', color: '#176a21' }
-                  : { borderColor: 'rgba(172,173,173,.25)', color: '#5a5c5c' }}
-              >
-                <span className="material-symbols-outlined text-base">{e.icon}</span>
-                {e.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Objects */}
-        <div>
-          <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">
-            Objects <span className="text-error text-[10px] font-normal normal-case tracking-normal">required</span>
-          </p>
-
-          <div className="flex flex-col gap-2 mb-2">
-            {objects.map((obj, idx) => {
-              const cfg = OBJECT_TYPES.find(t => t.type === obj.objectType) ?? null
-              return (
-                <div
-                  key={obj.id}
-                  className="rounded-2xl border-2 bg-surface-container overflow-hidden transition-colors"
-                  style={{ borderColor: obj.objectType ? 'rgba(23,106,33,.2)' : 'rgba(172,173,173,.2)' }}
-                >
-                  {/* Card header */}
-                  <div
-                    className="flex items-center gap-2 px-4 py-3 cursor-pointer select-none"
-                    onClick={() => toggleExpanded(obj.id)}
-                  >
-                    <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0">
-                      <span className="text-on-primary text-[10px] font-bold">{idx + 1}</span>
+          {/* Visual Evidence */}
+          <div>
+            <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">Visual Evidence</p>
+            <div
+              onClick={() => fileInputRef.current?.click()}
+              onDrop={handleDrop}
+              onDragOver={e => e.preventDefault()}
+              className="w-full min-h-[11rem] p-4 rounded-2xl border-2 border-dashed border-outline-variant/40 bg-surface-container flex flex-col items-center justify-center gap-2 cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors overflow-hidden"
+            >
+              {imagePreviews.length > 0 ? (
+                <div className="grid grid-cols-2 gap-2 w-full">
+                  {imagePreviews.map((preview, idx) => (
+                    <div key={idx} className="relative aspect-video rounded-lg overflow-hidden group border border-outline-variant/20 bg-black/5">
+                      <img src={preview} alt="Preview" className="w-full h-full object-cover" />
+                      <button
+                        onClick={(e) => { e.stopPropagation(); removeImage(idx); }}
+                        className="absolute top-1 right-1 w-6 h-6 bg-black/60 rounded-full flex items-center justify-center text-white opacity-0 group-hover:opacity-100 transition-opacity"
+                        aria-label="Remove image"
+                      >
+                        <span className="material-symbols-outlined text-sm">close</span>
+                      </button>
                     </div>
-                    <span className={`flex-1 text-sm font-semibold ${obj.objectType ? 'text-on-surface' : 'text-on-surface-variant italic'}`}>
-                      {cfg ? cfg.label : 'Select a type…'}
-                    </span>
-                    <span className="material-symbols-outlined text-on-surface-variant text-base transition-transform" style={{ transform: obj.expanded ? 'rotate(180deg)' : '' }}>
-                      expand_more
-                    </span>
-                    <button
-                      onClick={e => { e.stopPropagation(); removeObject(obj.id) }}
-                      className="w-7 h-7 rounded-full flex items-center justify-center text-on-surface-variant hover:text-error hover:bg-error/10 transition-colors"
-                      aria-label="Remove object"
-                    >
-                      <span className="material-symbols-outlined text-base">delete</span>
-                    </button>
-                  </div>
-
-                  {obj.expanded && (
-                    <div className="px-4 pb-4 flex flex-col gap-4 border-t border-outline-variant/20 pt-3">
-
-                      {/* Object type picker */}
-                      <div>
-                        <p className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2">Object Type</p>
-                        <div className="grid grid-cols-5 gap-1.5">
-                          {visibleTypes.map(t => {
-                            const isSelected = obj.objectType === t.type
-                            const isDisabled = !isSelected && selectedTypes.has(t.type)
-                            return (
-                              <button
-                                key={t.type}
-                                aria-label={t.label}
-                                disabled={isDisabled}
-                                onClick={() => selectObjectType(obj.id, t.type)}
-                                title={isDisabled ? `${t.label} already added` : t.label}
-                                className="flex flex-col items-center gap-1 py-2 rounded-xl border-2 transition-all text-[10px] font-semibold disabled:opacity-35 disabled:cursor-not-allowed"
-                                style={isSelected
-                                  ? { borderColor: '#176a21', backgroundColor: 'rgba(23,106,33,.08)', color: '#176a21' }
-                                  : { borderColor: 'rgba(172,173,173,.25)', backgroundColor: '#f0f1f1', color: '#5a5c5c' }}
-                              >
-                                <span className="material-symbols-outlined text-xl">{t.icon}</span>
-                                {t.label}
-                              </button>
-                            )
-                          })}
-                        </div>
-                      </div>
-
-                      {/* Issues — only for OBSTACLE and when type is selected */}
-                      {cfg && reportType === 'OBSTACLE' && (
-                        <div>
-                          <p className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2">
-                            Issues <span className="text-error">*</span>
-                          </p>
-                          <div className="grid grid-cols-2 gap-1">
-                            {cfg.issues.map(issue => (
-                              <label
-                                key={issue.key}
-                                className="flex items-center gap-2 px-2.5 py-2 rounded-lg cursor-pointer hover:bg-primary/5 transition-colors"
-                              >
-                                <input
-                                  type="checkbox"
-                                  checked={obj.issues.includes(issue.key)}
-                                  onChange={() => toggleIssue(obj.id, issue.key)}
-                                  className="w-3.5 h-3.5 accent-primary"
-                                />
-                                <span className="text-xs font-medium text-on-surface">{issue.label}</span>
-                              </label>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Measurements — optional, collapsible */}
-                      {cfg && cfg.measurements.length > 0 && (
-                        <div>
-                          <button
-                            onClick={() => toggleShowMeasurements(obj.id)}
-                            className="flex items-center gap-1.5 text-xs font-semibold text-primary mb-2"
-                          >
-                            <span className="material-symbols-outlined text-base">straighten</span>
-                            {obj.showMeasurements ? 'Hide measurements' : 'Show measurements (optional)'}
-                          </button>
-                          {obj.showMeasurements && (
-                            <div className="flex flex-col gap-3">
-                              {cfg.measurements.map(m => (
-                                <div key={m.key}>
-                                  <p className="text-[10px] font-semibold text-on-surface-variant mb-1">{m.label}</p>
-                                  <div className="flex items-center rounded-lg border border-outline-variant/30 bg-surface-container-lowest overflow-hidden focus-within:border-primary/50">
-                                    <input
-                                      type="number"
-                                      min="0"
-                                      step="0.1"
-                                      value={obj.measurements[m.key] ?? ''}
-                                      onChange={e => setMeasurement(obj.id, m.key, e.target.value)}
-                                      className="flex-1 px-3 py-2 text-sm bg-transparent outline-none text-on-surface"
-                                      placeholder="—"
-                                    />
-                                    <span className="px-2.5 text-xs text-on-surface-variant font-medium border-l border-outline-variant/25 bg-surface-container">
-                                      {m.unit}
-                                    </span>
-                                  </div>
-                                  {m.accessible_min !== undefined && (
-                                    <p className="text-[10px] text-primary mt-1 flex items-center gap-1">
-                                      <span className="material-symbols-outlined text-xs">check_circle</span>
-                                      ≥ {m.accessible_min} {m.unit} is accessible
-                                    </p>
-                                  )}
-                                  {m.accessible_max !== undefined && (
-                                    <p className="text-[10px] text-primary mt-1 flex items-center gap-1">
-                                      <span className="material-symbols-outlined text-xs">check_circle</span>
-                                      ≤ {m.accessible_max} {m.unit} is accessible
-                                    </p>
-                                  )}
-                                </div>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      )}
-
+                  ))}
+                  {imagePreviews.length < 5 && (
+                    <div className="aspect-video rounded-lg border-2 border-dashed border-outline-variant/40 flex flex-col items-center justify-center text-on-surface-variant hover:text-primary hover:border-primary/40 hover:bg-primary/5 transition-colors">
+                      <span className="material-symbols-outlined text-2xl mb-1">add</span>
+                      <span className="text-[10px] font-medium">Add more</span>
                     </div>
                   )}
                 </div>
-              )
-            })}
+              ) : (
+                <>
+                  <span className="material-symbols-outlined text-4xl text-on-surface-variant">add_a_photo</span>
+                  <p className="text-sm font-medium text-on-surface-variant">Upload or drag photos here</p>
+                  <p className="text-xs text-outline">Maximum file size: 15 MB (JPG, PNG). Up to 5 files.</p>
+                </>
+              )}
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept="image/jpeg,image/png"
+              className="hidden"
+              onChange={handleImageChange}
+            />
           </div>
 
-          <button
-            onClick={addObject}
-            className="w-full py-3 rounded-xl border-2 border-dashed border-primary/35 text-primary text-sm font-semibold flex items-center justify-center gap-1.5 hover:bg-primary/5 hover:border-primary/50 transition-colors"
-          >
-            <span className="material-symbols-outlined text-lg">add_circle</span>
-            Add Object
-          </button>
+          {/* Report Type */}
+          <div>
+            <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">Report Type</p>
+            <div className="grid grid-cols-2 gap-2">
+              {[
+                { value: 'OBSTACLE', icon: 'construction', label: 'Obstacle', desc: 'Something broken or missing' },
+                { value: 'FEATURE', icon: 'accessible_forward', label: 'Feature', desc: 'Something helpful that exists' },
+              ].map(t => (
+                <button
+                  key={t.value}
+                  aria-label={t.label}
+                  onClick={() => handleReportTypeChange(t.value)}
+                  className="flex flex-col items-center gap-1.5 p-3 rounded-xl border-2 transition-all text-xs font-semibold"
+                  style={reportType === t.value
+                    ? { borderColor: '#176a21', backgroundColor: 'rgba(23,106,33,.07)', color: '#176a21' }
+                    : { borderColor: 'rgba(172,173,173,.25)', backgroundColor: '', color: '#5a5c5c' }}
+                >
+                  <span className="material-symbols-outlined text-xl">{t.icon}</span>
+                  <span className="font-bold text-xs">{t.label}</span>
+                  <span className="text-[10px] opacity-70 text-center leading-tight">{t.desc}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Environment */}
+          <div>
+            <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">Environment</p>
+            <div className="grid grid-cols-2 gap-2">
+              {[
+                { value: 'OUTDOOR', icon: 'wb_sunny', label: 'Outdoor' },
+                { value: 'INDOOR', icon: 'home', label: 'Indoor' },
+              ].map(e => (
+                <button
+                  key={e.value}
+                  aria-label={e.label}
+                  onClick={() => handleEnvironmentChange(e.value)}
+                  className="flex items-center justify-center gap-2 py-2.5 rounded-xl border-2 text-xs font-semibold transition-all"
+                  style={environment === e.value
+                    ? { borderColor: '#176a21', backgroundColor: 'rgba(23,106,33,.07)', color: '#176a21' }
+                    : { borderColor: 'rgba(172,173,173,.25)', color: '#5a5c5c' }}
+                >
+                  <span className="material-symbols-outlined text-base">{e.icon}</span>
+                  {e.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Objects */}
+          <div>
+            <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">
+              Objects <span className="text-error text-[10px] font-normal normal-case tracking-normal">required</span>
+            </p>
+
+            <div className="flex flex-col gap-2 mb-2">
+              {objects.map((obj, idx) => {
+                const cfg = OBJECT_TYPES.find(t => t.type === obj.objectType) ?? null
+                return (
+                  <div
+                    key={obj.id}
+                    className="rounded-2xl border-2 bg-surface-container overflow-hidden transition-colors"
+                    style={{ borderColor: obj.objectType ? 'rgba(23,106,33,.2)' : 'rgba(172,173,173,.2)' }}
+                  >
+                    {/* Card header */}
+                    <div
+                      className="flex items-center gap-2 px-4 py-3 cursor-pointer select-none"
+                      onClick={() => toggleExpanded(obj.id)}
+                    >
+                      <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0">
+                        <span className="text-on-primary text-[10px] font-bold">{idx + 1}</span>
+                      </div>
+                      <span className={`flex-1 text-sm font-semibold ${obj.objectType ? 'text-on-surface' : 'text-on-surface-variant italic'}`}>
+                        {cfg ? cfg.label : 'Select a type…'}
+                      </span>
+                      <span className="material-symbols-outlined text-on-surface-variant text-base transition-transform" style={{ transform: obj.expanded ? 'rotate(180deg)' : '' }}>
+                        expand_more
+                      </span>
+                      <button
+                        onClick={e => { e.stopPropagation(); removeObject(obj.id) }}
+                        className="w-7 h-7 rounded-full flex items-center justify-center text-on-surface-variant hover:text-error hover:bg-error/10 transition-colors"
+                        aria-label="Remove object"
+                      >
+                        <span className="material-symbols-outlined text-base">delete</span>
+                      </button>
+                    </div>
+
+                    {obj.expanded && (
+                      <div className="px-4 pb-4 flex flex-col gap-4 border-t border-outline-variant/20 pt-3">
+
+                        {/* Object type picker */}
+                        <div>
+                          <p className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2">Object Type</p>
+                          <div className="grid grid-cols-5 gap-1.5">
+                            {visibleTypes.map(t => {
+                              const isSelected = obj.objectType === t.type
+                              const isDisabled = !isSelected && selectedTypes.has(t.type)
+                              return (
+                                <button
+                                  key={t.type}
+                                  aria-label={t.label}
+                                  disabled={isDisabled}
+                                  onClick={() => selectObjectType(obj.id, t.type)}
+                                  title={isDisabled ? `${t.label} already added` : t.label}
+                                  className="flex flex-col items-center gap-1 py-2 rounded-xl border-2 transition-all text-[10px] font-semibold disabled:opacity-35 disabled:cursor-not-allowed"
+                                  style={isSelected
+                                    ? { borderColor: '#176a21', backgroundColor: 'rgba(23,106,33,.08)', color: '#176a21' }
+                                    : { borderColor: 'rgba(172,173,173,.25)', backgroundColor: '#f0f1f1', color: '#5a5c5c' }}
+                                >
+                                  <span className="material-symbols-outlined text-xl">{t.icon}</span>
+                                  {t.label}
+                                </button>
+                              )
+                            })}
+                          </div>
+                        </div>
+
+                        {/* Issues — only for OBSTACLE and when type is selected */}
+                        {cfg && reportType === 'OBSTACLE' && (
+                          <div>
+                            <p className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2">
+                              Issues <span className="text-error">*</span>
+                            </p>
+                            <div className="grid grid-cols-2 gap-1">
+                              {cfg.issues.map(issue => (
+                                <label
+                                  key={issue.key}
+                                  className="flex items-center gap-2 px-2.5 py-2 rounded-lg cursor-pointer hover:bg-primary/5 transition-colors"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    checked={obj.issues.includes(issue.key)}
+                                    onChange={() => toggleIssue(obj.id, issue.key)}
+                                    className="w-3.5 h-3.5 accent-primary"
+                                  />
+                                  <span className="text-xs font-medium text-on-surface">{issue.label}</span>
+                                </label>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Measurements — optional, collapsible */}
+                        {cfg && cfg.measurements.length > 0 && (
+                          <div>
+                            <button
+                              onClick={() => toggleShowMeasurements(obj.id)}
+                              className="flex items-center gap-1.5 text-xs font-semibold text-primary mb-2"
+                            >
+                              <span className="material-symbols-outlined text-base">straighten</span>
+                              {obj.showMeasurements ? 'Hide measurements' : 'Show measurements (optional)'}
+                            </button>
+                            {obj.showMeasurements && (
+                              <div className="flex flex-col gap-3">
+                                {cfg.measurements.map(m => (
+                                  <div key={m.key}>
+                                    <p className="text-[10px] font-semibold text-on-surface-variant mb-1">{m.label}</p>
+                                    <div className="flex items-center rounded-lg border border-outline-variant/30 bg-surface-container-lowest overflow-hidden focus-within:border-primary/50">
+                                      <input
+                                        type="number"
+                                        min="0"
+                                        step="0.1"
+                                        value={obj.measurements[m.key] ?? ''}
+                                        onChange={e => setMeasurement(obj.id, m.key, e.target.value)}
+                                        className="flex-1 px-3 py-2 text-sm bg-transparent outline-none text-on-surface"
+                                        placeholder="—"
+                                      />
+                                      <span className="px-2.5 text-xs text-on-surface-variant font-medium border-l border-outline-variant/25 bg-surface-container">
+                                        {m.unit}
+                                      </span>
+                                    </div>
+                                    {m.accessible_min !== undefined && (
+                                      <p className="text-[10px] text-primary mt-1 flex items-center gap-1">
+                                        <span className="material-symbols-outlined text-xs">check_circle</span>
+                                        ≥ {m.accessible_min} {m.unit} is accessible
+                                      </p>
+                                    )}
+                                    {m.accessible_max !== undefined && (
+                                      <p className="text-[10px] text-primary mt-1 flex items-center gap-1">
+                                        <span className="material-symbols-outlined text-xs">check_circle</span>
+                                        ≤ {m.accessible_max} {m.unit} is accessible
+                                      </p>
+                                    )}
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+
+            <button
+              onClick={addObject}
+              className="w-full py-3 rounded-xl border-2 border-dashed border-primary/35 text-primary text-sm font-semibold flex items-center justify-center gap-1.5 hover:bg-primary/5 hover:border-primary/50 transition-colors"
+            >
+              <span className="material-symbols-outlined text-lg">add_circle</span>
+              Add Object
+            </button>
+          </div>
+
+          {/* Description */}
+          <div>
+            <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">Details</p>
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value.slice(0, 1000))}
+              rows={4}
+              maxLength={1000}
+              placeholder="Provide a brief description of the issue..."
+              className="w-full rounded-xl border border-outline-variant/30 bg-surface-container p-4 text-sm text-on-surface placeholder-on-surface-variant/50 resize-none focus:outline-none focus:ring-2 focus:ring-primary/30"
+            />
+            <p className={`text-xs text-right mt-1 ${description.length >= 900 ? 'text-error' : 'text-outline'}`}>
+              {description.length}/1000
+            </p>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p className="text-sm text-error bg-error-container/20 rounded-lg px-4 py-2">{error}</p>
+          )}
+
+          {/* Actions */}
+          <div className="grid grid-cols-2 gap-3 pt-2">
+            <button
+              onClick={onClose}
+              className="py-4 rounded-xl border border-outline-variant/30 text-on-surface font-semibold hover:bg-surface-container transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="py-4 rounded-xl bg-primary text-on-primary font-bold hover:opacity-90 active:scale-95 transition-all disabled:opacity-60"
+            >
+              {submitting ? 'Submitting…' : 'Submit Report'}
+            </button>
+          </div>
+
         </div>
-
-        {/* Description */}
-        <div>
-          <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">Details</p>
-          <textarea
-            value={description}
-            onChange={e => setDescription(e.target.value.slice(0, 1000))}
-            rows={4}
-            maxLength={1000}
-            placeholder="Provide a brief description of the issue..."
-            className="w-full rounded-xl border border-outline-variant/30 bg-surface-container p-4 text-sm text-on-surface placeholder-on-surface-variant/50 resize-none focus:outline-none focus:ring-2 focus:ring-primary/30"
-          />
-          <p className={`text-xs text-right mt-1 ${description.length >= 900 ? 'text-error' : 'text-outline'}`}>
-            {description.length}/1000
-          </p>
-        </div>
-
-        {/* Error */}
-        {error && (
-          <p className="text-sm text-error bg-error-container/20 rounded-lg px-4 py-2">{error}</p>
-        )}
-
-        {/* Actions */}
-        <div className="grid grid-cols-2 gap-3 pt-2">
-          <button
-            onClick={onClose}
-            className="py-4 rounded-xl border border-outline-variant/30 text-on-surface font-semibold hover:bg-surface-container transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={submitting}
-            className="py-4 rounded-xl bg-primary text-on-primary font-bold hover:opacity-90 active:scale-95 transition-all disabled:opacity-60"
-          >
-            {submitting ? 'Submitting…' : 'Submit Report'}
-          </button>
-        </div>
-
-      </div>
       </aside>
     </div>
   )

--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -25,6 +25,76 @@ import Toast from './Toast.jsx'
 
 const MAX_DESCRIPTION = 1000
 
+function ImageCarousel({ allImages, title }) {
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  if (!allImages || allImages.length === 0) {
+    return (
+      <div className="w-full h-64 bg-surface-container rounded-xl shadow-sm flex items-center justify-center border border-outline-variant/10">
+        <span className="material-symbols-outlined text-6xl text-outline-variant">image</span>
+      </div>
+    )
+  }
+
+  const handlePrev = (e) => {
+    e.stopPropagation()
+    setCurrentIndex((prev) => (prev === 0 ? allImages.length - 1 : prev - 1))
+  }
+
+  const handleNext = (e) => {
+    e.stopPropagation()
+    setCurrentIndex((prev) => (prev === allImages.length - 1 ? 0 : prev + 1))
+  }
+
+  return (
+    <div className="relative w-full h-64 rounded-xl shadow-sm border border-outline-variant/10 overflow-hidden group bg-black/5">
+      <img
+        src={allImages[currentIndex]}
+        alt={`${title} - Photo ${currentIndex + 1}`}
+        className="w-full h-full object-cover transition-opacity duration-300"
+      />
+
+      {/* Navigation Arrows */}
+      {allImages.length > 1 && (
+        <>
+          <button
+            onClick={handlePrev}
+            className="absolute left-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-black/40 text-white flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity backdrop-blur-sm hover:bg-black/60"
+            aria-label="Previous image"
+          >
+            <span className="material-symbols-outlined text-xl">chevron_left</span>
+          </button>
+          
+          <button
+            onClick={handleNext}
+            className="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-black/40 text-white flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity backdrop-blur-sm hover:bg-black/60"
+            aria-label="Next image"
+          >
+            <span className="material-symbols-outlined text-xl">chevron_right</span>
+          </button>
+
+          {/* Dots Indicator */}
+          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5 px-2 py-1 rounded-full bg-black/20 backdrop-blur-sm">
+            {allImages.map((_, i) => (
+              <button
+                key={i}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setCurrentIndex(i)
+                }}
+                className={`w-1.5 h-1.5 rounded-full transition-all ${
+                  currentIndex === i ? 'bg-white w-3' : 'bg-white/50 hover:bg-white/80'
+                }`}
+                aria-label={`Go to image ${i + 1}`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
 /**
  * ReportPanel
  * Desktop: fixed right sidebar (500px) alongside the map.
@@ -143,13 +213,13 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
     if (!report || !isAuthenticated || !token) return
     getFollowStatus(report.id, token)
       .then(data => setFollowing(data?.following ?? false))
-      .catch(() => {})
+      .catch(() => { })
   }, [report?.id, isAuthenticated])
 
 
-  
 
-  
+
+
 
   const voteMutation = useMutation({
     mutationFn: ({ type }) =>
@@ -224,20 +294,20 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
 
 
   async function handleCommentSubmit() {
-  if (!newComment.trim()) return
-  setSubmittingComment(true)
-  try {
-    console.log('[handleCommentSubmit] Submitting comment:', newComment.trim())
-    const created = await createComment(report.id, newComment.trim(), token, userId)
-    console.log('[handleCommentSubmit] Created comment:', created)
-    setComments(prev => [created, ...prev])
-    setNewComment('')
-  } catch (err) {
-    console.error('[handleCommentSubmit] Error submitting comment:', err)
-  } finally {
-    setSubmittingComment(false)
+    if (!newComment.trim()) return
+    setSubmittingComment(true)
+    try {
+      console.log('[handleCommentSubmit] Submitting comment:', newComment.trim())
+      const created = await createComment(report.id, newComment.trim(), token, userId)
+      console.log('[handleCommentSubmit] Created comment:', created)
+      setComments(prev => [created, ...prev])
+      setNewComment('')
+    } catch (err) {
+      console.error('[handleCommentSubmit] Error submitting comment:', err)
+    } finally {
+      setSubmittingComment(false)
+    }
   }
-}
 
   async function handleDeleteComment(commentId) {
     try {
@@ -329,20 +399,20 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
         <aside
           style={isMobileSheet
             ? {
-                height: `${sheetHeightDvh}dvh`,
-                maxHeight: `${sheetHeightDvh}dvh`,
-                width: '100%',
-                borderTopLeftRadius: '32px',
-                borderTopRightRadius: '32px',
-                borderTop: '1px solid rgba(172,173,173,.2)',
-                boxShadow: '0 -10px 40px rgba(0,0,0,0.2)',
-              }
+              height: `${sheetHeightDvh}dvh`,
+              maxHeight: `${sheetHeightDvh}dvh`,
+              width: '100%',
+              borderTopLeftRadius: '32px',
+              borderTopRightRadius: '32px',
+              borderTop: '1px solid rgba(172,173,173,.2)',
+              boxShadow: '0 -10px 40px rgba(0,0,0,0.2)',
+            }
             : {
-                width: '500px',
-                height: '100%',
-                maxHeight: '100%',
-                borderLeft: '1px solid rgba(172,173,173,.1)',
-              }}
+              width: '500px',
+              height: '100%',
+              maxHeight: '100%',
+              borderLeft: '1px solid rgba(172,173,173,.1)',
+            }}
           className={`pointer-events-auto bg-surface-container-low flex flex-col relative overflow-y-auto ${isDragging ? '' : 'transition-[height,max-height] duration-200 ease-out'}`}
         >
 
@@ -363,572 +433,560 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
             <div className="w-12 h-1.5 bg-outline-variant/40 rounded-full mx-auto" />
           </div>
 
-        {/* Top status strip — always visible, holds the close button and the
+          {/* Top status strip — always visible, holds the close button and the
             current status pills so they stay reachable even when an active
             fix card pushes the hero image below the fold. */}
-        <div className="flex items-center justify-between px-5 pt-4 pb-2 gap-2">
-          <button
-            onClick={onClose}
-            className="w-8 h-8 bg-white rounded-full flex items-center justify-center shadow border border-outline-variant/20"
-            aria-label="Close panel"
-          >
-            <span className="material-symbols-outlined text-base">close</span>
-          </button>
-          <div className="flex items-center gap-1.5 flex-wrap justify-end">
-            <span className={`text-xs font-bold px-3 py-1.5 rounded-full uppercase tracking-wider ${
-              isFixed
+          <div className="flex items-center justify-between px-5 pt-4 pb-2 gap-2">
+            <button
+              onClick={onClose}
+              className="w-8 h-8 bg-white rounded-full flex items-center justify-center shadow border border-outline-variant/20"
+              aria-label="Close panel"
+            >
+              <span className="material-symbols-outlined text-base">close</span>
+            </button>
+            <div className="flex items-center gap-1.5 flex-wrap justify-end">
+              <span className={`text-xs font-bold px-3 py-1.5 rounded-full uppercase tracking-wider ${isFixed
                 ? 'bg-emerald-100 text-emerald-800'
                 : isRejected
-                ? 'bg-red-100 text-red-800'
-                : isValidated
-                ? 'bg-primary-container text-on-primary-container'
-                : 'bg-amber-100 text-amber-800'
-            }`}>
-              {isFixed ? 'Fixed' : isRejected ? 'Rejected' : isValidated ? 'Validated' : 'Unverified'}
-            </span>
-            {activeFix && (
-              <span className="text-[11px] font-bold px-2.5 py-1 rounded-full uppercase tracking-wider bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200">
-                Fix pending
+                  ? 'bg-red-100 text-red-800'
+                  : isValidated
+                    ? 'bg-primary-container text-on-primary-container'
+                    : 'bg-amber-100 text-amber-800'
+                }`}>
+                {isFixed ? 'Fixed' : isRejected ? 'Rejected' : isValidated ? 'Validated' : 'Unverified'}
               </span>
-            )}
+              {activeFix && (
+                <span className="text-[11px] font-bold px-2.5 py-1 rounded-full uppercase tracking-wider bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200">
+                  Fix pending
+                </span>
+              )}
+            </div>
           </div>
-        </div>
 
-        {/* Active fix request — pinned to the very top of the panel so a
+          {/* Active fix request — pinned to the very top of the panel so a
             returning voter sees the live question first, before the original
             report's metadata, image, and description. */}
-        {activeFix && (
-          <div className="px-5 pb-3">
-            <section className="rounded-2xl overflow-hidden ring-1 ring-emerald-200 shadow-sm">
-              <div className="px-4 py-2 bg-emerald-700 text-white text-[11px] font-extrabold tracking-widest uppercase flex items-center gap-2">
-                <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>build</span>
-                Fix Requested · {formatDate(activeFix.createdAt)}
-              </div>
-              <div className="bg-white p-5 flex flex-col gap-4">
-                {activeFix.mediaUrls && activeFix.mediaUrls.length > 0 && (
-                  <img
-                    src={activeFix.mediaUrls[0]}
-                    alt="Proposed fix"
-                    className="w-full max-h-56 object-cover rounded-lg"
-                  />
-                )}
-                <div className="flex items-center gap-2 text-xs">
-                  <div className="w-7 h-7 rounded-full bg-surface-container-high flex items-center justify-center">
-                    <span className="material-symbols-outlined text-on-surface-variant" style={{ fontSize: '14px' }}>person</span>
-                  </div>
-                  <p>
-                    <span className="font-bold text-on-surface">{activeFix.submittedByName || 'Anonymous'}</span>
-                    <span className="text-on-surface-variant"> says this is fixed</span>
-                  </p>
+          {activeFix && (
+            <div className="px-5 pb-3">
+              <section className="rounded-2xl overflow-hidden ring-1 ring-emerald-200 shadow-sm">
+                <div className="px-4 py-2 bg-emerald-700 text-white text-[11px] font-extrabold tracking-widest uppercase flex items-center gap-2">
+                  <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>build</span>
+                  Fix Requested · {formatDate(activeFix.createdAt)}
                 </div>
-                {activeFix.description && (
-                  <p className="text-sm leading-relaxed text-on-surface">{activeFix.description}</p>
-                )}
-
-                <div>
-                  <div className="flex items-center justify-between mb-2">
-                    <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
-                      Does this look fixed to you?
+                <div className="bg-white p-5 flex flex-col gap-4">
+                  {activeFix.mediaUrls && activeFix.mediaUrls.length > 0 && (
+                    <img
+                      src={activeFix.mediaUrls[0]}
+                      alt="Proposed fix"
+                      className="w-full max-h-56 object-cover rounded-lg"
+                    />
+                  )}
+                  <div className="flex items-center gap-2 text-xs">
+                    <div className="w-7 h-7 rounded-full bg-surface-container-high flex items-center justify-center">
+                      <span className="material-symbols-outlined text-on-surface-variant" style={{ fontSize: '14px' }}>person</span>
+                    </div>
+                    <p>
+                      <span className="font-bold text-on-surface">{activeFix.submittedByName || 'Anonymous'}</span>
+                      <span className="text-on-surface-variant"> says this is fixed</span>
                     </p>
-                    <span className="text-[11px] font-bold text-emerald-700">{fixPct}% consensus</span>
                   </div>
-                  <div className="bg-surface-container-high h-1.5 w-full rounded-full overflow-hidden">
-                    <div className="h-full rounded-full bg-emerald-600" style={{ width: `${fixPct}%` }} />
-                  </div>
-                  <p className="text-[11px] text-on-surface-variant mt-2">
-                    {activeFix.agrees || 0} agrees · {activeFix.disagrees || 0} disagrees
-                  </p>
-
-                  {fixVoteError && (
-                    <p role="alert" className="text-xs text-error bg-error-container/20 rounded-lg px-3 py-2 mt-2">
-                      {fixVoteError}
-                    </p>
+                  {activeFix.description && (
+                    <p className="text-sm leading-relaxed text-on-surface">{activeFix.description}</p>
                   )}
 
-                  {!isFixSubmitter && (
-                    <div className="grid grid-cols-2 gap-2 mt-3">
-                      <button
-                        onClick={() => handleFixVote('agree')}
-                        disabled={fixVoting}
-                        className={`py-2.5 rounded-xl text-sm font-bold active:scale-95 transition-all disabled:opacity-60 ${
-                          activeFix.userVote === 'agree'
+                  <div>
+                    <div className="flex items-center justify-between mb-2">
+                      <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+                        Does this look fixed to you?
+                      </p>
+                      <span className="text-[11px] font-bold text-emerald-700">{fixPct}% consensus</span>
+                    </div>
+                    <div className="bg-surface-container-high h-1.5 w-full rounded-full overflow-hidden">
+                      <div className="h-full rounded-full bg-emerald-600" style={{ width: `${fixPct}%` }} />
+                    </div>
+                    <p className="text-[11px] text-on-surface-variant mt-2">
+                      {activeFix.agrees || 0} agrees · {activeFix.disagrees || 0} disagrees
+                    </p>
+
+                    {fixVoteError && (
+                      <p role="alert" className="text-xs text-error bg-error-container/20 rounded-lg px-3 py-2 mt-2">
+                        {fixVoteError}
+                      </p>
+                    )}
+
+                    {!isFixSubmitter && (
+                      <div className="grid grid-cols-2 gap-2 mt-3">
+                        <button
+                          onClick={() => handleFixVote('agree')}
+                          disabled={fixVoting}
+                          className={`py-2.5 rounded-xl text-sm font-bold active:scale-95 transition-all disabled:opacity-60 ${activeFix.userVote === 'agree'
                             ? 'bg-emerald-700 text-white'
                             : 'bg-surface-container-highest text-on-surface hover:bg-emerald-100 hover:text-emerald-800'
-                        }`}
-                      >
-                        {fixVoting ? '…' : 'Yes, fixed'}
-                      </button>
-                      <button
-                        onClick={() => handleFixVote('disagree')}
-                        disabled={fixVoting}
-                        className={`py-2.5 rounded-xl text-sm font-bold active:scale-95 transition-all disabled:opacity-60 ${
-                          activeFix.userVote === 'disagree'
+                            }`}
+                        >
+                          {fixVoting ? '…' : 'Yes, fixed'}
+                        </button>
+                        <button
+                          onClick={() => handleFixVote('disagree')}
+                          disabled={fixVoting}
+                          className={`py-2.5 rounded-xl text-sm font-bold active:scale-95 transition-all disabled:opacity-60 ${activeFix.userVote === 'disagree'
                             ? 'bg-red-700 text-white'
                             : 'bg-surface-container-highest text-on-surface hover:bg-red-100 hover:text-red-800'
-                        }`}
-                      >
-                        {fixVoting ? '…' : 'No, still there'}
-                      </button>
-                    </div>
-                  )}
-                  {isFixSubmitter && (
-                    <p className="text-[11px] text-on-surface-variant text-center mt-3 italic">
-                      You submitted this fix report — the community will vote.
+                            }`}
+                        >
+                          {fixVoting ? '…' : 'No, still there'}
+                        </button>
+                      </div>
+                    )}
+                    {isFixSubmitter && (
+                      <p className="text-[11px] text-on-surface-variant text-center mt-3 italic">
+                        You submitted this fix report — the community will vote.
+                      </p>
+                    )}
+                    <p className="text-[11px] text-on-surface-variant text-center mt-3">
+                      Confirms as <strong>Fixed</strong> when 5+ agrees AND consensus ≥60%.
                     </p>
-                  )}
-                  <p className="text-[11px] text-on-surface-variant text-center mt-3">
-                    Confirms as <strong>Fixed</strong> when 5+ agrees AND consensus ≥60%.
-                  </p>
+                  </div>
                 </div>
-              </div>
-            </section>
-          </div>
-        )}
-
-        <div className="px-6 pt-2 pb-2">
-          {report.image ? (
-            <img
-              className="w-full h-64 object-cover rounded-xl shadow-sm"
-              src={report.image}
-              alt={report.title}
-            />
-          ) : (
-            <div className="w-full h-64 bg-surface-container rounded-xl shadow-sm flex items-center justify-center">
-              <span className="material-symbols-outlined text-6xl text-outline-variant">image</span>
+              </section>
             </div>
           )}
-        </div>
 
-        {/* Fix entry CTA — sits between hero and title so a returning visitor
+          <div className="px-6 pt-2 pb-2">
+            <ImageCarousel allImages={(() => {
+              const allImages = report.media?.length > 0
+                ? report.media.map(m => m.url || m)
+                : (report.mediaUrls?.length > 0 ? report.mediaUrls : (report.image ? [report.image] : []))
+              return allImages
+            })()} title={report.title} />
+          </div>
+
+          {/* Fix entry CTA — sits between hero and title so a returning visitor
             can flag a resolved obstacle without scrolling. Hidden when the
             report is already FIXED or has an OPEN fix request in flight. */}
-        {canShowFixCta && (
-          <div className="px-6 pb-2">
-            <button
-              onClick={() => setShowCreateFix(true)}
-              className="w-full flex items-center justify-between gap-3 px-4 py-3 rounded-2xl border border-outline-variant/20 bg-surface-container-lowest hover:bg-emerald-50 transition group"
-            >
-              <div className="flex items-center gap-3">
-                <div className="w-9 h-9 rounded-full bg-emerald-100 flex items-center justify-center">
-                  <span className="material-symbols-outlined text-emerald-700" style={{ fontSize: '20px' }}>build</span>
-                </div>
-                <div className="text-left">
-                  <p className="text-sm font-bold text-on-surface">Has this been fixed?</p>
-                  <p className="text-xs text-on-surface-variant">Submit a fix report with a photo</p>
-                </div>
-              </div>
-              <span className="material-symbols-outlined text-on-surface-variant group-hover:translate-x-1 transition" style={{ fontSize: '20px' }}>chevron_right</span>
-            </button>
-          </div>
-        )}
-
-        <div className="px-8 pb-12 flex flex-col gap-8">
-
-          {/* Header */}
-          <div className="flex flex-col gap-4">
-            <div className="flex items-start justify-between gap-3">
-              <h1 className="text-3xl font-extrabold font-headline tracking-tight text-on-surface leading-tight">
-                {report.title}
-              </h1>
-              {canModify && !isEditing && (
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  <button
-                    type="button"
-                    onClick={handleStartEdit}
-                    className="px-3 py-1.5 rounded-lg bg-surface-container-high text-on-surface font-semibold text-sm cursor-pointer"
-                  >
-                    Edit
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleDelete}
-                    disabled={deleteReportMutation.isPending}
-                    aria-label="Delete report"
-                    className="px-3 py-1.5 rounded-lg bg-error/10 text-error font-semibold text-sm cursor-pointer disabled:opacity-60"
-                  >
-                    {deleteReportMutation.isPending ? 'Deleting…' : 'Delete'}
-                  </button>
-                </div>
-              )}
-            </div>
-            <div className="flex items-center justify-between">
+          {canShowFixCta && (
+            <div className="px-6 pb-2">
               <button
-                type="button"
-                onClick={() => report?.ownerId && navigate(isOwner ? '/profile' : `/profile/${report.ownerId}`)}
-                className="flex items-start gap-3 cursor-pointer group"
+                onClick={() => setShowCreateFix(true)}
+                className="w-full flex items-center justify-between gap-3 px-4 py-3 rounded-2xl border border-outline-variant/20 bg-surface-container-lowest hover:bg-emerald-50 transition group"
               >
-                <div className="w-10 h-10 rounded-full bg-surface-container-high flex items-center justify-center overflow-hidden flex-shrink-0">
-                  {reporter?.avatarUrl ? (
-                    <img src={reporter.avatarUrl} alt={reporter.name} className="w-full h-full object-cover" />
-                  ) : (
-                    <span className="material-symbols-outlined text-on-surface-variant">person</span>
-                  )}
+                <div className="flex items-center gap-3">
+                  <div className="w-9 h-9 rounded-full bg-emerald-100 flex items-center justify-center">
+                    <span className="material-symbols-outlined text-emerald-700" style={{ fontSize: '20px' }}>build</span>
+                  </div>
+                  <div className="text-left">
+                    <p className="text-sm font-bold text-on-surface">Has this been fixed?</p>
+                    <p className="text-xs text-on-surface-variant">Submit a fix report with a photo</p>
+                  </div>
                 </div>
-                <div className="min-w-0">
-                  <p className="text-sm font-bold text-on-surface group-hover:underline">
-                    {reporter?.name ?? report.reportedBy}
-                  </p>
-                  {report.date && (
-                    <p className="text-xs text-on-surface-variant">{report.date}</p>
-                  )}
-                </div>
+                <span className="material-symbols-outlined text-on-surface-variant group-hover:translate-x-1 transition" style={{ fontSize: '20px' }}>chevron_right</span>
               </button>
-              {report.environment && (
-                <span className="flex items-center gap-1 text-xs font-semibold text-on-surface-variant bg-surface-container px-2.5 py-1 rounded-lg">
-                  <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>
-                    {report.environment === 'INDOOR' ? 'home' : 'wb_sunny'}
-                  </span>
-                  {report.environment === 'INDOOR' ? 'Indoor' : 'Outdoor'}
-                </span>
-              )}
             </div>
-          </div>
+          )}
 
-          {/* Objects */}
-          {report.objects?.length > 0 && (
-            <section className="flex flex-col gap-3">
-              <h3 className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">Objects</h3>
-              {report.objects.map((obj, i) => {
-                const cfg = OBJECT_TYPE_MAP[obj.objectType]
-                return (
-                  <div key={i} className="bg-surface-container-lowest rounded-xl border border-outline-variant/10 p-4 flex flex-col gap-3">
-                    <div className="flex items-center gap-2">
-                      <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
-                        <span className="material-symbols-outlined text-primary" style={{ fontSize: '18px', fontVariationSettings: "'FILL' 1" }}>
-                          {cfg?.icon ?? 'category'}
-                        </span>
-                      </div>
-                      <span className="text-sm font-bold text-on-surface">{cfg?.label ?? obj.objectType}</span>
-                    </div>
+          <div className="px-8 pb-12 flex flex-col gap-8">
 
-                    {obj.issues?.length > 0 && (
-                      <div className="flex flex-wrap gap-1.5">
-                        {obj.issues.map(issueKey => (
-                          <span key={issueKey} className="flex items-center gap-1 text-[11px] font-semibold px-2.5 py-1 rounded-full bg-error/10 text-error border border-error/15">
-                            <span className="material-symbols-outlined" style={{ fontSize: '12px' }}>warning</span>
-                            {cfg?.issues.find(i => i.key === issueKey)?.label ?? issueKey.replace(/_/g, ' ')}
-                          </span>
-                        ))}
-                      </div>
+            {/* Header */}
+            <div className="flex flex-col gap-4">
+              <div className="flex items-start justify-between gap-3">
+                <h1 className="text-3xl font-extrabold font-headline tracking-tight text-on-surface leading-tight">
+                  {report.title}
+                </h1>
+                {canModify && !isEditing && (
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <button
+                      type="button"
+                      onClick={handleStartEdit}
+                      className="px-3 py-1.5 rounded-lg bg-surface-container-high text-on-surface font-semibold text-sm cursor-pointer"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDelete}
+                      disabled={deleteReportMutation.isPending}
+                      aria-label="Delete report"
+                      className="px-3 py-1.5 rounded-lg bg-error/10 text-error font-semibold text-sm cursor-pointer disabled:opacity-60"
+                    >
+                      {deleteReportMutation.isPending ? 'Deleting…' : 'Delete'}
+                    </button>
+                  </div>
+                )}
+              </div>
+              <div className="flex items-center justify-between">
+                <button
+                  type="button"
+                  onClick={() => report?.ownerId && navigate(isOwner ? '/profile' : `/profile/${report.ownerId}`)}
+                  className="flex items-start gap-3 cursor-pointer group"
+                >
+                  <div className="w-10 h-10 rounded-full bg-surface-container-high flex items-center justify-center overflow-hidden flex-shrink-0">
+                    {reporter?.avatarUrl ? (
+                      <img src={reporter.avatarUrl} alt={reporter.name} className="w-full h-full object-cover" />
+                    ) : (
+                      <span className="material-symbols-outlined text-on-surface-variant">person</span>
                     )}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-bold text-on-surface group-hover:underline">
+                      {reporter?.name ?? report.reportedBy}
+                    </p>
+                    {report.date && (
+                      <p className="text-xs text-on-surface-variant">{report.date}</p>
+                    )}
+                  </div>
+                </button>
+                {report.environment && (
+                  <span className="flex items-center gap-1 text-xs font-semibold text-on-surface-variant bg-surface-container px-2.5 py-1 rounded-lg">
+                    <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>
+                      {report.environment === 'INDOOR' ? 'home' : 'wb_sunny'}
+                    </span>
+                    {report.environment === 'INDOOR' ? 'Indoor' : 'Outdoor'}
+                  </span>
+                )}
+              </div>
+            </div>
 
-                    {obj.measurements && Object.keys(obj.measurements).length > 0 && (
-                      <div className="flex flex-wrap gap-2">
-                        {Object.entries(obj.measurements).map(([key, val]) => {
-                          const schema = cfg?.measurements.find(m => m.key === key)
-                          const numVal = parseFloat(val)
-                          const isWarn = schema && (
-                            (schema.accessible_max !== undefined && numVal > schema.accessible_max) ||
-                            (schema.accessible_min !== undefined && numVal < schema.accessible_min)
-                          )
-                          return (
-                            <span key={key} className={`text-[11px] font-semibold px-2.5 py-1 rounded-lg flex items-center gap-1 ${
-                              isWarn
+            {/* Objects */}
+            {report.objects?.length > 0 && (
+              <section className="flex flex-col gap-3">
+                <h3 className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">Objects</h3>
+                {report.objects.map((obj, i) => {
+                  const cfg = OBJECT_TYPE_MAP[obj.objectType]
+                  return (
+                    <div key={i} className="bg-surface-container-lowest rounded-xl border border-outline-variant/10 p-4 flex flex-col gap-3">
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
+                          <span className="material-symbols-outlined text-primary" style={{ fontSize: '18px', fontVariationSettings: "'FILL' 1" }}>
+                            {cfg?.icon ?? 'category'}
+                          </span>
+                        </div>
+                        <span className="text-sm font-bold text-on-surface">{cfg?.label ?? obj.objectType}</span>
+                      </div>
+
+                      {obj.issues?.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5">
+                          {obj.issues.map(issueKey => (
+                            <span key={issueKey} className="flex items-center gap-1 text-[11px] font-semibold px-2.5 py-1 rounded-full bg-error/10 text-error border border-error/15">
+                              <span className="material-symbols-outlined" style={{ fontSize: '12px' }}>warning</span>
+                              {cfg?.issues.find(i => i.key === issueKey)?.label ?? issueKey.replace(/_/g, ' ')}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+
+                      {obj.measurements && Object.keys(obj.measurements).length > 0 && (
+                        <div className="flex flex-wrap gap-2">
+                          {Object.entries(obj.measurements).map(([key, val]) => {
+                            const schema = cfg?.measurements.find(m => m.key === key)
+                            const numVal = parseFloat(val)
+                            const isWarn = schema && (
+                              (schema.accessible_max !== undefined && numVal > schema.accessible_max) ||
+                              (schema.accessible_min !== undefined && numVal < schema.accessible_min)
+                            )
+                            return (
+                              <span key={key} className={`text-[11px] font-semibold px-2.5 py-1 rounded-lg flex items-center gap-1 ${isWarn
                                 ? 'bg-error/10 text-error border border-error/15'
                                 : 'bg-primary/10 text-primary border border-primary/15'
-                            }`}>
-                              <span className="material-symbols-outlined" style={{ fontSize: '12px' }}>
-                                {isWarn ? 'close' : 'check'}
-                              </span>
-                              {schema?.label ?? key}: {val} {schema?.unit ?? ''}
-                              {schema && (schema.accessible_min !== undefined || schema.accessible_max !== undefined) && (
-                                <span className="opacity-60 font-normal ml-0.5">
-                                  ({schema.accessible_min !== undefined ? `≥${schema.accessible_min}` : `≤${schema.accessible_max}`} ok)
+                                }`}>
+                                <span className="material-symbols-outlined" style={{ fontSize: '12px' }}>
+                                  {isWarn ? 'close' : 'check'}
                                 </span>
-                              )}
-                            </span>
-                          )
-                        })}
-                      </div>
-                    )}
-                  </div>
-                )
-              })}
-            </section>
-          )}
-
-          {/* Description */}
-          <section className="bg-surface-container-lowest p-6 rounded-xl border border-outline-variant/10">
-            <h3 className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">
-              Issue Details
-            </h3>
-            {!isEditing ? (
-              <p className="text-on-surface leading-relaxed font-body">
-                {report.description || 'No description provided.'}
-              </p>
-            ) : (
-              <div className="flex flex-col gap-4">
-                <div className="flex flex-col gap-1">
-                  <label htmlFor="report-edit-description" className="text-sm font-semibold text-on-surface">
-                    Description
-                  </label>
-                  <textarea
-                    id="report-edit-description"
-                    value={editDescription}
-                    onChange={(e) => setEditDescription(e.target.value)}
-                    rows={5}
-                    className="w-full px-4 py-3 bg-[#f0f1f1] border-none rounded-xl focus:ring-2 focus:ring-[#176a21]/40"
-                  />
-                  <p className={`text-xs text-right ${editDescriptionTooLong ? 'text-error' : 'text-on-surface-variant'}`}>
-                    {editDescription.length}/{MAX_DESCRIPTION}
-                  </p>
-                </div>
-
-                <fieldset className="flex flex-col gap-1">
-                  <legend className="text-sm font-semibold text-on-surface">Environment</legend>
-                  <div className="flex gap-3 mt-1">
-                    {['OUTDOOR', 'INDOOR'].map((opt) => (
-                      <label
-                        key={opt}
-                        className={`flex items-center gap-2 px-3 py-2 rounded-xl cursor-pointer ${editEnvironment === opt ? 'bg-primary/10 ring-2 ring-primary' : 'bg-[#f0f1f1]'}`}
-                      >
-                        <input
-                          type="radio"
-                          name="report-edit-environment"
-                          value={opt}
-                          checked={editEnvironment === opt}
-                          onChange={() => setEditEnvironment(opt)}
-                        />
-                        <span className="text-sm text-on-surface capitalize">{opt.toLowerCase()}</span>
-                      </label>
-                    ))}
-                  </div>
-                </fieldset>
-
-                {editError && (
-                  <p role="alert" className="text-sm text-error">
-                    {editError}
-                  </p>
-                )}
-
-                <div className="flex gap-2">
-                  <button
-                    type="button"
-                    onClick={handleSaveEdit}
-                    disabled={saveEditDisabled}
-                    className="px-4 py-2 rounded-lg bg-gradient-to-b from-[#176a21] to-[#025d16] text-[#d1ffc8] font-semibold disabled:opacity-60 cursor-pointer"
-                  >
-                    {updateReportMutation.isPending ? 'Saving…' : 'Save'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleCancelEdit}
-                    disabled={updateReportMutation.isPending}
-                    className="px-4 py-2 rounded-lg bg-surface-container text-on-surface font-semibold cursor-pointer"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
+                                {schema?.label ?? key}: {val} {schema?.unit ?? ''}
+                                {schema && (schema.accessible_min !== undefined || schema.accessible_max !== undefined) && (
+                                  <span className="opacity-60 font-normal ml-0.5">
+                                    ({schema.accessible_min !== undefined ? `≥${schema.accessible_min}` : `≤${schema.accessible_max}`} ok)
+                                  </span>
+                                )}
+                              </span>
+                            )
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </section>
             )}
-          </section>
 
-          {/* Location */}
-          {report.location && (
-            <section className="bg-surface-container-lowest p-4 rounded-xl border border-outline-variant/10 flex items-center gap-3">
-              <span className="material-symbols-outlined text-primary" style={{ fontVariationSettings: "'FILL' 1" }}>
-                location_on
-              </span>
-              <p className="text-sm font-medium text-on-surface">{report.location}</p>
-            </section>
-          )}
-
-          {/* Consensus */}
-          <section className="flex flex-col gap-4">
-            <div className="flex items-center justify-between">
-              <h3 className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
-                Community Consensus
+            {/* Description */}
+            <section className="bg-surface-container-lowest p-6 rounded-xl border border-outline-variant/10">
+              <h3 className="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-3">
+                Issue Details
               </h3>
-              <span className="text-xs font-bold text-primary">{consensusPct}% Consensus</span>
-            </div>
-            <div className="bg-surface-container-high h-2.5 w-full rounded-full overflow-hidden">
-              <div
-                className="bg-gradient-to-r from-primary-container to-primary h-full rounded-full transition-all"
-                style={{ width: `${consensusPct}%` }}
-              />
-            </div>
-            <div className="flex items-center justify-between text-sm text-on-surface-variant italic">
-              <span>{report.agrees || 0} people have agreed that this issue is active.</span>
-              <span className="flex gap-3 not-italic font-semibold">
-                <span className="flex items-center gap-1 text-primary">
-                  <span className="material-symbols-outlined" style={{ fontSize: '16px', fontVariationSettings: "'FILL' 1" }}>thumb_up</span>
-                  {report.agrees || 0}
-                </span>
-                <span className="flex items-center gap-1 text-error">
-                  <span className="material-symbols-outlined" style={{ fontSize: '16px', fontVariationSettings: "'FILL' 1" }}>thumb_down</span>
-                  {report.disagrees || 0}
-                </span>
-              </span>
-            </div>
+              {!isEditing ? (
+                <p className="text-on-surface leading-relaxed font-body">
+                  {report.description || 'No description provided.'}
+                </p>
+              ) : (
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-1">
+                    <label htmlFor="report-edit-description" className="text-sm font-semibold text-on-surface">
+                      Description
+                    </label>
+                    <textarea
+                      id="report-edit-description"
+                      value={editDescription}
+                      onChange={(e) => setEditDescription(e.target.value)}
+                      rows={5}
+                      className="w-full px-4 py-3 bg-[#f0f1f1] border-none rounded-xl focus:ring-2 focus:ring-[#176a21]/40"
+                    />
+                    <p className={`text-xs text-right ${editDescriptionTooLong ? 'text-error' : 'text-on-surface-variant'}`}>
+                      {editDescription.length}/{MAX_DESCRIPTION}
+                    </p>
+                  </div>
 
-            {/* Vote error */}
-            {voteError && (
-              <p className="text-sm text-error bg-error-container/20 rounded-lg px-4 py-2">
-                {voteError}
-              </p>
+                  <fieldset className="flex flex-col gap-1">
+                    <legend className="text-sm font-semibold text-on-surface">Environment</legend>
+                    <div className="flex gap-3 mt-1">
+                      {['OUTDOOR', 'INDOOR'].map((opt) => (
+                        <label
+                          key={opt}
+                          className={`flex items-center gap-2 px-3 py-2 rounded-xl cursor-pointer ${editEnvironment === opt ? 'bg-primary/10 ring-2 ring-primary' : 'bg-[#f0f1f1]'}`}
+                        >
+                          <input
+                            type="radio"
+                            name="report-edit-environment"
+                            value={opt}
+                            checked={editEnvironment === opt}
+                            onChange={() => setEditEnvironment(opt)}
+                          />
+                          <span className="text-sm text-on-surface capitalize">{opt.toLowerCase()}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </fieldset>
+
+                  {editError && (
+                    <p role="alert" className="text-sm text-error">
+                      {editError}
+                    </p>
+                  )}
+
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={handleSaveEdit}
+                      disabled={saveEditDisabled}
+                      className="px-4 py-2 rounded-lg bg-gradient-to-b from-[#176a21] to-[#025d16] text-[#d1ffc8] font-semibold disabled:opacity-60 cursor-pointer"
+                    >
+                      {updateReportMutation.isPending ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleCancelEdit}
+                      disabled={updateReportMutation.isPending}
+                      className="px-4 py-2 rounded-lg bg-surface-container text-on-surface font-semibold cursor-pointer"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </section>
+
+            {/* Location */}
+            {report.location && (
+              <section className="bg-surface-container-lowest p-4 rounded-xl border border-outline-variant/10 flex items-center gap-3">
+                <span className="material-symbols-outlined text-primary" style={{ fontVariationSettings: "'FILL' 1" }}>
+                  location_on
+                </span>
+                <p className="text-sm font-medium text-on-surface">{report.location}</p>
+              </section>
             )}
 
-            <div className="grid grid-cols-2 gap-3 mt-2">
-              <button
-                onClick={() => handleVote('agree')}
-                disabled={voting}
-                aria-label="Agree"
-                className={`flex items-center justify-center gap-2 py-3 rounded-xl font-bold active:scale-95 transition-all shadow-sm disabled:opacity-60 ${
-                  userVote === 'agree'
+            {/* Consensus */}
+            <section className="flex flex-col gap-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+                  Community Consensus
+                </h3>
+                <span className="text-xs font-bold text-primary">{consensusPct}% Consensus</span>
+              </div>
+              <div className="bg-surface-container-high h-2.5 w-full rounded-full overflow-hidden">
+                <div
+                  className="bg-gradient-to-r from-primary-container to-primary h-full rounded-full transition-all"
+                  style={{ width: `${consensusPct}%` }}
+                />
+              </div>
+              <div className="flex items-center justify-between text-sm text-on-surface-variant italic">
+                <span>{report.agrees || 0} people have agreed that this issue is active.</span>
+                <span className="flex gap-3 not-italic font-semibold">
+                  <span className="flex items-center gap-1 text-primary">
+                    <span className="material-symbols-outlined" style={{ fontSize: '16px', fontVariationSettings: "'FILL' 1" }}>thumb_up</span>
+                    {report.agrees || 0}
+                  </span>
+                  <span className="flex items-center gap-1 text-error">
+                    <span className="material-symbols-outlined" style={{ fontSize: '16px', fontVariationSettings: "'FILL' 1" }}>thumb_down</span>
+                    {report.disagrees || 0}
+                  </span>
+                </span>
+              </div>
+
+              {/* Vote error */}
+              {voteError && (
+                <p className="text-sm text-error bg-error-container/20 rounded-lg px-4 py-2">
+                  {voteError}
+                </p>
+              )}
+
+              <div className="grid grid-cols-2 gap-3 mt-2">
+                <button
+                  onClick={() => handleVote('agree')}
+                  disabled={voting}
+                  aria-label="Agree"
+                  className={`flex items-center justify-center gap-2 py-3 rounded-xl font-bold active:scale-95 transition-all shadow-sm disabled:opacity-60 ${userVote === 'agree'
                     ? 'bg-primary text-on-primary'
                     : 'bg-surface-container-highest text-on-surface hover:bg-primary/10 hover:text-primary'
-                }`}
-              >
-                <span className="material-symbols-outlined text-sm" style={{ fontVariationSettings: userVote === 'agree' ? "'FILL' 1" : "'FILL' 0" }}>thumb_up</span>
-                {voting ? '...' : 'Agree'}
-              </button>
-              <button
-                onClick={() => handleVote('disagree')}
-                disabled={voting}
-                aria-label="Disagree"
-                className={`flex items-center justify-center gap-2 py-3 rounded-xl font-bold active:scale-95 transition-all shadow-sm disabled:opacity-60 ${
-                  userVote === 'disagree'
+                    }`}
+                >
+                  <span className="material-symbols-outlined text-sm" style={{ fontVariationSettings: userVote === 'agree' ? "'FILL' 1" : "'FILL' 0" }}>thumb_up</span>
+                  {voting ? '...' : 'Agree'}
+                </button>
+                <button
+                  onClick={() => handleVote('disagree')}
+                  disabled={voting}
+                  aria-label="Disagree"
+                  className={`flex items-center justify-center gap-2 py-3 rounded-xl font-bold active:scale-95 transition-all shadow-sm disabled:opacity-60 ${userVote === 'disagree'
                     ? 'bg-error text-white'
                     : 'bg-surface-container-highest text-on-surface hover:bg-error/10 hover:text-error'
-                }`}
-              >
-                <span className="material-symbols-outlined text-sm" style={{ fontVariationSettings: userVote === 'disagree' ? "'FILL' 1" : "'FILL' 0" }}>thumb_down</span>
-                {voting ? '...' : 'Disagree'}
-              </button>
-            </div>
-          </section>
-
-
-          {/* Comments Section */}
-          <section className="flex flex-col gap-4">
-            <h3 className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
-              Comments {!commentsLoading && `(${comments.length})`}
-            </h3>
-
-            {isAuthenticated ? (
-              <div className="flex flex-col gap-2">
-                <textarea
-                  className="w-full bg-surface-container-lowest border border-outline-variant/20 rounded-xl p-4 text-sm text-on-surface placeholder:text-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/30 resize-none"
-                  rows={3}
-                  placeholder="Add a comment..."
-                  value={newComment}
-                  onChange={(e) => setNewComment(e.target.value)}
-                />
-                <button
-                  onClick={handleCommentSubmit}
-                  disabled={submittingComment || !newComment.trim()}
-                  className="self-end px-6 py-2 bg-primary text-on-primary rounded-full text-sm font-bold active:scale-95 transition-all disabled:opacity-50"
+                    }`}
                 >
-                  {submittingComment ? 'Posting...' : 'Post'}
+                  <span className="material-symbols-outlined text-sm" style={{ fontVariationSettings: userVote === 'disagree' ? "'FILL' 1" : "'FILL' 0" }}>thumb_down</span>
+                  {voting ? '...' : 'Disagree'}
                 </button>
               </div>
-            ) : (
-              <p className="text-sm text-on-surface-variant bg-surface-container-lowest p-4 rounded-xl border border-outline-variant/10">
-                <a href="/login" className="font-bold text-primary hover:underline">Log in</a> to leave a comment.
-              </p>
-            )}
+            </section>
 
-            {commentsLoading ? (
-              <p className="text-sm text-on-surface-variant italic">Loading comments...</p>
-            ) : comments.length === 0 ? (
-              <p className="text-sm text-on-surface-variant italic">No comments yet.</p>
-            ) : (
-              <div className="flex flex-col gap-4">
-                {comments.map(comment => (
-                  <div key={comment.id} className="flex gap-3">
-                    <div className="w-8 h-8 rounded-full bg-surface-container-high flex-shrink-0 flex items-center justify-center">
-                      <span className="material-symbols-outlined text-sm text-on-surface-variant">person</span>
-                    </div>
-                    <div className="flex flex-col gap-1 flex-1">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <p className="text-sm font-bold text-on-surface">{comment.author?.name || 'Anonymous'}</p>
-                          <p className="text-xs text-outline">{formatDate(comment.createdAt)}</p>
-                        </div>
-                        {userId && comment.author?.id == userId && (
-                          <button
-                            onClick={() => handleDeleteComment(comment.id)}
-                            className="text-outline hover:text-error transition-colors"
-                            aria-label="Delete comment"
-                          >
-                            <span className="material-symbols-outlined text-sm">delete</span>
-                          </button>
-                        )}
+
+            {/* Comments Section */}
+            <section className="flex flex-col gap-4">
+              <h3 className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+                Comments {!commentsLoading && `(${comments.length})`}
+              </h3>
+
+              {isAuthenticated ? (
+                <div className="flex flex-col gap-2">
+                  <textarea
+                    className="w-full bg-surface-container-lowest border border-outline-variant/20 rounded-xl p-4 text-sm text-on-surface placeholder:text-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/30 resize-none"
+                    rows={3}
+                    placeholder="Add a comment..."
+                    value={newComment}
+                    onChange={(e) => setNewComment(e.target.value)}
+                  />
+                  <button
+                    onClick={handleCommentSubmit}
+                    disabled={submittingComment || !newComment.trim()}
+                    className="self-end px-6 py-2 bg-primary text-on-primary rounded-full text-sm font-bold active:scale-95 transition-all disabled:opacity-50"
+                  >
+                    {submittingComment ? 'Posting...' : 'Post'}
+                  </button>
+                </div>
+              ) : (
+                <p className="text-sm text-on-surface-variant bg-surface-container-lowest p-4 rounded-xl border border-outline-variant/10">
+                  <a href="/login" className="font-bold text-primary hover:underline">Log in</a> to leave a comment.
+                </p>
+              )}
+
+              {commentsLoading ? (
+                <p className="text-sm text-on-surface-variant italic">Loading comments...</p>
+              ) : comments.length === 0 ? (
+                <p className="text-sm text-on-surface-variant italic">No comments yet.</p>
+              ) : (
+                <div className="flex flex-col gap-4">
+                  {comments.map(comment => (
+                    <div key={comment.id} className="flex gap-3">
+                      <div className="w-8 h-8 rounded-full bg-surface-container-high flex-shrink-0 flex items-center justify-center">
+                        <span className="material-symbols-outlined text-sm text-on-surface-variant">person</span>
                       </div>
-                      <p className="text-sm text-on-surface-variant leading-relaxed">{comment.content}</p>
+                      <div className="flex flex-col gap-1 flex-1">
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm font-bold text-on-surface">{comment.author?.name || 'Anonymous'}</p>
+                            <p className="text-xs text-outline">{formatDate(comment.createdAt)}</p>
+                          </div>
+                          {userId && comment.author?.id == userId && (
+                            <button
+                              onClick={() => handleDeleteComment(comment.id)}
+                              className="text-outline hover:text-error transition-colors"
+                              aria-label="Delete comment"
+                            >
+                              <span className="material-symbols-outlined text-sm">delete</span>
+                            </button>
+                          )}
+                        </div>
+                        <p className="text-sm text-on-surface-variant leading-relaxed">{comment.content}</p>
+                      </div>
                     </div>
+                  ))}
+                </div>
+              )}
+            </section>
+
+
+            {/* Activity Timeline */}
+            <section className="flex flex-col gap-6">
+              <h3 className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+                Recent Activity
+              </h3>
+              <div className="relative pl-6 flex flex-col gap-8">
+                <div className="absolute left-[7px] top-2 bottom-2 w-[2px] bg-surface-container-highest" />
+                <div className="relative">
+                  <div className="absolute -left-[23px] top-1 w-4 h-4 rounded-full bg-primary ring-4 ring-surface-container-low" />
+                  <div className="flex flex-col gap-1">
+                    <p className="text-sm font-bold text-on-surface">System</p>
+                    <p className="text-sm text-on-surface-variant">
+                      Report submitted and pending community verification.
+                    </p>
+                    <p className="text-xs text-outline mt-1 uppercase font-bold">{report.date}</p>
                   </div>
-                ))}
-              </div>
-            )}
-          </section>
-
-
-          {/* Activity Timeline */}
-          <section className="flex flex-col gap-6">
-            <h3 className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
-              Recent Activity
-            </h3>
-            <div className="relative pl-6 flex flex-col gap-8">
-              <div className="absolute left-[7px] top-2 bottom-2 w-[2px] bg-surface-container-highest" />
-              <div className="relative">
-                <div className="absolute -left-[23px] top-1 w-4 h-4 rounded-full bg-primary ring-4 ring-surface-container-low" />
-                <div className="flex flex-col gap-1">
-                  <p className="text-sm font-bold text-on-surface">System</p>
-                  <p className="text-sm text-on-surface-variant">
-                    Report submitted and pending community verification.
-                  </p>
-                  <p className="text-xs text-outline mt-1 uppercase font-bold">{report.date}</p>
                 </div>
               </div>
-            </div>
-          </section>
+            </section>
 
-          {/* Follow Updates */}
-          <div className="pt-4">
-            <button
-              disabled={followLoading}
-              onClick={async () => {
-                if (!isAuthenticated) { navigate('/login'); return }
-                setFollowLoading(true)
-                try {
-                  if (following) {
-                    await unfollowReport(report.id, token)
-                    setFollowing(false)
-                    onFollowChange?.(false)
-                  } else {
-                    await followReport(report.id, token)
-                    setFollowing(true)
-                    onFollowChange?.(true)
+            {/* Follow Updates */}
+            <div className="pt-4">
+              <button
+                disabled={followLoading}
+                onClick={async () => {
+                  if (!isAuthenticated) { navigate('/login'); return }
+                  setFollowLoading(true)
+                  try {
+                    if (following) {
+                      await unfollowReport(report.id, token)
+                      setFollowing(false)
+                      onFollowChange?.(false)
+                    } else {
+                      await followReport(report.id, token)
+                      setFollowing(true)
+                      onFollowChange?.(true)
+                    }
+                  } catch (err) {
+                    console.error('[ReportPanel] Follow toggle failed:', err)
+                  } finally {
+                    setFollowLoading(false)
                   }
-                } catch (err) {
-                  console.error('[ReportPanel] Follow toggle failed:', err)
-                } finally {
-                  setFollowLoading(false)
-                }
-              }}
-              className={`w-full py-5 rounded-xl font-extrabold text-lg font-headline shadow-lg active:scale-[0.98] transition-all flex items-center justify-center gap-3 disabled:opacity-60 disabled:cursor-not-allowed ${
-                following
+                }}
+                className={`w-full py-5 rounded-xl font-extrabold text-lg font-headline shadow-lg active:scale-[0.98] transition-all flex items-center justify-center gap-3 disabled:opacity-60 disabled:cursor-not-allowed ${following
                   ? 'bg-surface-container-high text-on-surface border border-outline-variant/20'
                   : 'bg-gradient-to-b from-primary to-primary-dim text-on-primary'
-              }`}
-            >
-              {followLoading
-                ? <span className="material-symbols-outlined animate-spin">progress_activity</span>
-                : <span className="material-symbols-outlined" style={{ fontVariationSettings: "'FILL' 1" }}>
+                  }`}
+              >
+                {followLoading
+                  ? <span className="material-symbols-outlined animate-spin">progress_activity</span>
+                  : <span className="material-symbols-outlined" style={{ fontVariationSettings: "'FILL' 1" }}>
                     {following ? 'notifications_off' : 'notifications_active'}
                   </span>
-              }
-              {following ? 'Unfollow' : 'Follow Updates'}
-            </button>
-            <p className="text-center text-xs text-on-surface-variant mt-4 px-6">
-              {following
-                ? 'You will be notified of every status change on this report.'
-                : 'Follow to receive notifications when this report status changes.'}
-            </p>
-          </div>
+                }
+                {following ? 'Unfollow' : 'Follow Updates'}
+              </button>
+              <p className="text-center text-xs text-on-surface-variant mt-4 px-6">
+                {following
+                  ? 'You will be notified of every status change on this report.'
+                  : 'Follow to receive notifications when this report status changes.'}
+              </p>
+            </div>
 
-        </div>
+          </div>
         </aside>
       </div>
 


### PR DESCRIPTION
# 📝 Description
Fixes #508 Currently, the report creation panel only supports single file uploads and doesn't capture the database `mediaId`s needed for future edit/delete operations. 

This PR implements the multiple media file upload UI and updates the API integration:
- Added a drag-and-drop zone and file picker in `CreateReportPanel`.
- Implemented client-side validations (max 5 files, 15MB limit, JPG/PNG only) and thumbnail previews.
- Updated the `fetch` logic to send `FormData` and correctly parse the new backend batch response `[{id, url}]`, storing both in the component's state.

⚠️ **DEPENDENCY BLOCKER:** Do not merge this PR before the backend PR (#450) is merged into `main`! The new UI strictly relies on the updated JSON response format to function properly.
# 📊 Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  Refactoring
- [ ]  Documentation
<!-- Add/delete if they are not covering/relevant !-->
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [ ] All tests passed

# 📸 Screenshots / Recordings
*Successfully uploading multiple images, generating previews, and displaying them on the report detail card:*

| 1. Empty Dropzone | 2. Uploading Files | 3. Report Detail View |
| :---: | :---: | :---: |
| <img width="300" alt="Empty" src="https://github.com/user-attachments/assets/f4452794-b822-4f28-9dfb-e29b465a5e4d" /> | <img width="300" alt="Uploading" src="https://github.com/user-attachments/assets/e3ddb3aa-fb8a-4e6e-b5e1-3d7a95b1c3a8" /> | <img width="300" alt="Detail View" src="https://github.com/user-attachments/assets/f232049e-a60e-493b-b72c-5172a0342e8b" /> |
# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
