### PR TITLE
[Web] Add Leaderboard Page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import Home from './pages/Home.jsx'
 import Signup from './pages/Signup.jsx'
 import Login from './pages/Login.jsx'
 import Feed from './pages/Feed.jsx'
+import Leaderboard from './pages/Leaderboard.jsx'
 import ProfilePage from './pages/ProfilePage.jsx'
 import UserProfilePage from './pages/UserProfilePage.jsx'
 import RequireAdmin from './components/RequireAdmin.jsx'
@@ -26,6 +27,7 @@ function App() {
       <Route path="/signup" element={<Signup />} />
       <Route path="/login" element={<Login />} />
       <Route path="/feed" element={<Feed />} />
+      <Route path="/leaderboard" element={<Leaderboard />} />
       <Route element={<RequireAuth />}>
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/profile/:userId" element={<UserProfilePage />} />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -105,6 +105,16 @@ function Navbar() {
           >
             Feed
           </NavLink>
+          <NavLink
+            to="/leaderboard"
+            className={({ isActive }) =>
+              isActive
+                ? 'text-primary border-b-2 border-primary font-semibold pb-1'
+                : 'text-on-surface-variant hover:text-primary transition-colors font-medium pb-1'
+            }
+          >
+            Leaderboard
+          </NavLink>
           {isAdmin && (
             <NavLink
               to="/admin"

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -185,4 +185,12 @@ describe('Navbar', () => {
       expect(screen.getByText('home page')).toBeInTheDocument()
     })
   })
+
+  describe('top-level nav links', () => {
+    it('exposes a Leaderboard link pointing at /leaderboard', () => {
+      renderNavbar()
+      const link = screen.getByRole('link', { name: /leaderboard/i })
+      expect(link).toHaveAttribute('href', '/leaderboard')
+    })
+  })
 })

