### PR TITLE
[Web] Show error toast when report submission fails

### DIFF
--- a/frontend/src/components/CreateReportPanel.jsx
+++ b/frontend/src/components/CreateReportPanel.jsx
@@ -5,7 +5,7 @@ import { createReport, mapReport } from '../services/reportService.js'
 import { OBJECT_TYPES } from '../utils/objectTypeConfig.js'
 import ObjectTutorialModal from './ObjectTutorialModal.jsx'
 
-function CreateReportPanel({ position, positionLabel, onClose, onCreated }) {
+function CreateReportPanel({ position, positionLabel, onClose, onCreated, onError }) {
   const { token, userId } = useAuth()
   const navigate = useNavigate()
 
@@ -226,7 +226,11 @@ function CreateReportPanel({ position, positionLabel, onClose, onCreated }) {
       onCreated(mapped)
       onClose()
     } catch (err) {
-      setError(err.message || 'Failed to submit report. Please try again.')
+      const message = err.message || 'Failed to submit report. Please try again.'
+      setError(message)
+      // Surface the same message as a global toast for callers that wired one
+      // up (Home does). The inline error stays for persistent context.
+      if (onError) onError(message)
     } finally {
       setSubmitting(false)
     }

--- a/frontend/src/components/CreateReportPanel.test.jsx
+++ b/frontend/src/components/CreateReportPanel.test.jsx
@@ -32,14 +32,14 @@ const FAKE_REPORT_RESPONSE = {
   mediaUrls: [],
 }
 
-function renderPanel({ token = FAKE_TOKEN, onClose = vi.fn(), onCreated = vi.fn(), position = null } = {}) {
+function renderPanel({ token = FAKE_TOKEN, onClose = vi.fn(), onCreated = vi.fn(), onError = vi.fn(), position = null } = {}) {
   if (token) localStorage.setItem('token', token)
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <MemoryRouter>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <CreateReportPanel position={position} onClose={onClose} onCreated={onCreated} />
+          <CreateReportPanel position={position} onClose={onClose} onCreated={onCreated} onError={onError} />
         </AuthProvider>
       </QueryClientProvider>
     </MemoryRouter>
@@ -250,6 +250,24 @@ describe('CreateReportPanel', () => {
 
       await waitFor(() => {
         expect(screen.getByText(/server error/i)).toBeInTheDocument()
+      })
+    })
+
+    it('calls onError with the failure message so Home can raise a toast (#522)', async () => {
+      api.apiFetch.mockRejectedValue(new Error('Server error'))
+      const onError = vi.fn()
+      const user = userEvent.setup()
+
+      renderPanelWithPosition({ onError })
+
+      await user.click(screen.getByRole('button', { name: /add object/i }))
+      await user.click(screen.getByRole('button', { name: /^ramp$/i }))
+      await user.click(screen.getByRole('checkbox', { name: /too steep/i }))
+      await user.type(screen.getByPlaceholderText(/provide a brief description/i), 'test')
+      await user.click(screen.getByRole('button', { name: /submit report/i }))
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith('Server error')
       })
     })
   })

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -843,6 +843,7 @@ function Home() {
             setNewReportPinLabel('')
             setToast({ message: 'Report submitted successfully!', type: 'success' })
           }}
+          onError={(message) => setToast({ message, type: 'error' })}
         />
       )}
       {toast && (


### PR DESCRIPTION
## 📝 Description
Closes #522. Follow-up to #313.

The global Toast was already wired into Home for the success path (`Report submitted successfully!`), but `CreateReportPanel` only set an inline error on submit failure ,no global feedback. If the user had scrolled or moved focus, they could miss the failure entirely.

`CreateReportPanel` now also accepts an `onError(message)` callback. On a 4xx/5xx (or any thrown error from `createReport`), it fires both the existing inline error and `onError`. Home wires the callback to `setToast({ message, type: 'error' })`.

## 📊 Type of Change
- [x] Bug fix
- [x] New feature

## ✅ Acceptance Criteria
- [x] Project builds successfully
- [x] All tests passed (309/309)

Issue acceptance criteria:
- [x] Error toast appears at the bottom of the screen when submission fails
- [x] Toast auto-dismisses after a few seconds (existing Toast component)
- [x] Inline error message inside the panel remains visible
- [x] Success path still shows the success toast (no regression)
- [x] New test covers the onError trigger

## 🧪 How to Test
1. Open the map, click to drop a report pin, fill in a Ramp + issue + description.
2. Stop the backend (or DevTools → Offline) and click Submit.
3. Red error toast appears at the bottom-center. Inline error stays inside the panel.
4. Restart backend, retry the submit , green success toast as before.

## 📸 Screenshots
**Submission failure (backend offline) — red error toast at bottom-center, inline error remains in the panel:**
<img width="1322" height="596" alt="Ekran Resmi 2026-05-10 20 02 59" src="https://github.com/user-attachments/assets/d7a95b5d-163b-4c32-ab35-51d4da724215" />




## ⏱️ Estimated Review Time
- [x] < 5 min