### PR TITLE
[Backend] Add OpenAPI Annotations to Remaining Routing Controllers

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/config/OpenApiConfig.java
@@ -65,6 +65,7 @@ public class OpenApiConfig {
                         new Tag().name("Media").description("Upload report media to S3 and attach it to reports."),
                         new Tag().name("Object Types").description("Static catalogue of report object types and their issue/measurement schemas."),
                         new Tag().name("Routing").description("Accessible route planning that detours around verified obstacles."),
+                        new Tag().name("Routing Preferences").description("Per-user accessibility profile and routing-constraint settings that drive `/api/routes`. Includes built-in presets (Wheelchair, Blind/low-vision, Mobility-limited) and custom saved profiles."),
                         new Tag().name("Notifications").description("Per-user in-app notifications."),
                         new Tag().name("SSE — Public").description("Server-Sent Events stream of report-level changes; no auth required."),
                         new Tag().name("SSE — Notifications").description("Authenticated per-user Server-Sent Events stream for in-app notifications."),

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/CustomRoutingProfileController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/CustomRoutingProfileController.java
@@ -6,7 +6,13 @@ import com.bounswe2026group1.backend.dto.routing.CustomRoutingProfileResponse;
 import com.bounswe2026group1.backend.dto.routing.RoutingPreferencesResponse;
 import com.bounswe2026group1.backend.dto.routing.UpdateCustomRoutingProfileRequest;
 import com.bounswe2026group1.backend.service.CustomRoutingProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -29,11 +35,27 @@ import java.util.List;
 @RequestMapping("/api/users/me/routing-profiles")
 @RequiredArgsConstructor
 @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
+@Tag(name = "Routing Preferences",
+        description = "Per-user accessibility profile and routing-constraint settings that drive `/api/routes`. " +
+                "Includes built-in presets (Wheelchair, Blind/low-vision, Mobility-limited) and custom saved profiles.")
 public class CustomRoutingProfileController {
 
     private final CustomRoutingProfileService customRoutingProfileService;
 
     @GetMapping
+    @Operation(
+            summary = "List the caller's saved custom routing profiles",
+            description = "Returns every custom routing profile the authenticated user has saved, " +
+                    "ordered by creation time. Each user is capped at "
+                    + CustomRoutingProfileService.MAX_CUSTOM_PROFILES + " profiles."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of saved custom routing profiles.",
+                    content = @Content(schema = @Schema(implementation = CustomRoutingProfileResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Authentication required.",
+                    content = @Content(schema = @Schema(type = "string",
+                            example = "Authentication required.")))
+    })
     public ResponseEntity<?> list() {
         String email = currentUserEmailOrNull();
         if (email == null) {
@@ -44,6 +66,20 @@ public class CustomRoutingProfileController {
     }
 
     @PostMapping
+    @Operation(
+            summary = "Create a custom routing profile",
+            description = "Save a new named bundle of routing constraints (and an optional preferred " +
+                    "travel mode). Names are trimmed, capped at 50 characters, and must be unique per user. " +
+                    "Each user is capped at "
+                    + CustomRoutingProfileService.MAX_CUSTOM_PROFILES + " custom profiles."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Profile created.",
+                    content = @Content(schema = @Schema(implementation = CustomRoutingProfileResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Validation error (missing/blank name, name too long, missing body)."),
+            @ApiResponse(responseCode = "401", description = "Authentication required."),
+            @ApiResponse(responseCode = "409", description = "Profile cap reached, or another profile with the same name already exists.")
+    })
     public ResponseEntity<?> create(@Valid @RequestBody CreateCustomRoutingProfileRequest request) {
         String email = currentUserEmailOrNull();
         if (email == null) {
@@ -54,6 +90,20 @@ public class CustomRoutingProfileController {
     }
 
     @PutMapping("/{id}")
+    @Operation(
+            summary = "Update a custom routing profile",
+            description = "Owner-only. Patch the profile's name, constraints, and/or preferred travel " +
+                    "mode. Fields left null are preserved. If the profile is currently active, " +
+                    "constraint and travel-mode changes are propagated onto the user's live preferences."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Updated profile.",
+                    content = @Content(schema = @Schema(implementation = CustomRoutingProfileResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Validation error (blank name, name too long)."),
+            @ApiResponse(responseCode = "401", description = "Authentication required."),
+            @ApiResponse(responseCode = "404", description = "No profile with that id for the authenticated user."),
+            @ApiResponse(responseCode = "409", description = "Another profile with the same name already exists.")
+    })
     public ResponseEntity<?> update(@PathVariable Long id,
                                     @Valid @RequestBody UpdateCustomRoutingProfileRequest request) {
         String email = currentUserEmailOrNull();
@@ -65,6 +115,16 @@ public class CustomRoutingProfileController {
     }
 
     @DeleteMapping("/{id}")
+    @Operation(
+            summary = "Delete a custom routing profile",
+            description = "Owner-only. Removes the profile. If it was the user's active profile, the " +
+                    "user's preset is reset to `NONE` and their live constraint set is cleared."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Deleted."),
+            @ApiResponse(responseCode = "401", description = "Authentication required."),
+            @ApiResponse(responseCode = "404", description = "No profile with that id for the authenticated user.")
+    })
     public ResponseEntity<?> delete(@PathVariable Long id) {
         String email = currentUserEmailOrNull();
         if (email == null) {
@@ -75,6 +135,18 @@ public class CustomRoutingProfileController {
     }
 
     @PostMapping("/{id}/activate")
+    @Operation(
+            summary = "Activate a custom routing profile",
+            description = "Apply this profile's constraints (and travel mode, if set) to the caller's " +
+                    "live routing preferences and mark the profile as active. Sets the user's preset to " +
+                    "`CUSTOM`. Returns the resulting routing-preferences snapshot."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Profile activated; returns the updated preferences.",
+                    content = @Content(schema = @Schema(implementation = RoutingPreferencesResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Authentication required."),
+            @ApiResponse(responseCode = "404", description = "No profile with that id for the authenticated user.")
+    })
     public ResponseEntity<?> activate(@PathVariable Long id) {
         String email = currentUserEmailOrNull();
         if (email == null) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/CustomRoutingProfileController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/CustomRoutingProfileController.java
@@ -7,6 +7,7 @@ import com.bounswe2026group1.backend.dto.routing.RoutingPreferencesResponse;
 import com.bounswe2026group1.backend.dto.routing.UpdateCustomRoutingProfileRequest;
 import com.bounswe2026group1.backend.service.CustomRoutingProfileService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -35,9 +36,7 @@ import java.util.List;
 @RequestMapping("/api/users/me/routing-profiles")
 @RequiredArgsConstructor
 @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
-@Tag(name = "Routing Preferences",
-        description = "Per-user accessibility profile and routing-constraint settings that drive `/api/routes`. " +
-                "Includes built-in presets (Wheelchair, Blind/low-vision, Mobility-limited) and custom saved profiles.")
+@Tag(name = "Routing Preferences")
 public class CustomRoutingProfileController {
 
     private final CustomRoutingProfileService customRoutingProfileService;
@@ -51,7 +50,7 @@ public class CustomRoutingProfileController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "List of saved custom routing profiles.",
-                    content = @Content(schema = @Schema(implementation = CustomRoutingProfileResponse.class))),
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = CustomRoutingProfileResponse.class)))),
             @ApiResponse(responseCode = "401", description = "Authentication required.",
                     content = @Content(schema = @Schema(type = "string",
                             example = "Authentication required.")))

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/ObjectTypeController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/ObjectTypeController.java
@@ -3,6 +3,7 @@ package com.bounswe2026group1.backend.controller;
 import com.bounswe2026group1.backend.dto.ObjectTypeInfoResponse;
 import com.bounswe2026group1.backend.service.ObjectTypeService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -33,7 +34,7 @@ public class ObjectTypeController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Catalogue of object types with their valid issue types and measurement schemas.",
-                    content = @Content(schema = @Schema(implementation = ObjectTypeInfoResponse.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ObjectTypeInfoResponse.class))))
     })
     public List<ObjectTypeInfoResponse> getAll() {
         return objectTypeService.getAll();

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/ObjectTypeController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/ObjectTypeController.java
@@ -3,6 +3,10 @@ package com.bounswe2026group1.backend.controller;
 import com.bounswe2026group1.backend.dto.ObjectTypeInfoResponse;
 import com.bounswe2026group1.backend.service.ObjectTypeService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +31,10 @@ public class ObjectTypeController {
                     "measurement schema, so clients can render the right form when a user " +
                     "attaches an object to a report."
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Catalogue of object types with their valid issue types and measurement schemas.",
+                    content = @Content(schema = @Schema(implementation = ObjectTypeInfoResponse.class)))
+    })
     public List<ObjectTypeInfoResponse> getAll() {
         return objectTypeService.getAll();
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RoutingPreferencesController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RoutingPreferencesController.java
@@ -27,9 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/users/me/routing-preferences")
 @RequiredArgsConstructor
 @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
-@Tag(name = "Routing Preferences",
-        description = "Per-user accessibility profile and routing-constraint settings that drive `/api/routes`. " +
-                "Includes built-in presets (Wheelchair, Blind/low-vision, Mobility-limited) and custom saved profiles.")
+@Tag(name = "Routing Preferences")
 public class RoutingPreferencesController {
 
     private final RoutingPreferencesService routingPreferencesService;

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RoutingPreferencesController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RoutingPreferencesController.java
@@ -4,7 +4,13 @@ import com.bounswe2026group1.backend.config.OpenApiConfig;
 import com.bounswe2026group1.backend.dto.routing.RoutingPreferencesResponse;
 import com.bounswe2026group1.backend.dto.routing.UpdateRoutingPreferencesRequest;
 import com.bounswe2026group1.backend.service.RoutingPreferencesService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,11 +27,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/users/me/routing-preferences")
 @RequiredArgsConstructor
 @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
+@Tag(name = "Routing Preferences",
+        description = "Per-user accessibility profile and routing-constraint settings that drive `/api/routes`. " +
+                "Includes built-in presets (Wheelchair, Blind/low-vision, Mobility-limited) and custom saved profiles.")
 public class RoutingPreferencesController {
 
     private final RoutingPreferencesService routingPreferencesService;
 
     @GetMapping
+    @Operation(
+            summary = "Get the caller's routing preferences",
+            description = "Returns the active preset, the resolved routing-constraint set, the preferred " +
+                    "travel mode, the active custom profile id (if any), and the catalog of available " +
+                    "presets, constraints, and saved custom profiles."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Current preferences for the authenticated user.",
+                    content = @Content(schema = @Schema(implementation = RoutingPreferencesResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Authentication required.",
+                    content = @Content(schema = @Schema(type = "string",
+                            example = "Authentication required.")))
+    })
     public ResponseEntity<?> get() {
         String email = currentUserEmailOrNull();
         if (email == null) {
@@ -36,6 +58,20 @@ public class RoutingPreferencesController {
     }
 
     @PutMapping
+    @Operation(
+            summary = "Update routing preferences",
+            description = "Replace the caller's preset, constraint set, and/or preferred travel mode. " +
+                    "When both `preferredPreset` and `constraints` are supplied, `constraints` wins; the " +
+                    "active preset is then derived from the resolved constraint set. Switching to a " +
+                    "built-in preset (or `NONE`) implicitly deactivates any active custom profile."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Updated preferences.",
+                    content = @Content(schema = @Schema(implementation = RoutingPreferencesResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Authentication required.",
+                    content = @Content(schema = @Schema(type = "string",
+                            example = "Authentication required.")))
+    })
     public ResponseEntity<?> put(@RequestBody UpdateRoutingPreferencesRequest request) {
         String email = currentUserEmailOrNull();
         if (email == null) {


### PR DESCRIPTION
# 📝 Add OpenAPI Annotations to Remaining Routing Controllers
Fixes #535

Brings the last three undocumented controllers in line with `AuthController` / `ReportController`, closing the OpenAPI 3.0 coverage gap. `RoutingPreferencesController` and `CustomRoutingProfileController` are grouped under a new `Routing Preferences` Swagger tag (registered in [OpenApiConfig.java](backend/src/main/java/com/bounswe2026group1/backend/config/OpenApiConfig.java)) so user-facing accessibility-profile management stays separate from the public `/api/routes` planning endpoints. `ObjectTypeController` already had `@Tag`/`@Operation` and only needed `@ApiResponses`.

# 📊 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] All three controllers annotated (`@Tag` + `@Operation` + `@ApiResponses`)
- [x] `/swagger-ui` renders summaries, descriptions, and response codes for every endpoint in the three controllers
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests — N/A (annotations are metadata only)
- [x] All tests passed — 441/441 non-Testcontainers tests pass; 23 errors are pre-existing PostGIS/Testcontainers integration tests that need Docker (unrelated to this PR; same failures occur on `main` in this environment)

# 📸 Screenshots / Recordings
N/A — Swagger UI renders the new annotations; no UI changes elsewhere.

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min