--- a/frontend/src/hooks/useLeaderboard.js
+++ b/frontend/src/hooks/useLeaderboard.js
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { useAuth } from '../context/AuthContext.jsx'
+import { getLeaderboard } from '../services/leaderboardService.js'
+
+export const leaderboardKey = (isAuthenticated) => ['leaderboard', isAuthenticated ? 'auth' : 'anon']
+
+/**
+ * Fetches the top-N leaderboard plus, when authenticated, the caller's rank.
+ * The query key is segmented by auth state so anonymous and authenticated
+ * sessions don't share each other's `callerRank` slot.
+ */
+export function useLeaderboard() {
+  const { token, isAuthenticated } = useAuth()
+  return useQuery({
+    queryKey: leaderboardKey(isAuthenticated),
+    queryFn: () => getLeaderboard(token),
+    staleTime: 60_000,
+  })
+}

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -1,0 +1,138 @@
+import { Link } from 'react-router-dom'
+import Navbar from '../components/Navbar.jsx'
+import { useLeaderboard } from '../hooks/useLeaderboard.js'
+import { useAuth } from '../context/AuthContext.jsx'
+
+function Avatar({ url, name }) {
+  if (url) {
+    return (
+      <img
+        src={url}
+        alt=""
+        className="w-10 h-10 rounded-full object-cover flex-shrink-0"
+      />
+    )
+  }
+  return (
+    <div className="w-10 h-10 rounded-full bg-surface-container-high flex items-center justify-center flex-shrink-0">
+      <span className="material-symbols-outlined text-on-surface-variant" style={{ fontSize: '22px' }}>
+        person
+      </span>
+    </div>
+  )
+}
+
+function RankCell({ rank }) {
+  // Top 3 get a colored chip; the rest stay neutral. Tie-aware values are
+  // already produced by the backend (olympic-style rank assignment), so we
+  // never need to display "T-1" — the rank itself does the talking.
+  const tone =
+    rank === 1
+      ? 'bg-[#fde68a] text-[#92400e]' // gold
+      : rank === 2
+        ? 'bg-[#e5e7eb] text-[#374151]' // silver
+        : rank === 3
+          ? 'bg-[#fed7aa] text-[#9a3412]' // bronze
+          : 'bg-surface-container text-on-surface-variant'
+  return (
+    <div className={`w-12 h-10 rounded-lg flex items-center justify-center font-bold text-sm tabular-nums ${tone}`}>
+      #{rank}
+    </div>
+  )
+}
+
+function YourRankBanner({ rank, points }) {
+  return (
+    <div className="bg-primary/5 border border-primary/20 rounded-2xl p-4 flex items-center justify-between gap-4">
+      <div className="flex items-center gap-3">
+        <span className="material-symbols-outlined text-primary" style={{ fontSize: '24px' }}>
+          person_pin
+        </span>
+        <div className="flex flex-col">
+          <span className="text-xs uppercase tracking-wide text-on-surface-variant">Your rank</span>
+          <span className="text-2xl font-bold text-on-surface tabular-nums">#{rank}</span>
+        </div>
+      </div>
+      <div className="flex flex-col items-end">
+        <span className="text-xs uppercase tracking-wide text-on-surface-variant">Points</span>
+        <span className="text-2xl font-bold text-on-surface tabular-nums">{points}</span>
+      </div>
+    </div>
+  )
+}
+
+function Leaderboard() {
+  const { isAuthenticated } = useAuth()
+  const { data, isPending, isError } = useLeaderboard()
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background">
+      <Navbar />
+      <main className="flex-1 max-w-3xl w-full mx-auto p-4 md:p-8 flex flex-col gap-6">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-3xl font-bold font-headline text-on-surface">Leaderboard</h1>
+          <p className="text-sm text-on-surface-variant">
+            Top contributors ranked by points. Tied scores share a rank.
+          </p>
+        </div>
+
+        {isPending && (
+          <p className="text-sm text-on-surface-variant">Loading leaderboard…</p>
+        )}
+
+        {isError && (
+          <p role="alert" className="text-sm text-error">
+            Failed to load the leaderboard. Please try again later.
+          </p>
+        )}
+
+        {!isPending && !isError && data && (
+          <>
+            {data.callerRank && (
+              <YourRankBanner rank={data.callerRank.rank} points={data.callerRank.points} />
+            )}
+
+            {!isAuthenticated && (
+              <p className="text-xs text-on-surface-variant">
+                <Link to="/login" className="text-primary font-semibold hover:underline">
+                  Log in
+                </Link>{' '}
+                to see your own rank on this page.
+              </p>
+            )}
+
+            {data.entries.length === 0 ? (
+              <p className="text-sm text-on-surface-variant">
+                No ranked users yet. Submit a report to get on the board.
+              </p>
+            ) : (
+              <ol className="flex flex-col gap-2">
+                {data.entries.map((entry) => (
+                  <li
+                    key={entry.userId}
+                    className="bg-surface-container-lowest rounded-2xl shadow-sm p-3 flex items-center gap-3"
+                  >
+                    <RankCell rank={entry.rank} />
+                    <Avatar url={entry.avatarUrl} name={entry.name} />
+                    <Link
+                      to={`/profile/${entry.userId}`}
+                      className="flex-1 min-w-0 text-on-surface font-semibold hover:text-primary transition-colors truncate"
+                    >
+                      {entry.name}
+                    </Link>
+                    <div className="flex flex-col items-end flex-shrink-0">
+                      <span className="text-xs uppercase tracking-wide text-on-surface-variant">Points</span>
+                      <span className="font-bold text-on-surface tabular-nums">{entry.points}</span>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default Leaderboard

--- a/frontend/src/pages/Leaderboard.test.jsx
+++ b/frontend/src/pages/Leaderboard.test.jsx
@@ -1,0 +1,112 @@
+import { render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Leaderboard from './Leaderboard.jsx'
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: vi.fn(),
+}))
+vi.mock('../hooks/useLeaderboard.js', () => ({
+  useLeaderboard: vi.fn(),
+  leaderboardKey: () => ['leaderboard'],
+}))
+vi.mock('../components/Navbar.jsx', () => ({
+  default: () => <div data-testid="navbar" />,
+}))
+
+import { useAuth } from '../context/AuthContext.jsx'
+import { useLeaderboard } from '../hooks/useLeaderboard.js'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <Leaderboard />
+    </MemoryRouter>,
+  )
+}
+
+const SAMPLE_PAYLOAD = {
+  entries: [
+    { rank: 1, userId: 10, name: 'Alice', avatarUrl: null, points: 200 },
+    { rank: 1, userId: 11, name: 'Bob', avatarUrl: null, points: 200 },
+    { rank: 3, userId: 12, name: 'Carol', avatarUrl: null, points: 150 },
+  ],
+  callerRank: { rank: 5, points: 95 },
+}
+
+describe('Leaderboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuth.mockReturnValue({ token: 'tok', isAuthenticated: true })
+  })
+
+  it('renders a loading state while the query is pending', () => {
+    useLeaderboard.mockReturnValue({ data: undefined, isPending: true, isError: false })
+    renderPage()
+    expect(screen.getByText(/loading leaderboard/i)).toBeInTheDocument()
+  })
+
+  it('renders an error state when the query fails', () => {
+    useLeaderboard.mockReturnValue({ data: undefined, isPending: false, isError: true })
+    renderPage()
+    expect(screen.getByRole('alert')).toHaveTextContent(/failed to load/i)
+  })
+
+  it('renders the entries with rank, name, and points', () => {
+    useLeaderboard.mockReturnValue({ data: SAMPLE_PAYLOAD, isPending: false, isError: false })
+    renderPage()
+
+    const list = screen.getByRole('list')
+    const items = within(list).getAllByRole('listitem')
+    expect(items).toHaveLength(3)
+
+    // Tied users (Alice, Bob at rank 1) both show "#1"; Carol at rank 3.
+    expect(within(items[0]).getByText('#1')).toBeInTheDocument()
+    expect(within(items[1]).getByText('#1')).toBeInTheDocument()
+    expect(within(items[2]).getByText('#3')).toBeInTheDocument()
+
+    expect(within(items[0]).getByText('Alice')).toBeInTheDocument()
+    expect(within(items[2]).getByText('150')).toBeInTheDocument()
+  })
+
+  it('shows the "your rank" banner when authenticated and ranked', () => {
+    useLeaderboard.mockReturnValue({ data: SAMPLE_PAYLOAD, isPending: false, isError: false })
+    renderPage()
+
+    // Banner sits above the list and surfaces both rank and points.
+    expect(screen.getByText(/your rank/i)).toBeInTheDocument()
+    expect(screen.getByText('#5')).toBeInTheDocument()
+    expect(screen.getByText('95')).toBeInTheDocument()
+  })
+
+  it('hides the "your rank" banner when callerRank is null (anonymous or opt-out)', () => {
+    useAuth.mockReturnValue({ token: null, isAuthenticated: false })
+    useLeaderboard.mockReturnValue({
+      data: { ...SAMPLE_PAYLOAD, callerRank: null },
+      isPending: false,
+      isError: false,
+    })
+    renderPage()
+
+    expect(screen.queryByText(/your rank/i)).not.toBeInTheDocument()
+    // Anonymous viewers get a hint to log in instead.
+    expect(screen.getByText(/log in/i)).toBeInTheDocument()
+  })
+
+  it('shows an empty-state message when nobody is ranked yet', () => {
+    useLeaderboard.mockReturnValue({
+      data: { entries: [], callerRank: null },
+      isPending: false,
+      isError: false,
+    })
+    renderPage()
+    expect(screen.getByText(/no ranked users yet/i)).toBeInTheDocument()
+  })
+
+  it('links each entry to the user profile page', () => {
+    useLeaderboard.mockReturnValue({ data: SAMPLE_PAYLOAD, isPending: false, isError: false })
+    renderPage()
+
+    const aliceLink = screen.getByRole('link', { name: 'Alice' })
+    expect(aliceLink).toHaveAttribute('href', '/profile/10')
+  })
+})

--- a/frontend/src/services/leaderboardService.js
+++ b/frontend/src/services/leaderboardService.js
@@ -1,0 +1,15 @@
+import { apiFetch } from './api.js'
+
+function authHeaders(token) {
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+/**
+ * Fetches the public leaderboard payload — top-N entries plus the caller's
+ * own rank when authenticated. The endpoint is public, so token is optional;
+ * callers pass it through so the backend can populate `callerRank` in the
+ * response (it stays null for anonymous viewers and opt-out users).
+ */
+export async function getLeaderboard(token) {
+  return apiFetch('/api/leaderboard', { headers: authHeaders(token) })
+}


### PR DESCRIPTION
# 📝 Description
Adds the public `/leaderboard` page that consumes the API introduced in #499 and the navigation entry point. Frontend slice; lands on top of the profile UI shipped under #503 inside the #499  branch.

- `leaderboardService.getLeaderboard(token)` — public endpoint; the token is forwarded so the backend can populate `callerRank` on the response (stays null for anonymous viewers and opt-out users).
- `useLeaderboard` query hook with an auth-segmented key — anonymous and authenticated sessions don't share each other's `callerRank` cache slot.
- `Leaderboard` page: top-N list with rank, avatar, name, and points; gold/silver/bronze tone for the top three; tied scores share a rank (the backend produces olympic-style ordering, the UI just renders what comes back). A "Your rank" banner sits above the list when the caller is authenticated and ranked; anonymous viewers see a "log in" hint instead. Empty leaderboard surfaces "No ranked users yet" copy.
- Each entry links to `/profile/{id}` so visitors can drill into a contributor's profile.
- `App.jsx` registers the `/leaderboard` route as a public page.
- Navbar gains a Leaderboard nav link next to Home and Feed.
- 7 new tests for the page (loading/error/empty, ranks, tied scores, banner visibility, anonymous fallback, profile link) plus 1 new test on Navbar covering the link.

Merge order: this PR sits on top of the gamification stack. Once PR-1 → PR-2 → PR-3 → PR-4 (with #503 already inside) reach main, this branch's base auto-rolls to main and is ready to merge.

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
<img width="1429" height="683" alt="image" src="https://github.com/user-attachments/assets/41498252-6c39-4bc4-86d0-542cfe890242" />

# ⏱️ Estimated Review Time
- [x] 5-15 min
