### PR TITLE
[Backend] Fix Routing UX: Constraints, Profiles, and ORS Preference

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
@@ -62,18 +62,21 @@ public class RouteController {
         RegisteredUser caller = currentUserOrNull();
 
         // Three-state contract for the constraints argument (issue #544):
-        //   • null     — signed-in user with NONE preset; skip avoidance entirely.
+        //   • null     — signed-in caller has explicitly opted out of avoidance:
+        //                NONE preset, or CUSTOM preset with zero rules selected,
+        //                or any preset whose stored constraint set is empty
+        //                (the last covers data anomalies defensively).
         //   • Set.of() — anonymous baseline; avoid every verified obstacle.
         //   • non-empty — filter avoid set to hazards the user actually cares about.
         Set<RoutingConstraint> constraints;
         if (caller == null) {
             constraints = Set.of();
-        } else if (caller.getPreferredPreset() == RoutingPreset.NONE) {
+        } else if (caller.getPreferredPreset() == RoutingPreset.NONE
+                || caller.getRoutingConstraints() == null
+                || caller.getRoutingConstraints().isEmpty()) {
             constraints = null;
         } else {
-            constraints = caller.getRoutingConstraints() != null
-                    ? caller.getRoutingConstraints()
-                    : Set.of();
+            constraints = caller.getRoutingConstraints();
         }
         TravelMode preferredMode = caller != null ? caller.getPreferredTravelMode() : null;
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
@@ -61,27 +61,30 @@ public class RouteController {
         // and the user object again for recording the planned route. Anonymous → null.
         RegisteredUser caller = currentUserOrNull();
 
-        // Three-state contract for the constraints argument (issue #544):
-        //   • null     — signed-in caller has explicitly opted out of avoidance:
-        //                NONE preset, or CUSTOM preset with zero rules selected,
-        //                or any preset whose stored constraint set is empty
-        //                (the last covers data anomalies defensively).
-        //   • Set.of() — anonymous baseline; avoid every verified obstacle.
-        //   • non-empty — filter avoid set to hazards the user actually cares about.
-        Set<RoutingConstraint> constraints;
+        // Anonymous callers go through the 1-arg overload (always emits every
+        // alternative — Fastest + Accessible + Ramp-Assisted — since we don't
+        // know what they need). Authed callers go through the 3-arg overload
+        // which adapts the alternative set to their preferred mode.
+        List<RouteResponse> options;
         if (caller == null) {
-            constraints = Set.of();
-        } else if (caller.getPreferredPreset() == RoutingPreset.NONE
-                || caller.getRoutingConstraints() == null
-                || caller.getRoutingConstraints().isEmpty()) {
-            constraints = null;
+            options = routeService.getRouteOptions(request);
         } else {
-            constraints = caller.getRoutingConstraints();
-        }
-        TravelMode preferredMode = caller != null ? caller.getPreferredTravelMode() : null;
-
-        List<RouteResponse> options = routeService.getRouteOptions(request, constraints, preferredMode);
-        if (caller != null) {
+            // Three-state contract for the constraints argument (issue #544):
+            //   • null     — caller has explicitly opted out of avoidance:
+            //                NONE preset, or CUSTOM preset with zero rules,
+            //                or any preset whose stored constraint set is
+            //                empty (the last covers data anomalies).
+            //   • non-empty — filter avoid set to hazards the user actually
+            //                 cares about.
+            Set<RoutingConstraint> constraints;
+            if (caller.getPreferredPreset() == RoutingPreset.NONE
+                    || caller.getRoutingConstraints() == null
+                    || caller.getRoutingConstraints().isEmpty()) {
+                constraints = null;
+            } else {
+                constraints = caller.getRoutingConstraints();
+            }
+            options = routeService.getRouteOptions(request, constraints, caller.getPreferredTravelMode());
             recordPlannedRouteForUser(caller, request, options);
         }
         return ResponseEntity.ok(options);

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
@@ -7,6 +7,7 @@ import com.bounswe2026group1.backend.model.Location;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.model.Route;
 import com.bounswe2026group1.backend.model.RoutingConstraint;
+import com.bounswe2026group1.backend.model.RoutingPreset;
 import com.bounswe2026group1.backend.model.TravelMode;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.repository.RouteRepository;
@@ -60,9 +61,20 @@ public class RouteController {
         // and the user object again for recording the planned route. Anonymous → null.
         RegisteredUser caller = currentUserOrNull();
 
-        Set<RoutingConstraint> constraints = caller != null && caller.getRoutingConstraints() != null
-                ? caller.getRoutingConstraints()
-                : Set.of();
+        // Three-state contract for the constraints argument (issue #544):
+        //   • null     — signed-in user with NONE preset; skip avoidance entirely.
+        //   • Set.of() — anonymous baseline; avoid every verified obstacle.
+        //   • non-empty — filter avoid set to hazards the user actually cares about.
+        Set<RoutingConstraint> constraints;
+        if (caller == null) {
+            constraints = Set.of();
+        } else if (caller.getPreferredPreset() == RoutingPreset.NONE) {
+            constraints = null;
+        } else {
+            constraints = caller.getRoutingConstraints() != null
+                    ? caller.getRoutingConstraints()
+                    : Set.of();
+        }
         TravelMode preferredMode = caller != null ? caller.getPreferredTravelMode() : null;
 
         List<RouteResponse> options = routeService.getRouteOptions(request, constraints, preferredMode);

--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
@@ -62,7 +62,7 @@ public class RouteController {
         RegisteredUser caller = currentUserOrNull();
 
         // Anonymous callers go through the 1-arg overload (always emits every
-        // alternative — Fastest + Accessible + Ramp-Assisted — since we don't
+        // alternative — Fastest + Accessible + Wheelchair — since we don't
         // know what they need). Authed callers go through the 3-arg overload
         // which adapts the alternative set to their preferred mode.
         List<RouteResponse> options;

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ObstacleService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ObstacleService.java
@@ -53,28 +53,40 @@ public class ObstacleService {
 
     /**
      * Backwards-compatible no-arg overload — same as the empty-constraint case,
-     * which preserves the pre-#365 baseline (every VERIFIED obstacle becomes
-     * a polygon).
+     * which preserves the pre-#365 anonymous baseline (every VERIFIED obstacle
+     * becomes a polygon). Distinct from passing {@code null}, which means
+     * "skip avoidance entirely" (issue #544).
      */
     public ObjectNode buildAvoidPolygons() {
         return buildAvoidPolygons(Set.of());
     }
 
     /**
-     * Build the GeoJSON MultiPolygon avoid set for routing.
+     * Build the GeoJSON MultiPolygon avoid set for routing. Three input states:
      *
-     * <p>When {@code constraints} is empty the baseline is preserved: every
-     * VERIFIED obstacle report becomes an avoid polygon (anonymous and
-     * NONE-preset users get the historical "Accessible Route" behaviour).
+     * <ul>
+     *   <li>{@code null} → caller explicitly opted out of avoidance (signed-in
+     *       user with {@code RoutingPreset.NONE}). Returns {@code null} so no
+     *       polygons are sent to ORS and the Accessible Route alternative is
+     *       skipped (issue #544).</li>
+     *   <li>Empty set → anonymous baseline. Every VERIFIED obstacle report
+     *       becomes an avoid polygon — preserves the pre-#365 contract for
+     *       callers without a profile we can read.</li>
+     *   <li>Non-empty set → only VERIFIED obstacle reports whose objects expose
+     *       at least one {@link IssueHazard} matching a hazard in the expanded
+     *       constraint set become polygons. Constraints can only narrow the
+     *       avoid set, never widen it past the baseline.</li>
+     * </ul>
      *
-     * <p>When {@code constraints} is non-empty, only VERIFIED obstacle reports
-     * whose objects expose at least one {@link IssueHazard} matching a hazard
-     * in the expanded constraint set become polygons. Constraints can only
-     * narrow the avoid set, never widen it past the baseline.
-     *
-     * @return a GeoJSON MultiPolygon node, or null if no reports survive the filter
+     * @return a GeoJSON MultiPolygon node, or null if avoidance is skipped /
+     *         no reports survive the filter
      */
     public ObjectNode buildAvoidPolygons(Set<RoutingConstraint> constraints) {
+        // null = caller explicitly opted out (NONE preset). Skip avoidance.
+        if (constraints == null) {
+            return null;
+        }
+
         // Fetch only VERIFIED obstacle reports for route avoidance.
         List<Report> obstacles = reportRepository.findByTypeAndStatusIn(ReportType.OBSTACLE, ACTIVE_STATUSES);
         if (obstacles.isEmpty()) {
@@ -201,17 +213,25 @@ public class ObstacleService {
     /**
      * Return VERIFIED OUTDOOR obstacle reports that lie within
      * {@value PATH_BUFFER_METERS} m of any segment of the given decoded path
-     * AND are relevant to the caller's accessibility constraints.
+     * AND are relevant to the caller's accessibility constraints. Mirrors the
+     * three-state {@code constraints} contract on {@link #buildAvoidPolygons(Set)}:
      *
-     * <p>When {@code constraints} is empty the baseline applies: every nearby
-     * VERIFIED OUTDOOR obstacle is returned (anonymous and NONE-preset users
-     * get the full set). When non-empty, the result is filtered to obstacles
-     * whose objects expose at least one hazard the user actually cares about
-     * — same predicate that {@link #buildAvoidPolygons(Set)} uses, so the
-     * {@code hasObstacles} flag on a route response stays consistent with
-     * which polygons would have been avoided.
+     * <ul>
+     *   <li>{@code null} → caller explicitly opted out — returns an empty list
+     *       so the {@code hasObstacles} flag never lights up for them (issue #544).</li>
+     *   <li>Empty set → anonymous baseline: every nearby VERIFIED OUTDOOR
+     *       obstacle is returned.</li>
+     *   <li>Non-empty set → filtered to obstacles whose objects expose at least
+     *       one hazard the user actually cares about, using the same predicate
+     *       as {@link #buildAvoidPolygons(Set)} so {@code hasObstacles} stays
+     *       consistent with which polygons would have been avoided.</li>
+     * </ul>
      */
     public List<Report> findObstaclesOnPath(List<Location> pathPoints, Set<RoutingConstraint> constraints) {
+        // null = caller explicitly opted out — no obstacle is "on path" for them.
+        if (constraints == null) {
+            return List.of();
+        }
         if (pathPoints.size() < 2) {
             return List.of();
         }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/OrsRoutingClient.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/OrsRoutingClient.java
@@ -98,7 +98,7 @@ public class OrsRoutingClient {
         root.put("units", "m");
         root.put("instructions", true);
         root.put("geometry", true);
-        root.put("preference", "recommended");
+        root.put("preference", "shortest");
 
         if (avoidPolygons != null) {
             ObjectNode options = objectMapper.createObjectNode();

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -41,7 +41,11 @@ public class RouteService {
      * alternative whose mode matches their preferred travel mode.
      *
      * @param request           start/end coordinates from the controller
-     * @param constraints       caller's selected routing constraints; empty for anonymous / NONE preset
+     * @param constraints       caller's selected routing constraints. {@code null}
+     *                          means the signed-in caller picked
+     *                          {@code RoutingPreset.NONE} and explicitly opted out
+     *                          of avoidance (issue #544); empty set means the
+     *                          anonymous baseline; non-empty filters by hazard.
      * @param preferredMode     caller's preferred travel mode; null for no preference
      */
     public List<RouteResponse> getRouteOptions(
@@ -52,8 +56,9 @@ public class RouteService {
         Location start = new Location(request.getStartLat(), request.getStartLon());
         Location end = new Location(request.getEndLat(), request.getEndLon());
 
-        // Build avoid polygons once — reused for routes 2 and 3.
-        // Empty constraints preserves the pre-#365 baseline (every VERIFIED obstacle becomes a polygon).
+        // Build avoid polygons once — reused for routes 2 and 3. Three-state
+        // contract on `constraints`: null skips avoidance entirely, empty set
+        // is the anonymous baseline (avoid all), non-empty filters by hazard.
         ObjectNode avoidPolygons = obstacleService.buildAvoidPolygons(constraints);
 
         List<RouteResponse> routes = new ArrayList<>();

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -143,72 +143,71 @@ public class RouteService {
         RouteResponse bestWheelchair = null;
 
         if (includeWheelchairAlternative) {
+            // Candidate A: direct wheelchair route with obstacle avoidance
+            RoutingDirectionsResult wheelchairResult =
+                    fetchOrNull(start, end, TravelMode.WHEELCHAIR, avoidPolygons);
+            if (wheelchairResult != null) {
+                bestWheelchair = RouteResponse.builder()
+                        .routeLabel(wheelchairLabel)
+                        .distanceMeters(wheelchairResult.getDistanceMeters())
+                        .durationSeconds(wheelchairResult.getDurationSeconds())
+                        .mode(TravelMode.WHEELCHAIR)
+                        .geometry(wheelchairResult.getGeometry())
+                        .steps(wheelchairResult.getSteps())
+                        .hasObstacles(false)
+                        .build();
+            }
 
-        // Candidate A: direct wheelchair route with obstacle avoidance
-        RoutingDirectionsResult wheelchairResult = fetchOrNull(start, end, TravelMode.WHEELCHAIR, avoidPolygons);
-        if (wheelchairResult != null) {
-            bestWheelchair = RouteResponse.builder()
-                    .routeLabel(wheelchairLabel)
-                    .distanceMeters(wheelchairResult.getDistanceMeters())
-                    .durationSeconds(wheelchairResult.getDurationSeconds())
-                    .mode(TravelMode.WHEELCHAIR)
-                    .geometry(wheelchairResult.getGeometry())
-                    .steps(wheelchairResult.getSteps())
-                    .hasObstacles(false)
-                    .build();
-        }
+            // Candidate B: multi-leg route through nearest ramp entry/exit
+            Report ramp = obstacleService.findClosestRampInBoundingBox(start, end);
+            if (ramp != null && ramp.getEntryPoint() != null && ramp.getExitPoint() != null) {
+                Location rampA = ramp.getEntryPoint();
+                Location rampB = ramp.getExitPoint();
+                double distAToStart = haversineMeters(rampA, start);
+                double distBToStart = haversineMeters(rampB, start);
+                Location rampEntry = distAToStart <= distBToStart ? rampA : rampB;
+                Location rampExit  = distAToStart <= distBToStart ? rampB : rampA;
 
-        // Candidate B: multi-leg route through nearest ramp entry/exit
-        Report ramp = obstacleService.findClosestRampInBoundingBox(start, end);
-        if (ramp != null && ramp.getEntryPoint() != null && ramp.getExitPoint() != null) {
-            Location rampA = ramp.getEntryPoint();
-            Location rampB = ramp.getExitPoint();
-            double distAToStart = haversineMeters(rampA, start);
-            double distBToStart = haversineMeters(rampB, start);
-            Location rampEntry = distAToStart <= distBToStart ? rampA : rampB;
-            Location rampExit  = distAToStart <= distBToStart ? rampB : rampA;
+                RoutingDirectionsResult leg1 = fetchOrNull(start, rampEntry, TravelMode.WHEELCHAIR, avoidPolygons);
+                RoutingDirectionsResult leg2 = fetchOrNull(rampEntry, rampExit, TravelMode.WALKING, null);
+                RoutingDirectionsResult leg3 = fetchOrNull(rampExit, end, TravelMode.WHEELCHAIR, avoidPolygons);
 
-            RoutingDirectionsResult leg1 = fetchOrNull(start, rampEntry, TravelMode.WHEELCHAIR, avoidPolygons);
-            RoutingDirectionsResult leg2 = fetchOrNull(rampEntry, rampExit, TravelMode.WALKING, null);
-            RoutingDirectionsResult leg3 = fetchOrNull(rampExit, end, TravelMode.WHEELCHAIR, avoidPolygons);
+                if (leg1 != null && leg2 != null && leg3 != null) {
+                    double totalDistance = leg1.getDistanceMeters() + leg2.getDistanceMeters() + leg3.getDistanceMeters();
+                    double totalDuration = leg1.getDurationSeconds() + leg2.getDurationSeconds() + leg3.getDurationSeconds();
 
-            if (leg1 != null && leg2 != null && leg3 != null) {
-                double totalDistance = leg1.getDistanceMeters() + leg2.getDistanceMeters() + leg3.getDistanceMeters();
-                double totalDuration = leg1.getDurationSeconds() + leg2.getDurationSeconds() + leg3.getDurationSeconds();
+                    // Pick the ramp-assisted multi-leg if it's shorter than the direct wheelchair route
+                    if (bestWheelchair == null || totalDistance < bestWheelchair.getDistanceMeters()) {
+                        List<Location> combinedPath = new ArrayList<>();
+                        combinedPath.addAll(PolylineDecoder.decode(leg1.getGeometry()));
+                        combinedPath.addAll(PolylineDecoder.decode(leg2.getGeometry()));
+                        combinedPath.addAll(PolylineDecoder.decode(leg3.getGeometry()));
 
-                // Pick the ramp-assisted multi-leg if it's shorter than the direct wheelchair route
-                if (bestWheelchair == null || totalDistance < bestWheelchair.getDistanceMeters()) {
-                    List<Location> combinedPath = new ArrayList<>();
-                    combinedPath.addAll(PolylineDecoder.decode(leg1.getGeometry()));
-                    combinedPath.addAll(PolylineDecoder.decode(leg2.getGeometry()));
-                    combinedPath.addAll(PolylineDecoder.decode(leg3.getGeometry()));
+                        List<RouteStep> combinedSteps = new ArrayList<>();
+                        if (leg1.getSteps() != null) combinedSteps.addAll(leg1.getSteps());
+                        combinedSteps.addAll(leg2.getSteps());
+                        combinedSteps.add(RouteStep.builder().instruction("Exit the ramp").maneuverType("ramp_exit").build());
+                        if (leg3.getSteps() != null) combinedSteps.addAll(leg3.getSteps());
 
-                    List<RouteStep> combinedSteps = new ArrayList<>();
-                    if (leg1.getSteps() != null) combinedSteps.addAll(leg1.getSteps());
-                    combinedSteps.addAll(leg2.getSteps());
-                    combinedSteps.add(RouteStep.builder().instruction("Exit the ramp").maneuverType("ramp_exit").build());
-                    if (leg3.getSteps() != null) combinedSteps.addAll(leg3.getSteps());
-
-                    bestWheelchair = RouteResponse.builder()
-                            .routeLabel(wheelchairLabel)
-                            .distanceMeters(totalDistance)
-                            .durationSeconds(totalDuration)
-                            .mode(TravelMode.WHEELCHAIR)
-                            .geometry(PolylineEncoder.encode(combinedPath))
-                            .steps(combinedSteps)
-                            .hasObstacles(false)
-                            .build();
+                        bestWheelchair = RouteResponse.builder()
+                                .routeLabel(wheelchairLabel)
+                                .distanceMeters(totalDistance)
+                                .durationSeconds(totalDuration)
+                                .mode(TravelMode.WHEELCHAIR)
+                                .geometry(PolylineEncoder.encode(combinedPath))
+                                .steps(combinedSteps)
+                                .hasObstacles(false)
+                                .build();
+                    }
+                } else {
+                    log.warn("Ramp-assisted route via ramp skipped; leg 1, leg 2, or leg 3 returned null.");
                 }
-            } else {
-                log.warn("Ramp-assisted route via ramp skipped; leg 1, leg 2, or leg 3 returned null.");
+            }
+
+            if (bestWheelchair != null) {
+                routes.add(bestWheelchair);
             }
         }
-
-        if (bestWheelchair != null) {
-            routes.add(bestWheelchair);
-        }
-
-        } // end if (includeWheelchairAlternative)
 
         markPreferred(routes, preferredMode);
         return routes;

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -76,12 +76,12 @@ public class RouteService {
             boolean includeWheelchairAlternative) {
 
         // A wheelchair caller's wheelchair-mode route IS their accessible
-        // route — we label it "Accessible Route" rather than "Ramp-Assisted
+        // route — we label it "Accessible Route" rather than "Wheelchair
         // Route" so the route set reads naturally to them. Anonymous /
-        // walking callers see the separate "Ramp-Assisted Route" label as a
+        // walking callers see the separate "Wheelchair Route" label as a
         // third alternative.
         boolean isWheelchairCaller = preferredMode == TravelMode.WHEELCHAIR;
-        String wheelchairLabel = isWheelchairCaller ? "Accessible Route" : "Ramp-Assisted Route";
+        String wheelchairLabel = isWheelchairCaller ? "Accessible Route" : "Wheelchair Route";
 
         Location start = new Location(request.getStartLat(), request.getStartLon());
         Location end = new Location(request.getEndLat(), request.getEndLon());
@@ -137,7 +137,7 @@ public class RouteService {
 
         // 3. Wheelchair-mode route — best of direct wheelchair vs multi-leg
         // through ramp. Gated: only emitted for anonymous callers (separate
-        // "Ramp-Assisted Route" label) or wheelchair callers (their
+        // "Wheelchair Route" label) or wheelchair callers (their
         // "Accessible Route"). Walking / no-preference authed users get
         // nothing here.
         RouteResponse bestWheelchair = null;

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -26,32 +26,62 @@ public class RouteService {
     private final ObstacleService obstacleService;
 
     /**
-     * Backwards-compatible signature — anonymous routing path. Equivalent to
-     * {@link #getRouteOptions(RouteRequest, Set, TravelMode)} with no
-     * constraints and no preferred mode (no alternative is flagged
-     * {@code preferred:true}).
+     * Anonymous routing path. Anonymous callers get every alternative
+     * (Fastest + Accessible + Wheelchair) because we don't know what they
+     * need.
      */
     public List<RouteResponse> getRouteOptions(RouteRequest request) {
-        return getRouteOptions(request, Set.of(), null);
+        return getRouteOptions(request, Set.of(), null,
+                /* includeWalkingAccessibleAlternative = */ true,
+                /* includeWheelchairAlternative = */ true);
     }
 
     /**
-     * Build the route alternatives, optionally filtering avoid polygons by
-     * the caller's accessibility constraints (#365) and flagging the
-     * alternative whose mode matches their preferred travel mode.
+     * Authenticated routing path. The alternative set adapts to the caller's
+     * preferred travel mode:
+     * <ul>
+     *   <li>{@link TravelMode#WHEELCHAIR}: Fastest (walking, for context) +
+     *       <em>Accessible Route in wheelchair mode</em> (avoids obstacles,
+     *       routes through mapped ramps when nearby). The walking-mode
+     *       Accessible Route is suppressed; the wheelchair-mode one is its
+     *       accessibility-aware alternative.</li>
+     *   <li>Anything else (including {@code null}): Fastest + Accessible Route
+     *       in walking mode. The wheelchair alternative is suppressed.</li>
+     * </ul>
      *
      * @param request           start/end coordinates from the controller
      * @param constraints       caller's selected routing constraints. {@code null}
      *                          means the signed-in caller picked
-     *                          {@code RoutingPreset.NONE} and explicitly opted out
-     *                          of avoidance (issue #544); empty set means the
-     *                          anonymous baseline; non-empty filters by hazard.
+     *                          {@code RoutingPreset.NONE} (or CUSTOM with zero
+     *                          rules) and explicitly opted out of avoidance
+     *                          (issue #544); empty set means the anonymous
+     *                          baseline; non-empty filters by hazard.
      * @param preferredMode     caller's preferred travel mode; null for no preference
      */
     public List<RouteResponse> getRouteOptions(
             RouteRequest request,
             Set<RoutingConstraint> constraints,
             TravelMode preferredMode) {
+        boolean isWheelchairCaller = preferredMode == TravelMode.WHEELCHAIR;
+        return getRouteOptions(request, constraints, preferredMode,
+                /* includeWalkingAccessibleAlternative = */ !isWheelchairCaller,
+                /* includeWheelchairAlternative = */ isWheelchairCaller);
+    }
+
+    private List<RouteResponse> getRouteOptions(
+            RouteRequest request,
+            Set<RoutingConstraint> constraints,
+            TravelMode preferredMode,
+            boolean includeWalkingAccessibleAlternative,
+            boolean includeWheelchairAlternative) {
+
+        // A wheelchair caller's wheelchair-mode route IS their accessible
+        // route — we label it "Accessible Route" rather than "Ramp-Assisted
+        // Route" so the route set reads naturally to them. Anonymous /
+        // walking callers see the separate "Ramp-Assisted Route" label as a
+        // third alternative.
+        boolean isWheelchairCaller = preferredMode == TravelMode.WHEELCHAIR;
+        String wheelchairLabel = isWheelchairCaller ? "Accessible Route" : "Ramp-Assisted Route";
 
         Location start = new Location(request.getStartLat(), request.getStartLon());
         Location end = new Location(request.getEndLat(), request.getEndLon());
@@ -85,8 +115,11 @@ public class RouteService {
                     .build());
         }
 
-        // 2. Accessible walking route — always computed when avoid polygons exist
-        if (avoidPolygons != null) {
+        // 2. Accessible walking route — computed when avoid polygons exist AND
+        // the caller would actually act on a walking-mode alternative.
+        // Wheelchair callers' accessible alternative IS the wheelchair-mode
+        // route below; emitting a walking Accessible Route to them is noise.
+        if (avoidPolygons != null && includeWalkingAccessibleAlternative) {
             RoutingDirectionsResult accessibleResult = fetchOrNull(start, end, TravelMode.WALKING, avoidPolygons);
 
             if (accessibleResult != null) {
@@ -102,14 +135,20 @@ public class RouteService {
             }
         }
 
-        // 3. Ramp-Assisted Route — best of direct wheelchair vs multi-leg through ramp
+        // 3. Wheelchair-mode route — best of direct wheelchair vs multi-leg
+        // through ramp. Gated: only emitted for anonymous callers (separate
+        // "Ramp-Assisted Route" label) or wheelchair callers (their
+        // "Accessible Route"). Walking / no-preference authed users get
+        // nothing here.
         RouteResponse bestWheelchair = null;
+
+        if (includeWheelchairAlternative) {
 
         // Candidate A: direct wheelchair route with obstacle avoidance
         RoutingDirectionsResult wheelchairResult = fetchOrNull(start, end, TravelMode.WHEELCHAIR, avoidPolygons);
         if (wheelchairResult != null) {
             bestWheelchair = RouteResponse.builder()
-                    .routeLabel("Ramp-Assisted Route")
+                    .routeLabel(wheelchairLabel)
                     .distanceMeters(wheelchairResult.getDistanceMeters())
                     .durationSeconds(wheelchairResult.getDurationSeconds())
                     .mode(TravelMode.WHEELCHAIR)
@@ -151,7 +190,7 @@ public class RouteService {
                     if (leg3.getSteps() != null) combinedSteps.addAll(leg3.getSteps());
 
                     bestWheelchair = RouteResponse.builder()
-                            .routeLabel("Ramp-Assisted Route")
+                            .routeLabel(wheelchairLabel)
                             .distanceMeters(totalDistance)
                             .durationSeconds(totalDuration)
                             .mode(TravelMode.WHEELCHAIR)
@@ -168,6 +207,8 @@ public class RouteService {
         if (bestWheelchair != null) {
             routes.add(bestWheelchair);
         }
+
+        } // end if (includeWheelchairAlternative)
 
         markPreferred(routes, preferredMode);
         return routes;

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
@@ -286,4 +286,117 @@ class RoutingPreferencesRouteIntegrationTest {
         verify(obstacleService, atLeastOnce()).buildAvoidPolygons(isNull());
         verify(obstacleService, never()).buildAvoidPolygons(eq(Set.of()));
     }
+
+    // ── Preset-aware route set ──────────────────────────────────────────────
+    //
+    // Contract:
+    //   • Anonymous: Fastest + walking Accessible + Ramp-Assisted (3).
+    //   • Authed non-wheelchair: Fastest + walking Accessible (2).
+    //   • Authed wheelchair: Fastest + Accessible Route in WHEELCHAIR mode (2);
+    //     no separate "Ramp-Assisted Route" label since the
+    //     accessibility-aware alternative is already wheelchair-routed.
+
+    @Test
+    void anonymous_includesBothWalkingAccessibleAndRampAssistedRoutes() throws Exception {
+        // Accessible Route is emitted only when avoid polygons exist — stub a
+        // non-null payload so the test exercises the three-alternative path.
+        when(obstacleService.buildAvoidPolygons(any())).thenReturn(objectMapper.createObjectNode());
+
+        MvcResult result = mockMvc.perform(post("/api/routes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(labels(result))
+                .as("Anonymous callers don't have a declared mode, so all alternatives are returned")
+                .contains("Fastest Route", "Accessible Route", "Ramp-Assisted Route");
+    }
+
+    @Test
+    void authenticated_withWheelchairPreference_emitsAccessibleRouteInWheelchairMode() throws Exception {
+        // A wheelchair caller's accessibility-aware alternative IS the
+        // wheelchair route. We label it "Accessible Route" (not "Ramp-Assisted
+        // Route") and its mode is WHEELCHAIR — so it goes through
+        // avoid_polygons + mapped ramps.
+        when(obstacleService.buildAvoidPolygons(any())).thenReturn(objectMapper.createObjectNode());
+        user.setPreferredTravelMode(TravelMode.WHEELCHAIR);
+        // Give them a non-empty constraint set so the controller doesn't
+        // null-out their constraints (which would skip avoidance entirely).
+        user.setPreferredPreset(RoutingPreset.WHEELCHAIR_USER);
+        user.setRoutingConstraints(new HashSet<>(RoutingPreset.WHEELCHAIR_USER.getConstraints()));
+        registeredUserRepository.save(user);
+
+        MvcResult result = mockMvc.perform(post("/api/routes")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(labels(result))
+                .as("Wheelchair caller's route set: Fastest + Accessible (wheelchair mode); no separate Ramp-Assisted label")
+                .containsExactlyInAnyOrder("Fastest Route", "Accessible Route");
+
+        // The Accessible Route's mode is WHEELCHAIR for a wheelchair caller.
+        JsonNode accessible = null;
+        for (JsonNode alt : body) {
+            if ("Accessible Route".equals(alt.get("routeLabel").asString())) {
+                accessible = alt;
+                break;
+            }
+        }
+        assertThat(accessible).as("Accessible Route must be present for wheelchair caller").isNotNull();
+        assertThat(accessible.get("mode").asString())
+                .as("Wheelchair caller's Accessible Route uses the wheelchair profile")
+                .isEqualTo("WHEELCHAIR");
+    }
+
+    @Test
+    void authenticated_withWalkingPreference_dropsRampAssistedRoute() throws Exception {
+        user.setPreferredTravelMode(TravelMode.WALKING);
+        user.setPreferredPreset(RoutingPreset.BLIND_OR_LOW_VISION);
+        user.setRoutingConstraints(new HashSet<>(RoutingPreset.BLIND_OR_LOW_VISION.getConstraints()));
+        registeredUserRepository.save(user);
+
+        MvcResult result = mockMvc.perform(post("/api/routes")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(labels(result))
+                .as("Walking-mode users don't get a separate Ramp-Assisted Route card")
+                .doesNotContain("Ramp-Assisted Route");
+    }
+
+    @Test
+    void authenticated_withoutPreferredTravelMode_dropsRampAssistedRoute() throws Exception {
+        user.setPreferredTravelMode(null);
+        // Non-empty constraints so the user reaches the route-emission path
+        // rather than the null-constraints (opt-out) path.
+        user.setPreferredPreset(RoutingPreset.MOBILITY_LIMITED);
+        user.setRoutingConstraints(new HashSet<>(RoutingPreset.MOBILITY_LIMITED.getConstraints()));
+        registeredUserRepository.save(user);
+
+        MvcResult result = mockMvc.perform(post("/api/routes")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(labels(result))
+                .as("Authed users who haven't declared a mode are treated as non-wheelchair")
+                .doesNotContain("Ramp-Assisted Route");
+    }
+
+    private List<String> labels(MvcResult result) throws Exception {
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        List<String> out = new java.util.ArrayList<>();
+        for (JsonNode alt : body) out.add(alt.get("routeLabel").asString());
+        return out;
+    }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
@@ -263,4 +263,27 @@ class RoutingPreferencesRouteIntegrationTest {
         verify(obstacleService, atLeastOnce()).buildAvoidPolygons(isNull());
         verify(obstacleService, never()).buildAvoidPolygons(eq(Set.of()));
     }
+
+    /**
+     * A signed-in user with a {@code CUSTOM} preset and zero rules has, just
+     * like a {@code NONE}-preset user, explicitly opted out of obstacle
+     * avoidance — they built a profile and chose to filter on nothing. The
+     * controller treats them the same: {@code constraints = null} so
+     * {@link ObstacleService} skips avoidance entirely.
+     */
+    @Test
+    void authenticated_withCustomPresetAndEmptyConstraints_passesNullConstraintsToObstacleService() throws Exception {
+        user.setPreferredPreset(RoutingPreset.CUSTOM);
+        user.setRoutingConstraints(new HashSet<>());
+        registeredUserRepository.save(user);
+
+        mockMvc.perform(post("/api/routes")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk());
+
+        verify(obstacleService, atLeastOnce()).buildAvoidPolygons(isNull());
+        verify(obstacleService, never()).buildAvoidPolygons(eq(Set.of()));
+    }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
@@ -290,14 +290,14 @@ class RoutingPreferencesRouteIntegrationTest {
     // ── Preset-aware route set ──────────────────────────────────────────────
     //
     // Contract:
-    //   • Anonymous: Fastest + walking Accessible + Ramp-Assisted (3).
+    //   • Anonymous: Fastest + walking Accessible + Wheelchair (3).
     //   • Authed non-wheelchair: Fastest + walking Accessible (2).
     //   • Authed wheelchair: Fastest + Accessible Route in WHEELCHAIR mode (2);
-    //     no separate "Ramp-Assisted Route" label since the
+    //     no separate "Wheelchair Route" label since the
     //     accessibility-aware alternative is already wheelchair-routed.
 
     @Test
-    void anonymous_includesBothWalkingAccessibleAndRampAssistedRoutes() throws Exception {
+    void anonymous_includesBothWalkingAccessibleAndWheelchairRoutes() throws Exception {
         // Accessible Route is emitted only when avoid polygons exist — stub a
         // non-null payload so the test exercises the three-alternative path.
         when(obstacleService.buildAvoidPolygons(any())).thenReturn(objectMapper.createObjectNode());
@@ -310,13 +310,13 @@ class RoutingPreferencesRouteIntegrationTest {
 
         assertThat(labels(result))
                 .as("Anonymous callers don't have a declared mode, so all alternatives are returned")
-                .contains("Fastest Route", "Accessible Route", "Ramp-Assisted Route");
+                .contains("Fastest Route", "Accessible Route", "Wheelchair Route");
     }
 
     @Test
     void authenticated_withWheelchairPreference_emitsAccessibleRouteInWheelchairMode() throws Exception {
         // A wheelchair caller's accessibility-aware alternative IS the
-        // wheelchair route. We label it "Accessible Route" (not "Ramp-Assisted
+        // wheelchair route. We label it "Accessible Route" (not "Wheelchair
         // Route") and its mode is WHEELCHAIR — so it goes through
         // avoid_polygons + mapped ramps.
         when(obstacleService.buildAvoidPolygons(any())).thenReturn(objectMapper.createObjectNode());
@@ -336,7 +336,7 @@ class RoutingPreferencesRouteIntegrationTest {
 
         JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
         assertThat(labels(result))
-                .as("Wheelchair caller's route set: Fastest + Accessible (wheelchair mode); no separate Ramp-Assisted label")
+                .as("Wheelchair caller's route set: Fastest + Accessible (wheelchair mode); no separate Wheelchair label")
                 .containsExactlyInAnyOrder("Fastest Route", "Accessible Route");
 
         // The Accessible Route's mode is WHEELCHAIR for a wheelchair caller.
@@ -354,7 +354,7 @@ class RoutingPreferencesRouteIntegrationTest {
     }
 
     @Test
-    void authenticated_withWalkingPreference_dropsRampAssistedRoute() throws Exception {
+    void authenticated_withWalkingPreference_dropsWheelchairRoute() throws Exception {
         user.setPreferredTravelMode(TravelMode.WALKING);
         user.setPreferredPreset(RoutingPreset.BLIND_OR_LOW_VISION);
         user.setRoutingConstraints(new HashSet<>(RoutingPreset.BLIND_OR_LOW_VISION.getConstraints()));
@@ -368,12 +368,12 @@ class RoutingPreferencesRouteIntegrationTest {
                 .andReturn();
 
         assertThat(labels(result))
-                .as("Walking-mode users don't get a separate Ramp-Assisted Route card")
-                .doesNotContain("Ramp-Assisted Route");
+                .as("Walking-mode users don't get a separate Wheelchair Route card")
+                .doesNotContain("Wheelchair Route");
     }
 
     @Test
-    void authenticated_withoutPreferredTravelMode_dropsRampAssistedRoute() throws Exception {
+    void authenticated_withoutPreferredTravelMode_dropsWheelchairRoute() throws Exception {
         user.setPreferredTravelMode(null);
         // Non-empty constraints so the user reaches the route-emission path
         // rather than the null-constraints (opt-out) path.
@@ -390,7 +390,7 @@ class RoutingPreferencesRouteIntegrationTest {
 
         assertThat(labels(result))
                 .as("Authed users who haven't declared a mode are treated as non-wheelchair")
-                .doesNotContain("Ramp-Assisted Route");
+                .doesNotContain("Wheelchair Route");
     }
 
     private List<String> labels(MvcResult result) throws Exception {

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
@@ -393,6 +393,53 @@ class RoutingPreferencesRouteIntegrationTest {
                 .doesNotContain("Wheelchair Route");
     }
 
+    /**
+     * Edge case: a signed-in wheelchair user with {@code RoutingPreset.NONE}
+     * has opted out of avoidance (so controller passes {@code constraints =
+     * null} → {@code buildAvoidPolygons} returns {@code null}) AND is in
+     * wheelchair mode (so the wheelchair-mode Accessible Route is emitted).
+     * That alternative comes out unfiltered — wheelchair-profile but with no
+     * avoid polygons applied. Defensible (they opted out), pinned by this test.
+     */
+    @Test
+    void authenticated_withNonePresetAndWheelchairMode_emitsUnfilteredWheelchairAccessibleRoute() throws Exception {
+        user.setPreferredPreset(RoutingPreset.NONE);
+        user.setRoutingConstraints(new HashSet<>());
+        user.setPreferredTravelMode(TravelMode.WHEELCHAIR);
+        registeredUserRepository.save(user);
+
+        MvcResult result = mockMvc.perform(post("/api/routes")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // Controller passes null constraints; ObstacleService short-circuits
+        // and never sees Set.of() for this caller.
+        verify(obstacleService, atLeastOnce()).buildAvoidPolygons(isNull());
+        verify(obstacleService, never()).buildAvoidPolygons(eq(Set.of()));
+
+        // Route set is the wheelchair caller's: Fastest + Accessible (no
+        // separate Wheelchair Route label). The Accessible Route runs the
+        // wheelchair profile — but without avoidance, since the user opted out.
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        JsonNode accessible = null;
+        for (JsonNode alt : body) {
+            if ("Accessible Route".equals(alt.get("routeLabel").asString())) {
+                accessible = alt;
+                break;
+            }
+        }
+        assertThat(accessible).as("Accessible Route must be present").isNotNull();
+        assertThat(accessible.get("mode").asString())
+                .as("NONE-preset wheelchair caller's Accessible Route still uses the wheelchair profile")
+                .isEqualTo("WHEELCHAIR");
+        assertThat(labels(result))
+                .as("No separate Wheelchair Route card for a wheelchair caller")
+                .doesNotContain("Wheelchair Route");
+    }
+
     private List<String> labels(MvcResult result) throws Exception {
         JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
         List<String> out = new java.util.ArrayList<>();

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -234,8 +235,32 @@ class RoutingPreferencesRouteIntegrationTest {
         for (JsonNode alternative : body) {
             assertThat(alternative.get("preferred").asBoolean()).isFalse();
         }
+    }
 
-        // ObstacleService should still receive an empty constraint set (NONE preset).
-        verify(obstacleService, atLeastOnce()).buildAvoidPolygons(eq(Set.of()));
+    // ── NONE preset → null constraints reach ObstacleService (issue #544) ──
+
+    /**
+     * A signed-in user who explicitly chose {@code RoutingPreset.NONE} should
+     * NOT have their reports avoided. The controller must distinguish them
+     * from anonymous callers (who fall through to the {@code Set.of()}
+     * baseline) by passing {@code null} instead.
+     */
+    @Test
+    void authenticated_withNonePreset_passesNullConstraintsToObstacleService() throws Exception {
+        // Default setup already has preset=NONE; reaffirm explicitly for clarity.
+        user.setPreferredPreset(RoutingPreset.NONE);
+        user.setRoutingConstraints(new HashSet<>());
+        registeredUserRepository.save(user);
+
+        mockMvc.perform(post("/api/routes")
+                        .with(user(EMAIL).roles("USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(routeRequestBody()))
+                .andExpect(status().isOk());
+
+        // Anonymous would pass Set.of(); NONE-preset users pass null so
+        // ObstacleService skips avoidance entirely.
+        verify(obstacleService, atLeastOnce()).buildAvoidPolygons(isNull());
+        verify(obstacleService, never()).buildAvoidPolygons(eq(Set.of()));
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ObstacleServiceTest.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -204,6 +206,35 @@ class ObstacleServiceTest {
 
         assertNotNull(polygons);
         assertEquals(1, polygons.get("coordinates").size());
+    }
+
+    // -------------------------------------------------------------------------
+    // null constraints — explicit "skip avoidance" path (issue #544)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void buildAvoidPolygons_nullConstraints_skipsAvoidanceWithoutHittingRepository() {
+        // Signed-in users with RoutingPreset.NONE pass null to opt out of
+        // avoidance entirely. The method must short-circuit before any DB call
+        // so the route service can cheaply skip the Accessible Route alternative.
+        ObjectNode polygons = obstacleService.buildAvoidPolygons((Set<RoutingConstraint>) null);
+
+        assertNull(polygons,
+                "null constraints must produce no avoid polygons (issue #544)");
+        verify(reportRepository, never()).findByTypeAndStatusIn(any(), any());
+    }
+
+    @Test
+    void findObstaclesOnPath_nullConstraints_returnsEmptyWithoutHittingRepository() {
+        // Same null-as-opt-out contract for the on-path check that drives the
+        // hasObstacles flag — a NONE-preset user should never see warnings.
+        List<Report> obstacles = obstacleService.findObstaclesOnPath(
+                List.of(START, END), (Set<RoutingConstraint>) null);
+
+        assertTrue(obstacles.isEmpty(),
+                "null constraints must yield no on-path obstacles (issue #544)");
+        verify(reportRepository, never()).findReportsInBoundingBoxWithStatuses(
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyList());
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/OrsRoutingClientTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/OrsRoutingClientTest.java
@@ -98,6 +98,25 @@ class OrsRoutingClientTest {
         assertEquals("foot-walking", client.mapProfile(TravelMode.WALKING));
     }
 
+    /**
+     * Pins {@code preference: shortest}. ORS's pedestrian {@code recommended}
+     * preference biases toward side streets in OSM-sparse areas (e.g. Istanbul),
+     * producing absurd detours when a direct arterial sidewalk isn't separately
+     * mapped. {@code shortest} routes via the actually-shortest pedestrian path.
+     */
+    @Test
+    void fetchDirections_usesShortestPreference() throws Exception {
+        when(orsHttpClient.postDirections(anyString(), anyString()))
+                .thenReturn(minimalOrsSuccessJson());
+
+        client.fetchDirections(START, END, TravelMode.WALKING, null);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(orsHttpClient).postDirections(anyString(), bodyCaptor.capture());
+        JsonNode body = objectMapper.readTree(bodyCaptor.getValue());
+        assertEquals("shortest", body.path("preference").stringValue());
+    }
+
     @Test
     void fetchDirections_parsesSummaryAndGeometry() {
         String json = """

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceLiveOrsIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceLiveOrsIntegrationTest.java
@@ -120,14 +120,15 @@ class RouteServiceLiveOrsIntegrationTest extends AbstractPostgisIntegrationTest 
         reportRepository.save(rampReport);
 
         List<RouteResponse> rampRoutes = routeService.getRouteOptions(request);
-        RouteResponse rampAssisted = byLabel(rampRoutes, "Ramp-Assisted Route");
         RouteResponse wheelchairAfterRamp = byLabel(rampRoutes, "Wheelchair Route");
 
-        assertNotNull(rampAssisted, "Ramp-assisted route should be generated when a ramp report exists");
-        assertNotNull(wheelchairAfterRamp, "Wheelchair route should still be generated");
+        assertNotNull(wheelchairAfterRamp, "Wheelchair Route should be generated when a ramp report exists");
+        // RouteService internally picks the best of a direct wheelchair route
+        // and a multi-leg via the mapped ramp. Adding a usable ramp report
+        // should produce a shorter wheelchair route than the no-reports baseline.
         assertTrue(
-                rampAssisted.getDurationSeconds() < wheelchairAfterRamp.getDurationSeconds(),
-                "Ramp-assisted route duration should be shorter than wheelchair route duration");
+                wheelchairAfterRamp.getDurationSeconds() < baselineWheelchair.getDurationSeconds(),
+                "Adding a ramp report should shorten the Wheelchair Route relative to the baseline");
     }
 
     private static RouteResponse byLabel(List<RouteResponse> routes, String label) {

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
@@ -94,11 +94,11 @@ class RouteServiceTest {
                 routeService.getRouteOptions(
                         new RouteRequest(41.0850, 29.0450, 41.0820, 29.0500, TravelMode.WALKING)));
 
-        // The Ramp-Assisted Route should still be present (from the direct wheelchair candidate),
+        // The Wheelchair Route should still be present (from the direct wheelchair candidate),
         // proving the multi-leg candidate was dropped silently rather than crashing the request.
         boolean hasRampAssistedRoute = routes.stream()
-                .anyMatch(r -> "Ramp-Assisted Route".equals(r.getRouteLabel()));
+                .anyMatch(r -> "Wheelchair Route".equals(r.getRouteLabel()));
         assertTrue(hasRampAssistedRoute,
-                "Direct wheelchair Ramp-Assisted Route should remain when leg 2 fails. Routes: " + routes);
+                "Direct wheelchair Wheelchair Route should remain when leg 2 fails. Routes: " + routes);
     }
 }


### PR DESCRIPTION
# 📝 Fix Routing UX: Constraints, Profiles, and ORS Preference

Fixes #544

Four related fixes to the routing API surface, layered as four commits:

## 1. `fix: extend null-constraints opt-out to any empty constraint set`
Original scope of #544 — a signed-in user who explicitly opts out of obstacle avoidance shouldn't be treated as the anonymous baseline. Generalises the three-state contract: a `RoutingPreset.NONE` user, a CUSTOM-preset user with zero rules, and any other authed user whose stored constraint set is empty all produce `constraints = null` (skip avoidance entirely). Anonymous callers still pass `Set.of()` and get the defensive baseline.

## 2. `fix: use ORS shortest preference for pedestrian routing`
ORS's `recommended` preference biases foot-walking onto side streets in OSM-sparse areas. Concretely: on Nisbetiye Caddesi between Selçuklar and Akmerkez the route detoured 343 m through side streets when the direct sidewalk path is 208 m. `shortest` produces the natural human-intuitive route. Pinned by a new `OrsRoutingClientTest` case.

## 3. `feat: adapt routing alternative set to caller's preferred mode`
The old contract always returned three alternatives (Fastest + Accessible + Ramp-Assisted). Now:
- **Anonymous**: Fastest + walking Accessible + Wheelchair (3)
- **Authed non-wheelchair**: Fastest + walking Accessible (2)
- **Authed wheelchair**: Fastest + Accessible Route in WHEELCHAIR mode (2) — same wheelchair-routing + ramp-via-leg logic, just labeled "Accessible Route" because it IS that user's accessibility-aware alternative.

Anonymous callers go through the existing 1-arg overload; authed callers go through the 3-arg overload, which derives two booleans from `preferredMode` and dispatches to a private impl.

## 4. `refactor: rename "Ramp-Assisted Route" to "Wheelchair Route"`
`RouteService` internally picks the best of a direct wheelchair route and a multi-leg via mapped ramp — `"Ramp-Assisted Route"` was a misnomer when no nearby ramp existed. `"Wheelchair Route"` describes the alternative honestly. As a side effect this fixes a latent mismatch: the web `RoutePanel.jsx` polyline-color and the `Home.jsx` notice logic were both already keyed on `"Wheelchair Route"` and never fired against the old label.

# 📊 Type of Change
- [x] Bug fix (commits 1, 2)
- [x] New feature (commit 3 — preset-aware route set; minor response-shape change)
- [x] Refactor (commit 4 — label rename)

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully (`./mvnw clean verify`)
- [x] I have performed a self-review
- [x] Hard-to-understand bits are commented (three-state constraints contract, two-flag dispatch in `RouteService`)
- [x] Added/updated tests — 37 routing-area tests now pass:
  - `OrsRoutingClientTest` (8): added `fetchDirections_usesShortestPreference`
  - `RoutingPreferencesRouteIntegrationTest` (12): added 5 new tests covering NONE opt-out, CUSTOM-empty opt-out, anonymous 3-card set, wheelchair-mode Accessible, walking/no-preference drops Wheelchair
  - `RouteServiceTest`, `RouteControllerTest`, `ObstacleServiceTest` updated for label rename
- [x] Manual end-to-end check against the local docker stack: anonymous → 3 cards, authed walking → 2 cards, authed wheelchair → 2 cards with WHEELCHAIR-mode Accessible Route

# ⚠️ Minor API Contract Change
Response array length is now 1–3 (was always 3). Frontend already iterates over the array dynamically, so no breaking changes — verified that `Home.jsx` / `RoutePanel.jsx` render correctly for all three caller types.

# 📸 Screenshots / Recordings
N/A — backend changes verified via curl against running stack.

# ⏱️ Estimated Review Time
- [x] 15-30 min (four logical commits, but each is reviewable independently)