### PR TITLE
[Web] Persist agree/disagree button state across navigation

### DIFF
--- a/frontend/src/hooks/useReports.js
+++ b/frontend/src/hooks/useReports.js
@@ -12,14 +12,19 @@ export const reportKeys = {
 /**
  * Fetch the full report list.
  * Falls back to polling every 30 s when SSE is disconnected.
+ *
+ * The auth token is forwarded so each report carries the caller's
+ * `userVote` — without it the agree/disagree buttons lose their selected
+ * state across navigations.
  */
 export function useReports() {
   const sseStatus = useSseStatus()
   const disconnected = sseStatus !== 'connected'
+  const { token } = useAuth()
 
   return useQuery({
     queryKey: reportKeys.lists(),
-    queryFn: () => getReports().then((data) => data.map(mapReport)),
+    queryFn: () => getReports(token).then((data) => data.map(mapReport)),
     staleTime: 30_000,
     refetchInterval: disconnected ? 30_000 : false,
   })
@@ -32,10 +37,11 @@ export function useReports() {
 export function useReport(id) {
   const sseStatus = useSseStatus()
   const disconnected = sseStatus !== 'connected'
+  const { token } = useAuth()
 
   return useQuery({
     queryKey: reportKeys.detail(id),
-    queryFn: () => getReportById(id).then(mapReport),
+    queryFn: () => getReportById(id, token).then(mapReport),
     enabled: id != null,
     staleTime: 30_000,
     refetchInterval: disconnected ? 30_000 : false,

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -773,7 +773,7 @@ function Home() {
           <ReportPanel
             key={selectedReport.id}
             report={selectedReport}
-            userVote={userVotes[selectedReport.id] ?? null}
+            userVote={userVotes[selectedReport.id] ?? selectedReport.userVote ?? null}
             onVoteChange={(vote) => setUserVotes(prev => ({ ...prev, [selectedReport.id]: vote }))}
             // Toast lives on Home so it survives the panel unmounting
             // (e.g. after a successful delete that closes the panel).

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -4,17 +4,23 @@ import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
 /**
  * Fetch all reports from the backend.
  * GET /api/reports
+ *
+ * When a token is supplied the backend fills in each report's `userVote`
+ * from the caller's vote history — without it, the field is always null
+ * and the agree/disagree buttons can't render their selected state.
  */
-export async function getReports() {
-  return apiFetch('/api/reports')
+export async function getReports(token) {
+  const headers = token ? { Authorization: `Bearer ${token}` } : undefined
+  return apiFetch('/api/reports', headers ? { headers } : undefined)
 }
 
 /**
  * Fetch a single report by ID.
  * GET /api/reports/{id}
  */
-export async function getReportById(id) {
-  return apiFetch(`/api/reports/${id}`)
+export async function getReportById(id, token) {
+  const headers = token ? { Authorization: `Bearer ${token}` } : undefined
+  return apiFetch(`/api/reports/${id}`, headers ? { headers } : undefined)
 }
 
 /**


### PR DESCRIPTION
# 📝 Description
Fixes #514

The agree/disagree button on a report turned green when clicked, but reverted to the default unselected style after navigating away via the sidebar and returning to the same report. This PR persists the vote-button state across navigations.

Root cause was twofold:
- `Home.jsx` kept the user's vote in a local `userVotes` state, which was wiped when the route changed and `Home` unmounted.
- `getReports()` and `getReportById()` did not forward the auth token, so the backend always returned `userVote: null` and there was no source of truth to fall back to after re-mount.

Changes:
- `services/reportService.js` — `getReports(token)` / `getReportById(id, token)` now send `Authorization: Bearer <token>` when a token is provided.
- `hooks/useReports.js` — `useReports` / `useReport` pull the token from `useAuth()` and pass it through.
- `pages/Home.jsx` — `ReportPanel`'s `userVote` prop falls back to `selectedReport.userVote` when the local vote map has no entry.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [ ] All tests passed

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
