### PR TITLE
[Web] Fix Filter button flicker on second click (closes #516)

### DIFF
--- a/frontend/src/components/MapFilters.jsx
+++ b/frontend/src/components/MapFilters.jsx
@@ -14,8 +14,9 @@ import { excludedCount } from '../utils/mapFilters.js'
  *  - excludedIssues: Set<string>            (`${objectType}:${issue}`)
  *  - onChange:       (nextTypes, nextIssues) => void
  *  - onClose:        () => void
+ *  - triggerRef:     React.RefObject<HTMLElement>  (button that opens this panel)
  */
-function MapFilters({ excludedTypes, excludedIssues, onChange, onClose }) {
+function MapFilters({ excludedTypes, excludedIssues, onChange, onClose, triggerRef }) {
   const [expanded, setExpanded] = useState(() => new Set())
   const containerRef = useRef(null)
 
@@ -36,9 +37,12 @@ function MapFilters({ excludedTypes, excludedIssues, onChange, onClose }) {
   useEffect(() => {
     function handleKey(e) { if (e.key === 'Escape') onClose() }
     function handlePointer(e) {
-      if (!isMobileSheet && containerRef.current && !containerRef.current.contains(e.target)) {
-        onClose()
-      }
+      if (isMobileSheet) return
+      if (containerRef.current?.contains(e.target)) return
+      // Skip the trigger so its own onClick can toggle cleanly. Without this,
+      // pointerdown closes the panel first, then click reopens it — flicker.
+      if (triggerRef?.current?.contains(e.target)) return
+      onClose()
     }
     document.addEventListener('keydown', handleKey)
     document.addEventListener('pointerdown', handlePointer)
@@ -46,7 +50,7 @@ function MapFilters({ excludedTypes, excludedIssues, onChange, onClose }) {
       document.removeEventListener('keydown', handleKey)
       document.removeEventListener('pointerdown', handlePointer)
     }
-  }, [onClose, isMobileSheet])
+  }, [onClose, isMobileSheet, triggerRef])
 
   function toggleExpanded(type) {
     setExpanded((prev) => {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -307,6 +307,7 @@ function Home() {
   const [routeError, setRouteError] = useState('')
   const [toast, setToast] = useState(null)
   const [showFilters, setShowFilters] = useState(false)
+  const filterButtonRef = useRef(null)
   // Filter state lives in URL so the view is shareable; this is just a
   // memoized parse of the current `?excluded=` token.
   const { types: excludedTypes, issues: excludedIssues } = parseExcluded(searchParams.get('excluded'))
@@ -713,6 +714,7 @@ function Home() {
               <div className="hidden sm:block h-8 w-px bg-outline-variant/30" />
               <div className="relative flex-shrink-0">
                 <button
+                  ref={filterButtonRef}
                   type="button"
                   onClick={() => setShowFilters((v) => !v)}
                   className="p-2 hover:bg-primary/10 rounded-lg transition-colors cursor-pointer"
@@ -735,6 +737,7 @@ function Home() {
                     excludedIssues={excludedIssues}
                     onChange={setExcluded}
                     onClose={() => setShowFilters(false)}
+                    triggerRef={filterButtonRef}
                   />
                 )}
               </div>


### PR DESCRIPTION
## 📝 Description
Closes #516. The Filter button reopened the panel on the second click instead of closing it.

`MapFilters.jsx` registered a document-level `pointerdown` handler that called `onClose()` whenever the click target was outside the panel container. The Filter trigger lives outside that container, so on the second click the listener closed the panel first, then the trigger's `onClick` toggled it back to open ,net result: flicker.

Fixed by forwarding a `triggerRef` from `Home.jsx` and skipping `onClose()` when the click target is inside it. Same pattern Navbar uses for the notification dropdown.

## 📊 Type of Change
- [x] Bug fix

## ✅ Acceptance Criteria
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] All tests passed (308/308)

Issue acceptance criteria:
- [x] Clicking the Filter button when the panel is closed opens it
- [x] Clicking it when the panel is open closes it cleanly (no flicker)
- [x] Clicking elsewhere on the map still closes the panel
- [x] X button and Escape still close the panel
- [x] Existing tests pass

## 📸 Screenshots
_(not applicable; behavior change only)_

## 🧪 How to Test
1. Open the map at `/`.
2. Click the Filter button (`tune` icon next to the search bar). Panel opens.
3. Click it again. Panel closes cleanly ,no brief reopen.
4. Re-open the panel, click anywhere outside it. Still closes.
5. Press Escape, click the X, both still close.

## ⏱️ Estimated Review Time
- [x] < 5 min