### PR TITLE
[Backend] Serve Comments as W3C Web Annotations

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.bounswe2026group1.backend.controller;
 
 import com.bounswe2026group1.backend.config.OpenApiConfig;
+import com.bounswe2026group1.backend.dto.CommentAnnotationResponse;
 import com.bounswe2026group1.backend.dto.CommentResponse;
 import com.bounswe2026group1.backend.dto.CreateCommentRequest;
 import com.bounswe2026group1.backend.dto.UpdateCommentRequest;
@@ -14,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.List;
 
@@ -24,6 +26,8 @@ import java.util.List;
 public class CommentController {
 
     private final CommentService commentService;
+
+    private static final String LD_JSON = "application/ld+json";
 
     @GetMapping
     @Operation(summary = "List all comments")
@@ -43,6 +47,20 @@ public class CommentController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
+    @GetMapping(value = "/{id}/annotation", produces = LD_JSON)
+    @Operation(summary = "Get a single comment as a W3C Web Annotation",
+            description = "Same data as GET /api/comments/{id} but serialized per the W3C Web Annotation Data Model "
+                    + "(https://www.w3.org/TR/annotation-model/). Response media type is application/ld+json.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Comment found."),
+            @ApiResponse(responseCode = "404", description = "No comment with that id.")
+    })
+    public ResponseEntity<CommentAnnotationResponse> getByIdAsAnnotation(@PathVariable Long id) {
+        return commentService.getByIdAsAnnotation(id, currentApiBase())
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
     @GetMapping("/author/{authorId}")
     @Operation(summary = "List comments authored by a given user")
     public List<CommentResponse> getByAuthor(@PathVariable Long authorId) {
@@ -53,6 +71,18 @@ public class CommentController {
     @Operation(summary = "List comments on a given report")
     public List<CommentResponse> getByReport(@PathVariable Long reportId) {
         return commentService.getByReport(reportId);
+    }
+
+    @GetMapping(value = "/report/{reportId}/annotations", produces = LD_JSON)
+    @Operation(summary = "List comments on a given report as W3C Web Annotations",
+            description = "Same data as GET /api/comments/report/{reportId} but each item is serialized per the "
+                    + "W3C Web Annotation Data Model. Response media type is application/ld+json.")
+    public List<CommentAnnotationResponse> getByReportAsAnnotation(@PathVariable Long reportId) {
+        return commentService.getByReportAsAnnotation(reportId, currentApiBase());
+    }
+
+    private static String currentApiBase() {
+        return ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
     }
 
     @PostMapping

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/CommentAnnotationResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/CommentAnnotationResponse.java
@@ -10,8 +10,10 @@ import java.time.Instant;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "A comment serialized as a W3C Web Annotation Data Model Annotation "
-        + "(https://www.w3.org/TR/annotation-model/). Returned when the client requests "
-        + "media type application/ld+json on the standard comment endpoints.")
+        + "(https://www.w3.org/TR/annotation-model/). Returned by the dedicated "
+        + "/annotation(s) endpoints (GET /api/comments/{id}/annotation, "
+        + "GET /api/comments/report/{reportId}/annotations) as application/ld+json. "
+        + "The standard comment endpoints remain unaffected.")
 public record CommentAnnotationResponse(
 
         @JsonProperty("@context")

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/CommentAnnotationResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/CommentAnnotationResponse.java
@@ -1,0 +1,81 @@
+package com.bounswe2026group1.backend.dto;
+
+import com.bounswe2026group1.backend.model.Comment;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "A comment serialized as a W3C Web Annotation Data Model Annotation "
+        + "(https://www.w3.org/TR/annotation-model/). Returned when the client requests "
+        + "media type application/ld+json on the standard comment endpoints.")
+public record CommentAnnotationResponse(
+
+        @JsonProperty("@context")
+        @Schema(description = "JSON-LD context.", example = "http://www.w3.org/ns/anno.jsonld")
+        String context,
+
+        @Schema(description = "Annotation IRI.", example = "https://api.mapcess.live/api/comments/501")
+        String id,
+
+        @Schema(description = "Annotation type.", example = "Annotation")
+        String type,
+
+        @Schema(description = "Author of the annotation. Null if the author has been removed.",
+                nullable = true)
+        Creator creator,
+
+        @Schema(description = "When the annotation was created (UTC).", example = "2026-05-08T13:22:11Z")
+        Instant created,
+
+        @Schema(description = "Annotation body — the comment text.")
+        Body body,
+
+        @Schema(description = "IRI of the resource the annotation is about (the report).",
+                example = "https://api.mapcess.live/api/reports/77")
+        String target
+) {
+
+    @Schema(description = "Minimal public projection of a user as a schema.org-style Person reference. "
+            + "Never includes email, password, or role.")
+    public record Creator(
+            @Schema(description = "Author IRI.", example = "https://api.mapcess.live/api/users/42")
+            String id,
+            @Schema(description = "Object type.", example = "Person")
+            String type,
+            @Schema(description = "Display name.", example = "Alice Example")
+            String name
+    ) {}
+
+    @Schema(description = "Embedded TextualBody carrying the comment text.")
+    public record Body(
+            @Schema(description = "Body type.", example = "TextualBody")
+            String type,
+            @Schema(description = "Comment text.", example = "I confirmed this — the ramp is gone.")
+            String value,
+            @Schema(description = "MIME format of the body value.", example = "text/plain")
+            String format
+    ) {}
+
+    public static CommentAnnotationResponse fromEntity(Comment c, String apiBase) {
+        String base = apiBase == null ? "" : apiBase;
+        RegisteredUser a = c.getAuthor();
+        Creator creator = (a == null) ? null : new Creator(
+                base + "/api/users/" + a.getId(),
+                "Person",
+                a.getName());
+        Long reportId = (c.getReport() == null) ? null : c.getReport().getReportId();
+        String target = (reportId == null) ? null : base + "/api/reports/" + reportId;
+        return new CommentAnnotationResponse(
+                "http://www.w3.org/ns/anno.jsonld",
+                base + "/api/comments/" + c.getId(),
+                "Annotation",
+                creator,
+                c.getCreatedAt(),
+                new Body("TextualBody", c.getContent(), "text/plain"),
+                target);
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/CommentService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.service;
 
+import com.bounswe2026group1.backend.dto.CommentAnnotationResponse;
 import com.bounswe2026group1.backend.dto.CommentResponse;
 import com.bounswe2026group1.backend.dto.CreateCommentRequest;
 import com.bounswe2026group1.backend.dto.UpdateCommentRequest;
@@ -37,6 +38,16 @@ public class CommentService {
 
     public List<CommentResponse> getByReport(Long reportId) {
         return commentRepository.findByReportReportId(reportId).stream().map(CommentResponse::fromEntity).toList();
+    }
+
+    public Optional<CommentAnnotationResponse> getByIdAsAnnotation(Long id, String apiBase) {
+        return commentRepository.findById(id).map(c -> CommentAnnotationResponse.fromEntity(c, apiBase));
+    }
+
+    public List<CommentAnnotationResponse> getByReportAsAnnotation(Long reportId, String apiBase) {
+        return commentRepository.findByReportReportId(reportId).stream()
+                .map(c -> CommentAnnotationResponse.fromEntity(c, apiBase))
+                .toList();
     }
 
     @Transactional

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/CommentControllerTest.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.controller;
 
+import com.bounswe2026group1.backend.dto.CommentAnnotationResponse;
 import com.bounswe2026group1.backend.dto.CommentResponse;
 import com.bounswe2026group1.backend.dto.CreateCommentRequest;
 import com.bounswe2026group1.backend.dto.UpdateCommentRequest;
@@ -56,6 +57,18 @@ class CommentControllerTest {
                 "looks good",
                 Instant.parse("2026-05-08T20:00:00Z"),
                 new CommentResponse.AuthorRef(3L, "Alice", null));
+    }
+
+    private CommentAnnotationResponse annotationStub() {
+        return new CommentAnnotationResponse(
+                "http://www.w3.org/ns/anno.jsonld",
+                "http://localhost/api/comments/99",
+                "Annotation",
+                new CommentAnnotationResponse.Creator(
+                        "http://localhost/api/users/3", "Person", "Alice"),
+                Instant.parse("2026-05-08T20:00:00Z"),
+                new CommentAnnotationResponse.Body("TextualBody", "looks good", "text/plain"),
+                "http://localhost/api/reports/18");
     }
 
     // ───── Happy path ────────────────────────────────────────────────────────
@@ -226,6 +239,71 @@ class CommentControllerTest {
                 .andExpect(status().isBadRequest());
 
         verify(commentService, never()).update(any(Long.class), any(UpdateCommentRequest.class));
+    }
+
+    // ───── W3C Web Annotation shape (issue #537) ─────────────────────────────
+
+    @Test
+    void getByIdAsAnnotation_returnsAnnotationShape() throws Exception {
+        when(commentService.getByIdAsAnnotation(eq(99L), org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(Optional.of(annotationStub()));
+
+        mockMvc.perform(get("/api/comments/99/annotation")
+                        .header("Mapcess-Key", validApiKey)
+                        .accept("application/ld+json"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.['@context']").value("http://www.w3.org/ns/anno.jsonld"))
+                .andExpect(jsonPath("$.type").value("Annotation"))
+                .andExpect(jsonPath("$.id").value("http://localhost/api/comments/99"))
+                .andExpect(jsonPath("$.body.type").value("TextualBody"))
+                .andExpect(jsonPath("$.body.value").value("looks good"))
+                .andExpect(jsonPath("$.body.format").value("text/plain"))
+                .andExpect(jsonPath("$.target").value("http://localhost/api/reports/18"))
+                .andExpect(jsonPath("$.creator.type").value("Person"))
+                .andExpect(jsonPath("$.creator.name").value("Alice"))
+                .andExpect(jsonPath("$.creator.password").doesNotExist())
+                .andExpect(jsonPath("$.creator.email").doesNotExist());
+    }
+
+    @Test
+    void getByIdAsAnnotation_returns404WhenMissing() throws Exception {
+        when(commentService.getByIdAsAnnotation(eq(404L), org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/comments/404/annotation")
+                        .header("Mapcess-Key", validApiKey)
+                        .accept("application/ld+json"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getByReportAsAnnotation_returnsAnnotationList() throws Exception {
+        when(commentService.getByReportAsAnnotation(eq(18L), org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(java.util.List.of(annotationStub()));
+
+        mockMvc.perform(get("/api/comments/report/18/annotations")
+                        .header("Mapcess-Key", validApiKey)
+                        .accept("application/ld+json"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].['@context']").value("http://www.w3.org/ns/anno.jsonld"))
+                .andExpect(jsonPath("$[0].type").value("Annotation"))
+                .andExpect(jsonPath("$[0].body.value").value("looks good"))
+                .andExpect(jsonPath("$[0].target").value("http://localhost/api/reports/18"));
+    }
+
+    // ───── Legacy endpoints stay unchanged ───────────────────────────────────
+
+    @Test
+    void getByReport_legacyShapeUnchanged() throws Exception {
+        when(commentService.getByReport(eq(18L))).thenReturn(java.util.List.of(savedCommentStub()));
+
+        mockMvc.perform(get("/api/comments/report/18")
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].['@context']").doesNotExist())
+                .andExpect(jsonPath("$[0].body").doesNotExist())
+                .andExpect(jsonPath("$[0].id").value(99))
+                .andExpect(jsonPath("$[0].content").value("looks good"));
     }
 
     // The original prod-failure body for POST contained nested `author` and `report`


### PR DESCRIPTION
# 📝 Serve Comments as W3C Web Annotations
Fixes #537

Exposes each comment as a W3C Web Annotation Data Model Annotation (`@context`, `type: "Annotation"`, `body`, `target`) via two new `application/ld+json` endpoints. The existing legacy JSON endpoints are untouched, so deployed web and mobile clients are unaffected.

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

New endpoints:
- `GET /api/comments/{id}/annotation` → single Annotation
- `GET /api/comments/report/{reportId}/annotations` → list of Annotations

# 📸 Screenshots / Recordings
N/A — backend only.

# ⏱️ Estimated Review Time
- [x] < 5 min