### PR TITLE
[Web] Embed Schema.org JSON-LD on Report Pages

### DIFF
--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -20,6 +20,7 @@ import { useAuth } from '../context/AuthContext.jsx'
 import { useUserProfile } from '../hooks/useUserProfile.js'
 import { reportKeys, useUpdateMapReport, useDeleteMapReport } from '../hooks/useReports.js'
 import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
+import { reportJsonLdString } from '../utils/schemaOrg.js'
 import CreateFixRequestPanel from './CreateFixRequestPanel.jsx'
 import Toast from './Toast.jsx'
 import BadgeIcon from './BadgeIcon.jsx'
@@ -405,9 +406,27 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
   const saveEditDisabled =
     updateReportMutation.isPending || !editDescription.trim() || editDescriptionTooLong
 
+  // Schema.org JSON-LD describing this report as a Place — lets search engines
+  // and assistive tools surface its accessibility metadata. The url field
+  // mirrors the panel's deep-link (`/?report=<id>`) so the canonical resource
+  // matches what a crawler would land on.
+  const jsonLdString = reportJsonLdString(report, {
+    url: typeof window !== 'undefined'
+      ? `${window.location.origin}/?report=${report.id}`
+      : undefined,
+  })
+
 
   return (
     <>
+      {jsonLdString && (
+        <script
+          type="application/ld+json"
+          data-testid="report-jsonld"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: jsonLdString }}
+        />
+      )}
       <div className="fixed inset-0 z-[1200] pointer-events-none flex flex-col justify-end lg:flex-row lg:justify-end">
         <aside
           style={isMobileSheet

--- a/frontend/src/utils/schemaOrg.js
+++ b/frontend/src/utils/schemaOrg.js
@@ -1,0 +1,143 @@
+// Schema.org JSON-LD helpers for report pages.
+//
+// Each report is published as a Place entity with `geo` coordinates plus the
+// accessibility metadata properties `accessibilityFeature` (positive features
+// the report references via its ObjectTypes) and `accessibilityHazard` (the
+// IssueType-level problems being reported). Tokens are camelCase per the
+// Schema.org accessibility-property convention so the JSON-LD parses cleanly
+// in Google's Rich Results test even though Schema.org doesn't formally
+// constrain the value vocabulary for physical Places yet.
+
+export const OBJECT_TYPE_TO_FEATURE = {
+  RAMP: 'ramp',
+  ELEVATOR: 'elevator',
+  SIDEWALK: 'sidewalk',
+  DOOR: 'accessibleDoor',
+  STAIR: 'staircase',
+  PEDESTRIAN_CROSSING: 'pedestrianCrossing',
+  CURB_RAMP: 'curbRamp',
+  WASHROOM: 'accessibleWashroom',
+  ROOM_SIGN: 'brailleSignage',
+}
+
+export const ISSUE_TYPE_TO_HAZARD = {
+  MISSING: 'missingFeature',
+  TOO_STEEP: 'steepGradient',
+  TOO_NARROW: 'tooNarrow',
+  MISSING_HANDRAIL: 'missingHandrail',
+  NO_LANDING: 'noLanding',
+  SLIPPERY_SURFACE: 'slipperySurface',
+  HANDRAIL_TOO_LOW: 'handrailTooLow',
+  INSUFFICIENT_LANDING_AREA: 'insufficientLandingArea',
+  OUT_OF_SERVICE: 'outOfService',
+  DOOR_TOO_NARROW: 'doorTooNarrow',
+  CABIN_TOO_SMALL: 'cabinTooSmall',
+  NO_AUDIO: 'noAudioCue',
+  NO_GRAB_BAR: 'noGrabBar',
+  INSUFFICIENT_LANDING: 'insufficientLanding',
+  NO_BRAILLE: 'noBrailleSignage',
+  BUTTON_HEIGHT_INVALID: 'buttonHeightInvalid',
+  INSUFFICIENT_LIGHTING: 'insufficientLighting',
+  BLOCKED: 'blockedPath',
+  NO_TACTILE_PAVING: 'noTactilePaving',
+  INSUFFICIENT_CLEARANCE: 'insufficientClearance',
+  UNEVEN_SURFACE: 'unevenSurface',
+  UNRAMPED_LEVEL_DIFFERENCE: 'unrampedLevelDifference',
+  HIGH_THRESHOLD: 'highThreshold',
+  STEP_AT_ENTRANCE: 'stepAtEntrance',
+  NO_LEVER_HANDLE: 'noLeverHandle',
+  HEAVY_DOOR: 'heavyDoor',
+  NO_AUTOMATIC_DOOR: 'noAutomaticDoor',
+  NO_GLASS_MARKING: 'noGlassMarking',
+  HANDLE_HEIGHT_INVALID: 'handleHeightInvalid',
+  INTERCOM_INACCESSIBLE: 'intercomInaccessible',
+  RISER_TOO_HIGH: 'riserTooHigh',
+  TREAD_TOO_SHALLOW: 'treadTooShallow',
+  NO_ANTI_SLIP: 'noAntiSlip',
+  OPEN_RISERS: 'openRisers',
+  IRREGULAR_STEPS: 'irregularSteps',
+  MISSING_NOSING_STRIP: 'missingNosingStrip',
+  NO_AUDIO_SIGNAL: 'noAudioSignal',
+  SIGNAL_TOO_SHORT: 'signalTooShort',
+  NO_DROPPED_CURB: 'noDroppedCurb',
+  FADED_MARKINGS: 'fadedMarkings',
+  NO_PEDESTRIAN_REFUGE: 'noPedestrianRefuge',
+  NO_TACTILE_WARNING: 'noTactileWarning',
+  RAISED_LIP: 'raisedLip',
+  NO_ACCESSIBLE_STALL: 'noAccessibleStall',
+  INSUFFICIENT_TURNING_SPACE: 'insufficientTurningSpace',
+  SINK_TOO_HIGH: 'sinkTooHigh',
+  NO_EMERGENCY_BUTTON: 'noEmergencyButton',
+  LOW_CONTRAST: 'lowContrast',
+  TEXT_TOO_SMALL: 'textTooSmall',
+  INVALID_HEIGHT: 'invalidHeight',
+}
+
+function isFiniteNumber(value) {
+  if (value == null || value === '') return false
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n)
+}
+
+function uniqueOrdered(values) {
+  return [...new Set(values)]
+}
+
+/**
+ * Build a Schema.org Place JSON-LD object describing a single report.
+ *
+ * Returns null when the report is missing a usable identifier — callers should
+ * skip rendering the script tag in that case. All other fields are added only
+ * when present so we don't pollute the output with empty arrays.
+ */
+export function buildReportJsonLd(report, { url } = {}) {
+  if (!report || report.id == null) return null
+
+  const features = []
+  const hazards = []
+  for (const obj of report.objects ?? []) {
+    const feature = OBJECT_TYPE_TO_FEATURE[obj.objectType]
+    if (feature) features.push(feature)
+    for (const issueKey of obj.issues ?? []) {
+      const hazard = ISSUE_TYPE_TO_HAZARD[issueKey]
+      if (hazard) hazards.push(hazard)
+    }
+  }
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Place',
+    '@id': `mapcess:report:${report.id}`,
+  }
+
+  if (report.title) jsonLd.name = report.title
+  if (report.description) jsonLd.description = report.description
+
+  if (isFiniteNumber(report.latitude) && isFiniteNumber(report.longitude)) {
+    jsonLd.geo = {
+      '@type': 'GeoCoordinates',
+      latitude: Number(report.latitude),
+      longitude: Number(report.longitude),
+    }
+  }
+
+  if (features.length) jsonLd.accessibilityFeature = uniqueOrdered(features)
+  if (hazards.length) jsonLd.accessibilityHazard = uniqueOrdered(hazards)
+  if (url) jsonLd.url = url
+
+  return jsonLd
+}
+
+/**
+ * Serialize a report's JSON-LD to a string suitable for embedding inside a
+ * <script type="application/ld+json"> tag. Returns an empty string when the
+ * report cannot produce a usable payload so the caller can skip rendering.
+ *
+ * The output escapes `</` to prevent a description containing `</script>`
+ * from prematurely closing the surrounding script element.
+ */
+export function reportJsonLdString(report, opts) {
+  const obj = buildReportJsonLd(report, opts)
+  if (!obj) return ''
+  return JSON.stringify(obj).replace(/</g, '\\u003c')
+}

