### PR TITLE
[Web] Render Badge Notifications and Author Badges

### DIFF
--- a/frontend/src/components/NotificationDropdown.jsx
+++ b/frontend/src/components/NotificationDropdown.jsx
@@ -6,6 +6,7 @@ const TYPE_ICON = {
   STATUS_CHANGE: 'task_alt',
   NEW_COMMENT: 'chat_bubble',
   NAV_ALERT: 'navigation',
+  BADGE_AWARDED: 'workspace_premium',
 }
 
 function timeAgo(isoString) {

--- a/frontend/src/components/NotificationDropdown.test.jsx
+++ b/frontend/src/components/NotificationDropdown.test.jsx
@@ -128,6 +128,41 @@ describe('NotificationDropdown', () => {
     })
   })
 
+  describe('badge notifications', () => {
+    it('renders the workspace_premium icon for BADGE_AWARDED notifications', () => {
+      setupHooks([
+        makeNotif({
+          id: 9,
+          type: 'BADGE_AWARDED',
+          message: 'You earned the Trusted Reporter badge!',
+          relatedEntityId: null,
+        }),
+      ])
+      renderDropdown()
+      // Icon ligature is the text content of the material-symbols span.
+      expect(screen.getByText('workspace_premium')).toBeInTheDocument()
+    })
+
+    it('marks badge notification as read on click without navigating (no relatedEntityId)', async () => {
+      const user = userEvent.setup()
+      setupHooks([
+        makeNotif({
+          id: 9,
+          type: 'BADGE_AWARDED',
+          message: 'You earned the Trusted Reporter badge!',
+          relatedEntityId: null,
+          read: false,
+        }),
+      ])
+      renderDropdown()
+
+      await user.click(screen.getByText(/trusted reporter/i))
+
+      expect(markReadMutate).toHaveBeenCalledWith(9)
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+  })
+
   describe('dismiss behaviour', () => {
     it('calls onClose when Escape is pressed', async () => {
       const user = userEvent.setup()

--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -22,6 +22,7 @@ import { reportKeys, useUpdateMapReport, useDeleteMapReport } from '../hooks/use
 import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
 import CreateFixRequestPanel from './CreateFixRequestPanel.jsx'
 import Toast from './Toast.jsx'
+import BadgeIcon from './BadgeIcon.jsx'
 
 const MAX_DESCRIPTION = 1000
 
@@ -565,9 +566,14 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
                   )}
                 </div>
                 <div className="min-w-0">
-                  <p className="text-sm font-bold text-on-surface group-hover:underline">
-                    {reporter?.name ?? report.reportedBy}
-                  </p>
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    <p className="text-sm font-bold text-on-surface group-hover:underline">
+                      {reporter?.name ?? report.reportedBy}
+                    </p>
+                    {report.authorTopBadge && (
+                      <BadgeIcon badge={report.authorTopBadge} size="sm" />
+                    )}
+                  </div>
                   {report.date && (
                     <p className="text-xs text-on-surface-variant">{report.date}</p>
                   )}

--- a/frontend/src/components/ReportPanel.test.jsx
+++ b/frontend/src/components/ReportPanel.test.jsx
@@ -406,6 +406,21 @@ describe('ReportPanel', () => {
       expect(screen.getByText('User #42')).toBeInTheDocument()
     })
 
+    it('renders the author top badge chip next to the username when present', () => {
+      useUserProfile.mockReturnValue({ data: { name: 'Alice Mapper', avatarUrl: null } })
+      renderPanel({ report: { ...reportWithOwner, authorTopBadge: 'TOP_10' } })
+      // BadgeIcon (size="sm") exposes the badge label via aria-label.
+      expect(screen.getByLabelText('Top 10')).toBeInTheDocument()
+    })
+
+    it('omits the author badge when the report has no top badge', () => {
+      useUserProfile.mockReturnValue({ data: { name: 'Alice Mapper', avatarUrl: null } })
+      renderPanel({ report: { ...reportWithOwner, authorTopBadge: null } })
+      expect(screen.queryByLabelText('Top 10')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Trusted Reporter')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Expert Mapper')).not.toBeInTheDocument()
+    })
+
     it('navigates to /profile/:ownerId when the reporter row is clicked', async () => {
       useUserProfile.mockReturnValue({ data: { name: 'Alice Mapper', avatarUrl: null } })
       const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -207,6 +207,7 @@ export function mapReport(r) {
     latitude: r.latitude,
     longitude: r.longitude,
     activeFixRequest: mapFixRequest(r.activeFixRequest),
+    authorTopBadge: r.authorTopBadge ?? null,
   }
 }
 


### PR DESCRIPTION
# 📝 Description
Final frontend slice of the gamification rollout. Two small surface tweaks that make the existing badge data visible to users:

- `NotificationDropdown` maps the new `BADGE_AWARDED` notification type to a `workspace_premium` icon so badge alerts ("You earned the Trusted Reporter badge!", "You broke into the Top 10 — congrats!") visually stand out from status-change and comment notifications. Badge notifications carry a null `relatedEntityId`, so the existing click handler already does the right thing — mark as read, no navigation.
- `mapReport` forwards the new `authorTopBadge` field from the API response into the frontend report shape.
- `ReportPanel` renders a small `<BadgeIcon size="sm">` chip next to the author username in the reporter row — surfaces the highest-tier badge held by the report's author. Falls back to nothing when the author has no badges yet.
- 4 new tests across the two components covering icon render, the no-navigation click path for badge alerts, and the present/absent author-badge rendering.

Closes the gamification rollout end-to-end (PR-1 backend foundation → PR-7 frontend display).

Fixes #270

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
<img width="308" height="107" alt="image" src="https://github.com/user-attachments/assets/24fb13ed-0285-421e-a0ee-5e1f5ff7d9d4" />
<img width="232" height="107" alt="image" src="https://github.com/user-attachments/assets/a8b70586-5014-4be8-9d52-73d7ec873562" />

# ⏱️ Estimated Review Time
- [x] 5-15 min
