### PR TITLE
[Web] Stabilise hero image and spacing across login/signup transition (closes #520)

### DIFF
--- a/frontend/src/components/AuthFooter.jsx
+++ b/frontend/src/components/AuthFooter.jsx
@@ -3,7 +3,7 @@ const LINKS = ['Privacy Policy', 'Terms of Service', 'Accessibility', 'Contact S
 function AuthFooter() {
   return (
     <footer className="bg-[#f6f6f6] border-t border-[#2d2f2f]/10">
-      <div className="flex flex-col md:flex-row justify-between items-center px-12 py-12 w-full max-w-[1440px] mx-auto gap-8">
+      <div className="flex flex-col md:flex-row justify-between items-center px-12 py-2 w-full max-w-[1440px] mx-auto gap-2">
         <div className="text-lg font-bold text-[#495f69] uppercase tracking-widest font-headline">
           Mapcess
         </div>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -36,16 +36,17 @@ function Login() {
   }
 
   return (
-    <div className="bg-[#f6f6f6] font-body text-[#2d2f2f] antialiased hide-scrollbar min-h-screen flex flex-col">
-      <main className="flex flex-1">
+    <div className="bg-[#f6f6f6] font-body text-[#2d2f2f] antialiased hide-scrollbar md:h-screen min-h-screen md:overflow-hidden flex flex-col">
+      <main className="flex flex-1 md:min-h-0">
         <AuthLeftPanel
           headline="Empowering mobility for every neighbour."
           description="Your reports help people with mobility challenges find accessible routes, ramps, and barrier-free paths in their neighbourhood."
         />
 
         {/* Right Side */}
-        <section className="w-full md:w-1/2 lg:w-2/5 bg-white flex items-center justify-center px-6 py-12 md:px-16 lg:px-24">
-          <div className="w-full max-w-[440px] space-y-10">
+        <section className="w-full md:w-1/2 lg:w-2/5 bg-white px-6 py-12 md:px-16 lg:px-24 md:overflow-y-auto">
+          <div className="min-h-full flex items-center justify-center">
+            <div className="w-full max-w-[440px] space-y-8">
             {/* Mobile Branding */}
             <div className="md:hidden">
               <span className="text-2xl font-headline font-bold text-[#176a21] italic">
@@ -64,7 +65,7 @@ function Login() {
             </header>
 
             {/* Form */}
-            <form className="space-y-6" onSubmit={handleSubmit}>
+            <form className="space-y-4" onSubmit={handleSubmit}>
               {/* Error message */}
               {error && (
                 <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
@@ -164,6 +165,7 @@ function Login() {
                 Create an account
               </a>
             </p>
+            </div>
           </div>
         </section>
       </main>

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -50,16 +50,17 @@ function Signup() {
   }
 
   return (
-    <div className="bg-[#f6f6f6] font-body text-[#2d2f2f] antialiased hide-scrollbar min-h-screen flex flex-col">
-      <main className="flex flex-1">
+    <div className="bg-[#f6f6f6] font-body text-[#2d2f2f] antialiased hide-scrollbar md:h-screen min-h-screen md:overflow-hidden flex flex-col">
+      <main className="flex flex-1 md:min-h-0">
         <AuthLeftPanel
           headline="Make your city accessible for everyone."
           description="Join a community of contributors mapping accessibility features and barriers — so people with mobility challenges can navigate their neighbourhoods with confidence."
         />
 
         {/* Right Side */}
-        <section className="w-full md:w-1/2 lg:w-2/5 bg-white flex items-center justify-center px-6 py-8 md:px-16 lg:px-24">
-          <div className="w-full max-w-[440px] space-y-6">
+        <section className="w-full md:w-1/2 lg:w-2/5 bg-white px-6 py-12 md:px-16 lg:px-24 md:overflow-y-auto">
+          <div className="min-h-full flex items-center justify-center">
+            <div className="w-full max-w-[440px] space-y-8">
             {/* Mobile Branding */}
             <div className="md:hidden flex justify-center">
               <span className="text-2xl font-headline font-bold text-[#176a21] italic tracking-tight">
@@ -226,6 +227,7 @@ function Signup() {
                 Log in
               </a>
             </p>
+            </div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## 📝 Description
Closes #520. Switching between `/login` and `/signup` shifted the page height and re-cropped the hero image because (a) the two pages used different right-side padding and form spacing and (b) `min-h-screen` let the page grow whenever the form was taller than the viewport, dragging the left section's `object-cover` image up with it.

Fixed by:
- Capping desktop pages at exactly viewport height (`md:h-screen` + `md:overflow-hidden`) and scrolling the right form column internally (`md:overflow-y-auto`).
- Wrapping the form card in `min-h-full flex items-center justify-center` so it centers when content fits and grows from the top when it doesn't (canonical fix for flexbox-centering-with-overflow swallowing the top).
- Unifying right-side padding (`py-12 md:px-16 lg:px-24`), inner container spacing (`space-y-8`), and form spacing (`space-y-4`) across both pages.

Mobile keeps `min-h-screen` and natural document scroll ,single column, no left image to grow.

## 📊 Type of Change
- [x] Bug fix

## ✅ Acceptance Criteria
- [x] Project builds successfully
- [x] All tests passed (45/45 in Login + Signup)

Issue acceptance criteria:
- [x] No visible jump in page height when switching between `/login` and `/signup`
- [x] Hero image holds the same crop on both pages
- [x] Form card lands at the same vertical offset
- [x] Existing tests still pass

## 🧪 How to Test
1. Open `/login`, note the hero image and form card position.
2. Click "Create an account" → `/signup`. Image and form card position unchanged.
3. Click "Log in" → `/login`. Same.
4. Shrink the viewport height , Signup form scrolls inside its column; image stays at viewport height; heading remains accessible at the top of the scroll.

## ⏱️ Estimated Review Time
- [x] < 5 min