--- a/frontend/src/utils/schemaOrg.test.js
+++ b/frontend/src/utils/schemaOrg.test.js
@@ -1,0 +1,162 @@
+import {
+  buildReportJsonLd,
+  reportJsonLdString,
+  OBJECT_TYPE_TO_FEATURE,
+  ISSUE_TYPE_TO_HAZARD,
+} from './schemaOrg.js'
+import { OBJECT_TYPES } from './objectTypeConfig.js'
+
+describe('schemaOrg.buildReportJsonLd', () => {
+  const baseReport = {
+    id: 42,
+    title: 'Broken Curb Ramp',
+    description: 'The curb ramp at the corner is too steep for a wheelchair.',
+    latitude: 41.0824,
+    longitude: 29.0509,
+    objects: [
+      {
+        objectType: 'CURB_RAMP',
+        issues: ['TOO_STEEP', 'NO_TACTILE_WARNING'],
+      },
+    ],
+  }
+
+  test('returns null when report is missing', () => {
+    expect(buildReportJsonLd(null)).toBeNull()
+    expect(buildReportJsonLd(undefined)).toBeNull()
+  })
+
+  test('returns null when report has no id', () => {
+    expect(buildReportJsonLd({ title: 'No id' })).toBeNull()
+  })
+
+  test('produces a valid Place node with the expected core fields', () => {
+    const ld = buildReportJsonLd(baseReport)
+    expect(ld['@context']).toBe('https://schema.org')
+    expect(ld['@type']).toBe('Place')
+    expect(ld['@id']).toBe('mapcess:report:42')
+    expect(ld.name).toBe('Broken Curb Ramp')
+    expect(ld.description).toBe(baseReport.description)
+  })
+
+  test('emits geo coordinates as numbers', () => {
+    const ld = buildReportJsonLd(baseReport)
+    expect(ld.geo).toEqual({
+      '@type': 'GeoCoordinates',
+      latitude: 41.0824,
+      longitude: 29.0509,
+    })
+  })
+
+  test('coerces stringly-typed coordinates to numbers', () => {
+    const ld = buildReportJsonLd({ ...baseReport, latitude: '41.5', longitude: '29.0' })
+    expect(ld.geo.latitude).toBe(41.5)
+    expect(ld.geo.longitude).toBe(29.0)
+  })
+
+  test('omits geo when coordinates are missing or invalid', () => {
+    const noCoords = buildReportJsonLd({ ...baseReport, latitude: null, longitude: null })
+    expect(noCoords.geo).toBeUndefined()
+    const empty = buildReportJsonLd({ ...baseReport, latitude: '', longitude: '' })
+    expect(empty.geo).toBeUndefined()
+    const garbage = buildReportJsonLd({ ...baseReport, latitude: 'abc', longitude: 'xyz' })
+    expect(garbage.geo).toBeUndefined()
+  })
+
+  test('maps ObjectType to accessibilityFeature and IssueType to accessibilityHazard', () => {
+    const ld = buildReportJsonLd(baseReport)
+    expect(ld.accessibilityFeature).toEqual(['curbRamp'])
+    expect(ld.accessibilityHazard).toEqual(['steepGradient', 'noTactileWarning'])
+  })
+
+  test('deduplicates feature and hazard tokens across multiple objects', () => {
+    const ld = buildReportJsonLd({
+      ...baseReport,
+      objects: [
+        { objectType: 'RAMP', issues: ['TOO_STEEP'] },
+        { objectType: 'RAMP', issues: ['TOO_STEEP', 'TOO_NARROW'] },
+      ],
+    })
+    expect(ld.accessibilityFeature).toEqual(['ramp'])
+    expect(ld.accessibilityHazard).toEqual(['steepGradient', 'tooNarrow'])
+  })
+
+  test('drops unknown object types and issues silently', () => {
+    const ld = buildReportJsonLd({
+      ...baseReport,
+      objects: [
+        { objectType: 'UNKNOWN_OBJECT', issues: ['UNKNOWN_ISSUE', 'TOO_STEEP'] },
+      ],
+    })
+    expect(ld.accessibilityFeature).toBeUndefined()
+    expect(ld.accessibilityHazard).toEqual(['steepGradient'])
+  })
+
+  test('omits accessibilityFeature/Hazard arrays when empty', () => {
+    const ld = buildReportJsonLd({ ...baseReport, objects: [] })
+    expect(ld.accessibilityFeature).toBeUndefined()
+    expect(ld.accessibilityHazard).toBeUndefined()
+  })
+
+  test('attaches url when one is supplied', () => {
+    const ld = buildReportJsonLd(baseReport, { url: 'https://mapcess.live/?report=42' })
+    expect(ld.url).toBe('https://mapcess.live/?report=42')
+  })
+})
+
+describe('schemaOrg.reportJsonLdString', () => {
+  test('returns empty string when report is unrenderable', () => {
+    expect(reportJsonLdString(null)).toBe('')
+    expect(reportJsonLdString({})).toBe('')
+  })
+
+  test('serializes to valid JSON that round-trips', () => {
+    const report = {
+      id: 7,
+      title: 'Missing Ramp',
+      latitude: 1,
+      longitude: 2,
+      objects: [{ objectType: 'RAMP', issues: ['MISSING'] }],
+    }
+    const str = reportJsonLdString(report)
+    // Escaped `</` should not appear as a literal closing tag inside a script.
+    expect(str.includes('</')).toBe(false)
+    const parsed = JSON.parse(str.replace(/\\u003c/g, '<'))
+    expect(parsed['@type']).toBe('Place')
+    expect(parsed.accessibilityFeature).toEqual(['ramp'])
+    expect(parsed.accessibilityHazard).toEqual(['missingFeature'])
+  })
+
+  test('escapes inline </script> sequences in the description', () => {
+    const report = {
+      id: 9,
+      title: 'Hostile Description',
+      description: '</script><img src=x onerror=alert(1)>',
+      objects: [],
+    }
+    const str = reportJsonLdString(report)
+    expect(str.toLowerCase().includes('</script')).toBe(false)
+    // The escaped form should still parse back to the original text.
+    const parsed = JSON.parse(str.replace(/\\u003c/g, '<'))
+    expect(parsed.description).toBe('</script><img src=x onerror=alert(1)>')
+  })
+})
+
+describe('schemaOrg coverage of the project taxonomy', () => {
+  test('every ObjectType has a feature mapping', () => {
+    for (const t of OBJECT_TYPES) {
+      expect(OBJECT_TYPE_TO_FEATURE[t.type], `${t.type} missing feature mapping`).toBeTruthy()
+    }
+  })
+
+  test('every IssueType across the catalog has a hazard mapping', () => {
+    for (const t of OBJECT_TYPES) {
+      for (const issue of t.issues) {
+        expect(
+          ISSUE_TYPE_TO_HAZARD[issue.key],
+          `${t.type}.${issue.key} missing hazard mapping`,
+        ).toBeTruthy()
+      }
+    }
+  })
+})


### PR DESCRIPTION
# 📝 Embed Schema.org JSON-LD on Report Pages
Fixes #536

Adds a Schema.org `Place` JSON-LD block on the public report panel so search engines and assistive tools can understand the report's location and accessibility metadata.

- New `frontend/src/utils/schemaOrg.js` maps every `ObjectType` → `accessibilityFeature` token and every `IssueType` → `accessibilityHazard` token, then builds a `Place` JSON-LD object with `geo`, `accessibilityFeature`, and `accessibilityHazard`.
- `ReportPanel` renders a `<script type="application/ld+json">` for the open report; the embedded `url` mirrors the deep-link `/?report=<id>` so crawlers see the canonical resource.
- Output escapes `</` so a hostile description can't escape the script tag, and the test suite locks the taxonomy coverage so a new `IssueType`/`ObjectType` won't silently fall out of the JSON-LD.

# 📊 Type of Change
- [x]  New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# ⏱️ Estimated Review Time
- [x] < 5 min