### PR TITLE
[Web] Sign-up password warnings only turn red on submit attempt (closes #518)

### DIFF
--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -140,7 +140,6 @@ function Signup() {
                     autoComplete="new-password"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
-                    onBlur={() => setPasswordTouched(true)}
                     aria-invalid={passwordTouched && !passwordValidation.isValid}
                     aria-describedby="password-requirements"
                     required
@@ -151,10 +150,10 @@ function Signup() {
                     aria-live="polite"
                   >
                     {passwordValidation.results.map((rule) => {
-                      // Show red only after the user has tabbed away or
-                      // tried to submit (passwordTouched). While they're
-                      // still typing for the first time, unmet rules stay
-                      // grey so the form doesn't flash red on every keystroke.
+                      // Show red only after the user has actually tried to
+                      // submit (passwordTouched). While they're still working
+                      // on the form, unmet rules stay grey — passed rules
+                      // turn green in real time.
                       const showFailure = passwordTouched && !rule.passed
                       const colorClass = rule.passed
                         ? 'text-[#176a21]'
@@ -203,7 +202,7 @@ function Signup() {
               <button
                 className="w-full py-4 bg-gradient-to-b from-[#176a21] to-[#025d16] text-[#d1ffc8] font-headline font-bold text-lg rounded-full shadow-lg hover:brightness-110 hover:scale-[1.02] active:scale-95 transition-all duration-300 cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed disabled:scale-100"
                 type="submit"
-                disabled={!terms || isLoading || !passwordValidation.isValid}
+                disabled={!terms || isLoading}
               >
                 {isLoading ? 'Creating account…' : 'Create Account'}
               </button>

--- a/frontend/src/pages/Signup.test.jsx
+++ b/frontend/src/pages/Signup.test.jsx
@@ -146,31 +146,39 @@ describe('Signup page', () => {
       expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
     })
 
-    it('stays disabled when password does not meet all rules', async () => {
+    it('stays enabled when password is invalid so the user can click and see the rule errors (#518)', async () => {
       const user = userEvent.setup()
       renderSignup()
       await user.type(screen.getByLabelText(/^password$/i), 'weakpass')
       await user.click(screen.getByRole('checkbox', { name: /terms of service/i }))
-      expect(screen.getByRole('button', { name: /create account/i })).toBeDisabled()
+      expect(screen.getByRole('button', { name: /create account/i })).not.toBeDisabled()
     })
   })
 
   // ─── Password validation UI ──────────────────────────────────────────────────
 
   describe('password requirements checklist', () => {
-    it('keeps unmet rules in a neutral state while typing, then surfaces error copy after blur', async () => {
+    it('keeps unmet rules in a neutral state while typing, then surfaces error copy after a submit attempt', async () => {
       const user = userEvent.setup()
       renderSignup()
+      await user.type(screen.getByLabelText(/full name/i), 'Test User')
+      await user.type(screen.getByLabelText(/^email/i), 'test@test.com')
       const passwordInput = screen.getByLabelText(/^password$/i)
       await user.type(passwordInput, 'abc')
 
-      // While the user is still typing for the first time the unmet rules
-      // show their short label, not the long error message.
+      // Short labels while still working on the form.
       expect(screen.queryByText(/at least 8 characters long/i)).not.toBeInTheDocument()
       expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument()
 
-      // After blur (or attempt to submit) the long descriptive error copy appears.
+      // Tabbing to another field must NOT flash red — that was the regression
+      // from #489 (issue #518).
       await user.tab()
+      expect(screen.queryByText(/at least 8 characters long/i)).not.toBeInTheDocument()
+
+      // After clicking Create Account with an invalid password the descriptive
+      // copy appears. (Need the terms box ticked so the button isn't disabled.)
+      await user.click(screen.getByRole('checkbox', { name: /terms of service/i }))
+      await user.click(screen.getByRole('button', { name: /create account/i }))
       expect(screen.getByText(/at least 8 characters long/i)).toBeInTheDocument()
       expect(screen.getByText(/uppercase letter/i)).toBeInTheDocument()
       expect(screen.getByText(/at least one number/i)).toBeInTheDocument()


### PR DESCRIPTION
## 📝 Description
Closes #518. Follow-up to #489.

The previous fix turned unmet password rules red on `blur`. That fired on every field switch, typing one letter and tabbing to the email field flashed all rules red. Now the rules only turn red after the user actually clicks Create Account with an invalid password. While they're still working on the form, unmet rules stay grey; passed rules turn green in real time.

The Create Account button no longer disables itself when the password is invalid, it stays clickable so the user can submit, see the rules go red, and understand what's wrong. `handleSubmit` already short-circuits and sets `passwordTouched = true` for invalid passwords.

## 📊 Type of Change
- [x] Bug fix

## ✅ Acceptance Criteria
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] All tests passed (308/308)

Issue acceptance criteria:
- [x] Typing one character in password and switching to email leaves rules grey
- [x] Rules go green in real time as they're satisfied
- [x] Clicking Create Account with an invalid password turns unmet rules red
- [x] Red persists until the rules are satisfied

## 🧪 How to Test
1. Open `/signup`.
2. Type one letter in the password field, tab/click to the email field. Password rules stay grey.
3. Type a valid password, rules go green one by one.
4. Clear the password, type something weak (e.g. `abc`), tick terms, click Create Account. All unmet rules turn red.

## ⏱️ Estimated Review Time
- [x] < 5 min