### PR TITLE
[Web] Add password toggle and email validation on login/signup pages

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -9,9 +9,18 @@ import { useAuth } from '../context/AuthContext.jsx'
 function Login() {
   const [showPassword, setShowPassword] = useState(false)
   const [email, setEmail] = useState('')
+  const [emailError, setEmailError] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+
+  function validateEmail(value) {
+    if (value && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+      setEmailError('Please enter a valid email address.')
+    } else {
+      setEmailError('')
+    }
+  }
 
   const { login } = useAuth()
   const navigate = useNavigate()
@@ -20,6 +29,10 @@ function Login() {
   async function handleSubmit(e) {
     e.preventDefault()
     setError('')
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailError('Please enter a valid email address.')
+      return
+    }
     setIsLoading(true)
     try {
       const { token } = await loginUser({ email, password })
@@ -88,9 +101,13 @@ function Login() {
                   type="email"
                   autoComplete="email"
                   value={email}
-                  onChange={(e) => setEmail(e.target.value)}
+                  onChange={(e) => { setEmail(e.target.value); if (emailError) validateEmail(e.target.value) }}
+                  onBlur={(e) => validateEmail(e.target.value)}
                   required
                 />
+                {emailError && (
+                  <p className="text-xs text-red-600 px-1 mt-1">{emailError}</p>
+                )}
               </div>
 
               {/* Password */}

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -10,11 +10,21 @@ import { validatePassword } from '../utils/passwordValidation.js'
 function Signup() {
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
+  const [emailError, setEmailError] = useState('')
   const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
   const [passwordTouched, setPasswordTouched] = useState(false)
   const [terms, setTerms] = useState(false)
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+
+  function validateEmail(value) {
+    if (value && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+      setEmailError('Please enter a valid email address.')
+    } else {
+      setEmailError('')
+    }
+  }
 
   const { login } = useAuth()
   const navigate = useNavigate()
@@ -24,6 +34,10 @@ function Signup() {
   async function handleSubmit(e) {
     e.preventDefault()
     setError('')
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailError('Please enter a valid email address.')
+      return
+    }
     if (!passwordValidation.isValid) {
       setPasswordTouched(true)
       return
@@ -121,9 +135,13 @@ function Signup() {
                     type="email"
                     autoComplete="email"
                     value={email}
-                    onChange={(e) => setEmail(e.target.value)}
+                    onChange={(e) => { setEmail(e.target.value); if (emailError) validateEmail(e.target.value) }}
+                    onBlur={(e) => validateEmail(e.target.value)}
                     required
                   />
+                  {emailError && (
+                    <p className="text-xs text-red-600 px-1 mt-1">{emailError}</p>
+                  )}
                 </div>
 
                 <div className="space-y-2">
@@ -133,18 +151,30 @@ function Signup() {
                   >
                     Password
                   </label>
-                  <input
-                    className="w-full px-5 py-4 bg-[#f0f1f1] border-none rounded-xl focus:ring-2 focus:ring-[#176a21]/40 text-[#2d2f2f] placeholder:text-[#767777] transition-all outline-none"
-                    id="password"
-                    placeholder="••••••••"
-                    type="password"
-                    autoComplete="new-password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    aria-invalid={passwordTouched && !passwordValidation.isValid}
-                    aria-describedby="password-requirements"
-                    required
-                  />
+                  <div className="relative">
+                    <input
+                      className="w-full px-5 py-4 bg-[#f0f1f1] border-none rounded-xl focus:ring-2 focus:ring-[#176a21]/40 text-[#2d2f2f] placeholder:text-[#767777] transition-all outline-none pr-12"
+                      id="password"
+                      placeholder="••••••••"
+                      type={showPassword ? 'text' : 'password'}
+                      autoComplete="new-password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      aria-invalid={passwordTouched && !passwordValidation.isValid}
+                      aria-describedby="password-requirements"
+                      required
+                    />
+                    <button
+                      className="absolute right-4 top-1/2 -translate-y-1/2 text-[#acadad] hover:text-[#2d2f2f] transition-colors"
+                      type="button"
+                      onClick={() => setShowPassword((v) => !v)}
+                      aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    >
+                      <span className="material-symbols-outlined text-xl select-none">
+                        {showPassword ? 'visibility_off' : 'visibility'}
+                      </span>
+                    </button>
+                  </div>
                   <ul
                     id="password-requirements"
                     className="mt-2 space-y-1 text-sm"


### PR DESCRIPTION
## 📝 Description
Fixes #531.

Login and signup pages had two UX issues:
1. **No password toggle** on the signup page — users couldn't verify what they were typing. (Login already had one.)
2. **No email validation error message** on either page — invalid email formats were silently accepted until the server rejected them.

### Changes
- **Signup:** wrapped the password `<input>` in a relative container and added a show/hide toggle button (matching the existing Login toggle — same `visibility`/`visibility_off` Material Symbol icon).
- **Login & Signup:** added a `validateEmail` helper that runs on `onBlur` and re-runs on `onChange` once an error is already shown; `handleSubmit` also guards against malformed emails before sending the request. The error message renders inline below the email field.

## 📊 Type of Change
- [x] Bug fix

## ✅ Acceptance Criteria
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] Password field on signup page has a functional show/hide toggle
- [x] Password field on login page has a functional show/hide toggle (pre-existing, verified still works)
- [x] Entering an invalid email format shows "Please enter a valid email address." below the field
- [x] Email validation triggers on blur and on submit attempt
- [x] Valid emails and successful flows are unaffected (no regression)

## 🧪 How to Test
1. Go to `/signup` — type something in the password field and click the eye icon → password toggles between hidden and visible.
2. Type `notanemail` in the email field and click away → red error "Please enter a valid email address." appears below the field.
3. Correct the email → error disappears.
4. Go to `/login` and repeat steps 2–3 for the email field.
5. Submit the login form with a bad email → form is blocked, error shown.

## 📸 Screenshots / Recordings
<!-- If applicable -->

## ⏱️ Estimated Review Time
- [x] < 5 min