### PR TITLE
[Backend] Wire Gamification into Fix Requests

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/model/PointReason.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/PointReason.java
@@ -27,5 +27,26 @@ public enum PointReason {
     VOTE_ALIGNED,
 
     /** Voter penalty when their vote opposed the final status. */
-    VOTE_OPPOSED
+    VOTE_OPPOSED,
+
+    /** A vote was cast on a fix request. Symmetric to VOTE_CAST but tracked
+     *  separately so the cast/withdraw cycle for fix requests is paired
+     *  against its own ledger entries, not against report votes. */
+    FIX_REQUEST_VOTE_CAST,
+
+    /** A previously cast fix-request vote was fully withdrawn. */
+    FIX_REQUEST_VOTE_WITHDRAWN,
+
+    /** Bonus to the fix-request submitter when their request reaches
+     *  RESOLVED_FIXED — analogous to REPORT_VERIFIED_BONUS but for the
+     *  person who proved the report is no longer an obstacle. */
+    FIX_RESOLVED_BONUS,
+
+    /** Voter reward when their fix-request vote agreed with the resolved
+     *  outcome (agree → request resolved as fixed). */
+    FIX_VOTE_ALIGNED,
+
+    /** Voter penalty when their fix-request vote opposed the resolved
+     *  outcome (disagree → request still resolved as fixed). */
+    FIX_VOTE_OPPOSED
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/FixRequestVoteRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/FixRequestVoteRepository.java
@@ -27,4 +27,14 @@ public interface FixRequestVoteRepository extends JpaRepository<FixRequestVote, 
             """)
     List<Object[]> findVotesByUserIdAndFixRequestIds(@Param("userId") Long userId,
                                                      @Param("fixRequestIds") Collection<Long> fixRequestIds);
+
+    /** Returns {@code [userId, VoteType]} tuples for everyone who voted on a fix request.
+     *  Used by GamificationService at FIXED-transition time to award/deduct points to
+     *  voters based on whether they aligned with the resolved outcome. */
+    @Query("""
+            select frv.user.id, frv.voteType
+            from FixRequestVote frv
+            where frv.fixRequest.id = :fixRequestId
+            """)
+    List<Object[]> findVoteTuplesByFixRequestId(@Param("fixRequestId") Long fixRequestId);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/FixRequestService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/FixRequestService.java
@@ -37,6 +37,7 @@ public class FixRequestService {
     private final S3MediaService s3MediaService;
     private final PublicSseService publicSseService;
     private final NotificationService notificationService;
+    private final GamificationService gamificationService;
 
     @Value("${app.report.fix.threshold:5}")
     private int fixThreshold;
@@ -115,6 +116,11 @@ public class FixRequestService {
 
         var existing = fixRequestVoteRepository.findByUserIdAndFixRequestId(user.getId(), fixRequestId);
 
+        // Three branches mirror ReportService.verify/unverify: same-direction
+        // toggle = withdraw, opposite-direction = modify (no extra points),
+        // absent = fresh cast.
+        boolean fresh = false;
+        boolean withdrawn = false;
         if (existing.isPresent()) {
             FixRequestVote vote = existing.get();
             if (vote.getVoteType() == desired) {
@@ -122,6 +128,7 @@ public class FixRequestService {
                 if (desired == VoteType.AGREE) fixRequest.decrementAgrees();
                 else fixRequest.decrementDisagrees();
                 fixRequestVoteRepository.delete(vote);
+                withdrawn = true;
             } else {
                 // Switch
                 if (desired == VoteType.AGREE) {
@@ -138,10 +145,16 @@ public class FixRequestService {
             if (desired == VoteType.AGREE) fixRequest.incrementAgrees();
             else fixRequest.incrementDisagrees();
             fixRequestVoteRepository.save(new FixRequestVote(user, fixRequest, desired));
+            fresh = true;
         }
 
         evaluateFixStatus(fixRequest);
         FixRequest saved = fixRequestRepository.save(fixRequest);
+        if (fresh) {
+            gamificationService.awardOnFixRequestVoteCast(user, saved.getId());
+        } else if (withdrawn) {
+            gamificationService.deductOnFixRequestVoteWithdraw(user, saved.getId());
+        }
         // Broadcast on every vote so other clients see the consensus % update live.
         // Skipped when the vote just triggered a FIXED transition -- broadcastFixed
         // already fires for that case from evaluateFixStatus.
@@ -176,6 +189,7 @@ public class FixRequestService {
         reportRepository.save(report);
 
         notificationService.notifyStatusChange(report, fixRequest.getSubmittedBy().getId());
+        gamificationService.onFixRequestResolved(fixRequest);
         TransactionalEvents.runAfterCommit(() -> publicSseService.broadcastFixed(report));
     }
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
@@ -1,6 +1,7 @@
 package com.bounswe2026group1.backend.service;
 
 import com.bounswe2026group1.backend.model.Badge;
+import com.bounswe2026group1.backend.model.FixRequest;
 import com.bounswe2026group1.backend.model.PointEvent;
 import com.bounswe2026group1.backend.model.PointReason;
 import com.bounswe2026group1.backend.model.RegisteredUser;
@@ -8,6 +9,7 @@ import com.bounswe2026group1.backend.model.Report;
 import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.UserBadge;
 import com.bounswe2026group1.backend.model.VoteType;
+import com.bounswe2026group1.backend.repository.FixRequestVoteRepository;
 import com.bounswe2026group1.backend.repository.PointEventRepository;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.repository.ReportRepository;
@@ -40,6 +42,7 @@ public class GamificationService {
     private final RegisteredUserRepository userRepository;
     private final ReportRepository reportRepository;
     private final ReportVerificationRepository verificationRepository;
+    private final FixRequestVoteRepository fixRequestVoteRepository;
     private final PointEventRepository pointEventRepository;
     private final UserBadgeRepository userBadgeRepository;
     private final LeaderboardService leaderboardService;
@@ -71,6 +74,21 @@ public class GamificationService {
 
     @Value("${app.gamification.badges.expert-mapper-threshold:50}")
     private int expertMapperThreshold;
+
+    @Value("${app.gamification.points.fix-request-vote-cast:5}")
+    private int fixRequestVoteCastDelta;
+
+    @Value("${app.gamification.points.fix-request-vote-withdrawn:-5}")
+    private int fixRequestVoteWithdrawnDelta;
+
+    @Value("${app.gamification.points.fix-resolved-bonus:20}")
+    private int fixResolvedBonusDelta;
+
+    @Value("${app.gamification.points.fix-vote-aligned:15}")
+    private int fixVoteAlignedDelta;
+
+    @Value("${app.gamification.points.fix-vote-opposed:-5}")
+    private int fixVoteOpposedDelta;
 
     // ────────────────────────── Public API ──────────────────────────────
 
@@ -209,6 +227,83 @@ public class GamificationService {
         return newlyAwarded;
     }
 
+    // ────────────────────── Fix-request flow (symmetric) ────────────────
+
+    /**
+     * Voter cast a fresh vote on a fix request. Same semantics as
+     * {@link #awardOnVoteCast} but tracked against fix-request-specific
+     * ledger reasons so cast/withdraw cycles for fix requests are paired
+     * against each other, not against report votes on the same row.
+     */
+    @Transactional
+    public void awardOnFixRequestVoteCast(RegisteredUser voter, Long fixRequestId) {
+        if (voter == null || fixRequestId == null) return;
+        if (isCurrentlyVotedOnFixRequest(voter.getId(), fixRequestId)) {
+            return; // Modify-vote path, no extra points.
+        }
+        applyDelta(voter, fixRequestVoteCastDelta, PointReason.FIX_REQUEST_VOTE_CAST, fixRequestId);
+    }
+
+    /** Voter fully withdrew their previously cast fix-request vote. */
+    @Transactional
+    public void deductOnFixRequestVoteWithdraw(RegisteredUser voter, Long fixRequestId) {
+        if (voter == null || fixRequestId == null) return;
+        if (!isCurrentlyVotedOnFixRequest(voter.getId(), fixRequestId)) {
+            return;
+        }
+        applyDelta(voter, fixRequestVoteWithdrawnDelta, PointReason.FIX_REQUEST_VOTE_WITHDRAWN, fixRequestId);
+    }
+
+    /**
+     * A fix request reached the resolved-fixed state. The submitter (who
+     * proved the report is no longer an obstacle) gets the bonus; voters
+     * are paid out by alignment with the resolved outcome.
+     *
+     * <p>The original report author is intentionally NOT paid here — they
+     * already received the verified-bonus when the report first reached
+     * VERIFIED. Re-rewarding them on resolution would double-count.
+     */
+    @Transactional
+    public void onFixRequestResolved(FixRequest fixRequest) {
+        if (fixRequest == null) return;
+        Long fixRequestId = fixRequest.getId();
+
+        // 1) Submitter bonus.
+        RegisteredUser submitter = fixRequest.getSubmittedBy();
+        if (submitter != null) {
+            applyDelta(submitter, fixResolvedBonusDelta,
+                    PointReason.FIX_RESOLVED_BONUS, fixRequestId);
+        }
+
+        // 2) Voter alignment payout. Resolved-fixed → AGREE was the right call.
+        List<Object[]> voteTuples = fixRequestVoteRepository
+                .findVoteTuplesByFixRequestId(fixRequestId);
+        if (voteTuples.isEmpty()) return;
+
+        List<Long> voterIds = voteTuples.stream()
+                .map(row -> (Long) row[0])
+                .filter(id -> submitter == null || !id.equals(submitter.getId()))
+                .toList();
+        if (voterIds.isEmpty()) return;
+
+        Map<Long, RegisteredUser> votersById = userRepository.findAllById(voterIds).stream()
+                .collect(Collectors.toMap(RegisteredUser::getId, Function.identity()));
+
+        for (Object[] row : voteTuples) {
+            Long voterId = (Long) row[0];
+            VoteType voteType = (VoteType) row[1];
+            if (submitter != null && voterId.equals(submitter.getId())) continue;
+
+            RegisteredUser voter = votersById.get(voterId);
+            if (voter == null) continue;
+
+            boolean aligned = (voteType == VoteType.AGREE);
+            int delta = aligned ? fixVoteAlignedDelta : fixVoteOpposedDelta;
+            PointReason reason = aligned ? PointReason.FIX_VOTE_ALIGNED : PointReason.FIX_VOTE_OPPOSED;
+            applyDelta(voter, delta, reason, fixRequestId);
+        }
+    }
+
     // ────────────────────────── Internals ───────────────────────────────
 
     /**
@@ -259,6 +354,20 @@ public class GamificationService {
                 .countByUserIdAndRelatedEntityIdAndReason(userId, reportId, PointReason.VOTE_CAST);
         long withdrawals = pointEventRepository
                 .countByUserIdAndRelatedEntityIdAndReason(userId, reportId, PointReason.VOTE_WITHDRAWN);
+        return casts > withdrawals;
+    }
+
+    /**
+     * Fix-request analogue of {@link #isCurrentlyVoted}. Tracked against
+     * its own pair of ledger reasons so a user voting on both a report
+     * and a fix request for that report can still be paid for both —
+     * the two cast/withdraw cycles are independent.
+     */
+    private boolean isCurrentlyVotedOnFixRequest(Long userId, Long fixRequestId) {
+        long casts = pointEventRepository
+                .countByUserIdAndRelatedEntityIdAndReason(userId, fixRequestId, PointReason.FIX_REQUEST_VOTE_CAST);
+        long withdrawals = pointEventRepository
+                .countByUserIdAndRelatedEntityIdAndReason(userId, fixRequestId, PointReason.FIX_REQUEST_VOTE_WITHDRAWN);
         return casts > withdrawals;
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -86,3 +86,9 @@ app.gamification.badges.trusted-reporter-threshold=10
 app.gamification.badges.expert-mapper-threshold=50
 app.gamification.leaderboard.size=100
 app.gamification.leaderboard.top-badge-rank=10
+# Fix-request flow — symmetric with the report flow above
+app.gamification.points.fix-request-vote-cast=5
+app.gamification.points.fix-request-vote-withdrawn=-5
+app.gamification.points.fix-resolved-bonus=20
+app.gamification.points.fix-vote-aligned=15
+app.gamification.points.fix-vote-opposed=-5

--- a/backend/src/main/resources/db/migration/V4__drop_legacy_point_event_reason_check.sql
+++ b/backend/src/main/resources/db/migration/V4__drop_legacy_point_event_reason_check.sql
@@ -1,0 +1,16 @@
+-- Drop the legacy CHECK constraint on point_events.reason. Hibernate
+-- generated it from the original 7 PointReason values when the table was
+-- first created; the fix-request flow adds 5 new values
+-- (FIX_REQUEST_VOTE_CAST, FIX_REQUEST_VOTE_WITHDRAWN, FIX_RESOLVED_BONUS,
+-- FIX_VOTE_ALIGNED, FIX_VOTE_OPPOSED). ddl-auto does NOT extend existing
+-- CHECK constraints when new enum values are added later, so inserts using
+-- the new values would fail at the DB layer with a 23514 violation.
+--
+-- Same pattern as V2 and V3: the column stays plain VARCHAR; enum
+-- validation is enforced application-side via @Enumerated(EnumType.STRING)
+-- and Spring's JSON deserialization, which already rejects unknown values
+-- at the request layer with a 400 before any DB write.
+--
+-- IF EXISTS keeps this safe on fresh environments where the constraint
+-- never existed in the first place.
+ALTER TABLE IF EXISTS point_events DROP CONSTRAINT IF EXISTS point_events_reason_check;

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/FixRequestServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/FixRequestServiceTest.java
@@ -46,6 +46,7 @@ class FixRequestServiceTest {
     @Mock private S3MediaService s3MediaService;
     @Mock private PublicSseService publicSseService;
     @Mock private NotificationService notificationService;
+    @Mock private GamificationService gamificationService;
 
     @InjectMocks
     private FixRequestService fixRequestService;
@@ -361,4 +362,74 @@ class FixRequestServiceTest {
     }
 
     private static FixRequestState eqState(FixRequestState s) { return eq(s); }
+
+    // ── gamification wiring ──────────────────────────────────────────────────
+
+    @Test
+    void agree_freshCast_awardsFixRequestVoteCastPoints() {
+        FixRequest fr = new FixRequest(parentReport, submitter, null);
+        ReflectionTestUtils.setField(fr, "id", 50L);
+        when(registeredUserRepository.findByEmail("voter@test.com")).thenReturn(Optional.of(voter));
+        when(fixRequestRepository.findById(50L)).thenReturn(Optional.of(fr));
+        when(fixRequestVoteRepository.findByUserIdAndFixRequestId(3L, 50L)).thenReturn(Optional.empty());
+        when(fixRequestRepository.save(any(FixRequest.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        fixRequestService.agree(50L, "voter@test.com");
+
+        verify(gamificationService).awardOnFixRequestVoteCast(eq(voter), eq(50L));
+        verify(gamificationService, never()).deductOnFixRequestVoteWithdraw(any(), any());
+    }
+
+    @Test
+    void agree_toggleOff_deductsFixRequestWithdrawPoints() {
+        FixRequest fr = new FixRequest(parentReport, submitter, null);
+        ReflectionTestUtils.setField(fr, "id", 50L);
+        fr.incrementAgrees();
+        FixRequestVote existing = new FixRequestVote(voter, fr, VoteType.AGREE);
+        when(registeredUserRepository.findByEmail("voter@test.com")).thenReturn(Optional.of(voter));
+        when(fixRequestRepository.findById(50L)).thenReturn(Optional.of(fr));
+        when(fixRequestVoteRepository.findByUserIdAndFixRequestId(3L, 50L)).thenReturn(Optional.of(existing));
+        when(fixRequestRepository.save(any(FixRequest.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        fixRequestService.agree(50L, "voter@test.com");
+
+        verify(gamificationService).deductOnFixRequestVoteWithdraw(eq(voter), eq(50L));
+        verify(gamificationService, never()).awardOnFixRequestVoteCast(any(), any());
+    }
+
+    @Test
+    void agree_modifyOppositeVote_doesNotInvokeGamification() {
+        // DISAGREE → AGREE is a modify, not a fresh cast or withdraw — no points event.
+        FixRequest fr = new FixRequest(parentReport, submitter, null);
+        ReflectionTestUtils.setField(fr, "id", 50L);
+        fr.incrementDisagrees();
+        FixRequestVote existing = new FixRequestVote(voter, fr, VoteType.DISAGREE);
+        when(registeredUserRepository.findByEmail("voter@test.com")).thenReturn(Optional.of(voter));
+        when(fixRequestRepository.findById(50L)).thenReturn(Optional.of(fr));
+        when(fixRequestVoteRepository.findByUserIdAndFixRequestId(3L, 50L)).thenReturn(Optional.of(existing));
+        when(fixRequestRepository.save(any(FixRequest.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        fixRequestService.agree(50L, "voter@test.com");
+
+        verify(gamificationService, never()).awardOnFixRequestVoteCast(any(), any());
+        verify(gamificationService, never()).deductOnFixRequestVoteWithdraw(any(), any());
+    }
+
+    @Test
+    void agree_thresholdReached_invokesOnFixRequestResolved() {
+        // Pre-state: 4 agrees, this 5th vote pushes past the threshold and
+        // ratio (5/5 = 1.0 ≥ 0.6) so the request resolves to FIXED.
+        FixRequest fr = new FixRequest(parentReport, submitter, null);
+        ReflectionTestUtils.setField(fr, "id", 50L);
+        for (int i = 0; i < 4; i++) fr.incrementAgrees();
+        when(registeredUserRepository.findByEmail("voter@test.com")).thenReturn(Optional.of(voter));
+        when(fixRequestRepository.findById(50L)).thenReturn(Optional.of(fr));
+        when(fixRequestVoteRepository.findByUserIdAndFixRequestId(3L, 50L)).thenReturn(Optional.empty());
+        when(fixRequestRepository.save(any(FixRequest.class))).thenAnswer(i -> i.getArguments()[0]);
+        when(reportRepository.save(any(Report.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        fixRequestService.agree(50L, "voter@test.com");
+
+        verify(gamificationService).onFixRequestResolved(fr);
+    }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
@@ -1,6 +1,7 @@
 package com.bounswe2026group1.backend.service;
 
 import com.bounswe2026group1.backend.model.Badge;
+import com.bounswe2026group1.backend.model.FixRequest;
 import com.bounswe2026group1.backend.model.PointEvent;
 import com.bounswe2026group1.backend.model.PointReason;
 import com.bounswe2026group1.backend.model.RegisteredUser;
@@ -10,6 +11,7 @@ import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.ReportType;
 import com.bounswe2026group1.backend.model.UserBadge;
 import com.bounswe2026group1.backend.model.VoteType;
+import com.bounswe2026group1.backend.repository.FixRequestVoteRepository;
 import com.bounswe2026group1.backend.repository.PointEventRepository;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.repository.ReportRepository;
@@ -41,6 +43,7 @@ class GamificationServiceTest {
     @Mock private RegisteredUserRepository userRepository;
     @Mock private ReportRepository reportRepository;
     @Mock private ReportVerificationRepository verificationRepository;
+    @Mock private FixRequestVoteRepository fixRequestVoteRepository;
     @Mock private PointEventRepository pointEventRepository;
     @Mock private UserBadgeRepository userBadgeRepository;
     @Mock private LeaderboardService leaderboardService;
@@ -62,6 +65,11 @@ class GamificationServiceTest {
         ReflectionTestUtils.setField(gamificationService, "voteOpposedDelta", -5);
         ReflectionTestUtils.setField(gamificationService, "trustedReporterThreshold", 10);
         ReflectionTestUtils.setField(gamificationService, "expertMapperThreshold", 50);
+        ReflectionTestUtils.setField(gamificationService, "fixRequestVoteCastDelta", 5);
+        ReflectionTestUtils.setField(gamificationService, "fixRequestVoteWithdrawnDelta", -5);
+        ReflectionTestUtils.setField(gamificationService, "fixResolvedBonusDelta", 20);
+        ReflectionTestUtils.setField(gamificationService, "fixVoteAlignedDelta", 15);
+        ReflectionTestUtils.setField(gamificationService, "fixVoteOpposedDelta", -5);
     }
 
     // ───────────────────── awardOnReportSubmit ──────────────────────────
@@ -376,6 +384,115 @@ class GamificationServiceTest {
         verify(userBadgeRepository, never()).save(any(UserBadge.class));
     }
 
+    // ───────────────────── fix-request flow ─────────────────────────────
+
+    @Test
+    void awardOnFixRequestVoteCast_addsFivePointsOnFreshVote() {
+        RegisteredUser voter = newUser(2L, 100);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 500L, PointReason.FIX_REQUEST_VOTE_CAST)).thenReturn(0L);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 500L, PointReason.FIX_REQUEST_VOTE_WITHDRAWN)).thenReturn(0L);
+
+        gamificationService.awardOnFixRequestVoteCast(voter, 500L);
+
+        assertThat(voter.getPoints()).isEqualTo(105);
+        ArgumentCaptor<PointEvent> ev = ArgumentCaptor.forClass(PointEvent.class);
+        verify(pointEventRepository).save(ev.capture());
+        assertThat(ev.getValue().getReason()).isEqualTo(PointReason.FIX_REQUEST_VOTE_CAST);
+        assertThat(ev.getValue().getRelatedEntityId()).isEqualTo(500L);
+    }
+
+    @Test
+    void awardOnFixRequestVoteCast_isNoOpWhenAlreadyVoted_modifyVotePath() {
+        RegisteredUser voter = newUser(2L, 100);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 500L, PointReason.FIX_REQUEST_VOTE_CAST)).thenReturn(1L);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 500L, PointReason.FIX_REQUEST_VOTE_WITHDRAWN)).thenReturn(0L);
+
+        gamificationService.awardOnFixRequestVoteCast(voter, 500L);
+
+        assertThat(voter.getPoints()).isEqualTo(100);
+        verify(pointEventRepository, never()).save(any(PointEvent.class));
+    }
+
+    @Test
+    void awardOnFixRequestVoteCast_independentFromReportVoteLedger() {
+        // Defensive: a user who already cast a VOTE_CAST on report 500 should
+        // still be paid for the FIRST FIX_REQUEST_VOTE_CAST on a fix request
+        // that happens to share id 500 — the two ledgers are independent.
+        RegisteredUser voter = newUser(2L, 100);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 500L, PointReason.FIX_REQUEST_VOTE_CAST)).thenReturn(0L);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 500L, PointReason.FIX_REQUEST_VOTE_WITHDRAWN)).thenReturn(0L);
+
+        gamificationService.awardOnFixRequestVoteCast(voter, 500L);
+
+        assertThat(voter.getPoints()).isEqualTo(105);
+    }
+
+    @Test
+    void deductOnFixRequestVoteWithdraw_subtractsFiveOnActiveVote() {
+        RegisteredUser voter = newUser(2L, 100);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 500L, PointReason.FIX_REQUEST_VOTE_CAST)).thenReturn(1L);
+        when(pointEventRepository.countByUserIdAndRelatedEntityIdAndReason(
+                2L, 500L, PointReason.FIX_REQUEST_VOTE_WITHDRAWN)).thenReturn(0L);
+
+        gamificationService.deductOnFixRequestVoteWithdraw(voter, 500L);
+
+        assertThat(voter.getPoints()).isEqualTo(95);
+    }
+
+    @Test
+    void onFixRequestResolved_paysSubmitterBonusAndAlignsVoters() {
+        RegisteredUser submitter = newUser(1L, 0);
+        RegisteredUser agreer = newUser(2L, 0);
+        RegisteredUser disagreer = newUser(3L, 100);
+        FixRequest fixRequest = stubFixRequest(submitter);
+
+        when(fixRequestVoteRepository.findVoteTuplesByFixRequestId(500L))
+                .thenReturn(java.util.List.<Object[]>of(
+                        new Object[]{2L, VoteType.AGREE},
+                        new Object[]{3L, VoteType.DISAGREE}));
+        when(userRepository.findAllById(any()))
+                .thenReturn(java.util.List.of(agreer, disagreer));
+
+        gamificationService.onFixRequestResolved(fixRequest);
+
+        assertThat(submitter.getPoints()).isEqualTo(20);  // resolved bonus
+        assertThat(agreer.getPoints()).isEqualTo(15);     // aligned
+        assertThat(disagreer.getPoints()).isEqualTo(95);  // opposed (-5)
+        verify(pointEventRepository, times(3)).save(any(PointEvent.class));
+    }
+
+    @Test
+    void onFixRequestResolved_skipsSubmitterFromVoterFanOut() {
+        // If the submitter somehow appears in their own fix-request vote
+        // tuples, they should not be paid the +15 voter-aligned reward on
+        // top of the +20 resolved-bonus.
+        RegisteredUser submitter = newUser(1L, 0);
+        FixRequest fixRequest = stubFixRequest(submitter);
+
+        when(fixRequestVoteRepository.findVoteTuplesByFixRequestId(500L))
+                .thenReturn(java.util.List.<Object[]>of(
+                        new Object[]{1L, VoteType.AGREE}));
+
+        gamificationService.onFixRequestResolved(fixRequest);
+
+        // Submitter only gets the +20 bonus, never the +15 voter reward.
+        assertThat(submitter.getPoints()).isEqualTo(20);
+        verify(pointEventRepository, times(1)).save(any(PointEvent.class));
+    }
+
+    @Test
+    void onFixRequestResolved_nullFixRequestIsNoOp() {
+        gamificationService.onFixRequestResolved(null);
+        verify(pointEventRepository, never()).save(any(PointEvent.class));
+    }
+
     // ───────────────────────── helpers ──────────────────────────────────
 
     private static RegisteredUser newUser(Long id, int initialPoints) {
@@ -392,5 +509,12 @@ class GamificationServiceTest {
                 ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
         ReflectionTestUtils.setField(r, "reportId", 100L);
         return r;
+    }
+
+    private static FixRequest stubFixRequest(RegisteredUser submitter) {
+        FixRequest fr = new FixRequest();
+        ReflectionTestUtils.setField(fr, "id", 500L);
+        ReflectionTestUtils.setField(fr, "submittedBy", submitter);
+        return fr;
     }
 }


### PR DESCRIPTION
# 📝 Description
Closes a gap left by previous PRs: the report flow earns points but the parallel fix-request flow stayed silent. This PR makes the fix-request side fully symmetric with the report side.

- `PointReason` gains 5 new values (`FIX_REQUEST_VOTE_CAST`, `FIX_REQUEST_VOTE_WITHDRAWN`, `FIX_RESOLVED_BONUS`, `FIX_VOTE_ALIGNED`, `FIX_VOTE_OPPOSED`) so cast/withdraw cycles for fix requests pair against their own ledger entries — a user voting on both a report and its fix request can be paid for both, the two ledgers are independent.
- V4 Flyway migration drops the legacy `point_events.reason` CHECK constraint that didn't extend to cover the new values (same drop-only pattern as V2 and V3 — column stays plain VARCHAR, validation enforced application-side via `@Enumerated(STRING)` and Spring's JSON deserialization).
- `GamificationService` gains three public methods:
  - `awardOnFixRequestVoteCast` — +5 on fresh vote, no-op on modify-vote (mirrors `awardOnVoteCast`)
  - `deductOnFixRequestVoteWithdraw` — -5 on full withdraw
  - `onFixRequestResolved` — +20 to the **fix request submitter** (the original report author already received their +20 when the report first reached VERIFIED — re-rewarding here would double-count) and voter alignment payout (+15 / -5)
- `isCurrentlyVotedOnFixRequest` helper mirrors `isCurrentlyVoted` against the new ledger reasons.
- `FixRequestService.castVote` adopts the same fresh/withdrawn flag pattern as `ReportService.verify`/`unverify` and fires the new gamification methods at the right moment. `evaluateFixStatus` calls `onFixRequestResolved` alongside the existing `notifyStatusChange`.
- 5 new configurable point values in `application.properties` (default symmetric with report values).
- 10 new tests across `GamificationServiceTest` and `FixRequestServiceTest` covering vote-cast / withdraw / modify / threshold-triggered resolved / submitter not double-paid / null-fix-request guard.

No frontend changes — points and ranks already render from `ProfilePage` and `Leaderboard`. Notifications keep flowing through the existing `BADGE_AWARDED` channel (top-10 churn after a fix-resolution may trigger one).

**Merge order:** sits on top of #511 in the gamification stack. Git enforces V4 lands after V3 — the stack base relationship guarantees correct Flyway ordering on production.

Fixes #512

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [x] 5-15 min
