### PR TITLE
[Backend] Drop Legacy CHECK Constraint On user_routing_constraints

### DIFF
--- a/backend/src/main/resources/db/migration/V3__drop_legacy_routing_constraint_checks.sql
+++ b/backend/src/main/resources/db/migration/V3__drop_legacy_routing_constraint_checks.sql
@@ -1,0 +1,19 @@
+-- Drop legacy CHECK constraints on the RoutingConstraint enum collection tables.
+-- Same root cause as V2: when ddl-auto=update first generated these tables it
+-- emitted a CHECK enumerating the RoutingConstraint values that existed at the
+-- time. Adding new enum values later (REQUIRE_CURB_RAMPS,
+-- AVOID_INACCESSIBLE_CROSSINGS) does not extend the existing CHECK, so inserts
+-- referencing the newer values fail at the DB layer with a constraint
+-- violation, which surfaces as a 500 from PUT /api/users/me/routing-preferences.
+--
+-- The columns stay plain VARCHAR; enum validation is enforced application-side
+-- via @Enumerated(EnumType.STRING) and Spring deserialization, mirroring V2.
+--
+-- IF EXISTS keeps this safe on fresh environments where the constraint may
+-- never have been created (e.g. databases first stood up after the enum had
+-- already grown beyond its original 10 values).
+ALTER TABLE IF EXISTS user_routing_constraints
+    DROP CONSTRAINT IF EXISTS user_routing_constraints_constraint_value_check;
+
+ALTER TABLE IF EXISTS user_custom_routing_profile_constraints
+    DROP CONSTRAINT IF EXISTS user_custom_routing_profile_constraints_constraint_value_check;


### PR DESCRIPTION
# 📝 Drop Legacy CHECK Constraint On user_routing_constraints

Fixes #527

`PUT /api/users/me/routing-preferences` was returning 500 in prod when the request resolved to a constraint set containing `REQUIRE_CURB_RAMPS` or `AVOID_INACCESSIBLE_CROSSINGS` (which is every `WHEELCHAIR_USER` or `BLIND_OR_LOW_VISION` preset selection). Same root cause as V2: a stale Hibernate-generated CHECK constraint on the enum collection table that was never extended when new `RoutingConstraint` values were added later. This adds a V3 migration that drops the legacy CHECK on both `user_routing_constraints` and `user_custom_routing_profile_constraints` (idempotent, mirroring V2). No application-code changes — `@Enumerated(EnumType.STRING)` + Jackson already enforce valid enum values at the JSON layer.

# 📊 Type of Change
- [x] Bug fix

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully (`./mvnw clean verify` — exit 0)
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed

> No tests added: tests run on H2 with Flyway disabled (`spring.flyway.enabled=false` in `application-test.properties`), so the migration cannot be exercised by the existing test suite. The fix is a one-line `DROP CONSTRAINT IF EXISTS` and is idempotent on fresh DBs.

### Audit (other `@ElementCollection` + `@Enumerated(STRING)` columns)

| Table | Column | Status |
|---|---|---|
| `report_object_issues` | `issue_type` | Already dropped in V2 |
| `user_routing_constraints` | `constraint_value` | **Dropped in this PR** |
| `user_custom_routing_profile_constraints` | `constraint_value` | **Dropped in this PR** (defensive — created later, but covered for forward safety) |

# ⏱️ Estimated Review Time
- [x] < 5 min