### PR TITLE
[Web] Translate password rule labels on signup (closes #546)

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -500,6 +500,28 @@
       "tip": "Once five neighbours agree, your report becomes verified and starts shaping accessible routes for everyone."
     }
   },
+  "passwordRules": {
+    "length": {
+      "label": "At least 8 characters",
+      "message": "Password must be at least 8 characters long."
+    },
+    "uppercase": {
+      "label": "At least one uppercase letter",
+      "message": "Password must contain at least one uppercase letter."
+    },
+    "lowercase": {
+      "label": "At least one lowercase letter",
+      "message": "Password must contain at least one lowercase letter."
+    },
+    "digit": {
+      "label": "At least one number",
+      "message": "Password must contain at least one number."
+    },
+    "special": {
+      "label": "At least one special character ({{chars}})",
+      "message": "Password must contain at least one special character ({{chars}})."
+    }
+  },
   "auth": {
     "login": {
       "heroHeadline": "Empowering mobility for every neighbour.",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -499,6 +499,28 @@
       "tip": "Beş komşu onayladığında raporun doğrulanmış olur ve herkes için erişilebilir rotalar şekillenmeye başlar."
     }
   },
+  "passwordRules": {
+    "length": {
+      "label": "En az 8 karakter",
+      "message": "Şifre en az 8 karakter olmalı."
+    },
+    "uppercase": {
+      "label": "En az bir büyük harf",
+      "message": "Şifre en az bir büyük harf içermeli."
+    },
+    "lowercase": {
+      "label": "En az bir küçük harf",
+      "message": "Şifre en az bir küçük harf içermeli."
+    },
+    "digit": {
+      "label": "En az bir rakam",
+      "message": "Şifre en az bir rakam içermeli."
+    },
+    "special": {
+      "label": "En az bir özel karakter ({{chars}})",
+      "message": "Şifre en az bir özel karakter ({{chars}}) içermeli."
+    }
+  },
   "auth": {
     "login": {
       "heroHeadline": "Her komşu için hareket özgürlüğü.",

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -6,7 +6,7 @@ import AuthFooter from '../components/AuthFooter.jsx'
 import SocialAuthButtons from '../components/SocialAuthButtons.jsx'
 import { registerUser, loginUser } from '../services/authService.js'
 import { useAuth } from '../context/AuthContext.jsx'
-import { validatePassword } from '../utils/passwordValidation.js'
+import { SPECIAL_CHARS, validatePassword } from '../utils/passwordValidation.js'
 
 function Signup() {
   const { t } = useTranslation()
@@ -187,15 +187,19 @@ function Signup() {
                       // submit (passwordTouched). While they're still working
                       // on the form, unmet rules stay grey — passed rules
                       // turn green in real time.
-                      // Note: rule labels/messages remain in English (see
-                      // passwordValidation.js) — pulling them through i18n is
-                      // a follow-up so the util stays free of React context.
+                      // Labels and long-form messages come from i18n
+                      // (`passwordRules.<id>.label/.message`) so the checklist
+                      // follows the active language.
                       const showFailure = passwordTouched && !rule.passed
                       const colorClass = rule.passed
                         ? 'text-[#176a21]'
                         : showFailure
                           ? 'text-red-600'
                           : 'text-[#767777]'
+                      const ruleText = t(
+                        `passwordRules.${rule.id}.${showFailure ? 'message' : 'label'}`,
+                        { chars: SPECIAL_CHARS },
+                      )
                       return (
                         <li
                           key={rule.id}
@@ -204,7 +208,7 @@ function Signup() {
                           className={`flex items-center gap-2 ${colorClass}`}
                         >
                           <span aria-hidden="true">{rule.passed ? '✓' : '•'}</span>
-                          <span>{showFailure ? rule.message : rule.label}</span>
+                          <span>{ruleText}</span>
                         </li>
                       )
                     })}

--- a/frontend/src/utils/passwordValidation.js
+++ b/frontend/src/utils/passwordValidation.js
@@ -1,37 +1,20 @@
 // Client-side password rules mirror the backend regex in
 // RegisteredUserService.java: minimum 8 chars, and at least one uppercase,
 // lowercase, digit, and special char from @#$%^&+=!
+//
+// Labels and messages live in the locale JSON under `passwordRules.<id>.*`
+// and are resolved by Signup at render time so the checklist follows the
+// active language (issue #546). The util stays pure — no React imports —
+// so it can be reused outside React (tests, backend mirror checks, etc.).
 export const SPECIAL_CHARS = '@#$%^&+=!'
 
 export const PASSWORD_RULES = [
-  {
-    id: 'length',
-    label: 'At least 8 characters',
-    message: 'Password must be at least 8 characters long.',
-    test: (v) => v.length >= 8,
-  },
-  {
-    id: 'uppercase',
-    label: 'At least one uppercase letter',
-    message: 'Password must contain at least one uppercase letter.',
-    test: (v) => /[A-Z]/.test(v),
-  },
-  {
-    id: 'lowercase',
-    label: 'At least one lowercase letter',
-    message: 'Password must contain at least one lowercase letter.',
-    test: (v) => /[a-z]/.test(v),
-  },
-  {
-    id: 'digit',
-    label: 'At least one number',
-    message: 'Password must contain at least one number.',
-    test: (v) => /[0-9]/.test(v),
-  },
+  { id: 'length',    test: (v) => v.length >= 8 },
+  { id: 'uppercase', test: (v) => /[A-Z]/.test(v) },
+  { id: 'lowercase', test: (v) => /[a-z]/.test(v) },
+  { id: 'digit',     test: (v) => /[0-9]/.test(v) },
   {
     id: 'special',
-    label: `At least one special character (${SPECIAL_CHARS})`,
-    message: `Password must contain at least one special character (${SPECIAL_CHARS}).`,
     test: (v) => new RegExp(`[${SPECIAL_CHARS.replace(/[-\\^\]]/g, '\\$&')}]`).test(v),
   },
 ]
@@ -39,8 +22,6 @@ export const PASSWORD_RULES = [
 export function validatePassword(value = '') {
   const results = PASSWORD_RULES.map((rule) => ({
     id: rule.id,
-    label: rule.label,
-    message: rule.message,
     passed: rule.test(value),
   }))
   return {

--- a/frontend/src/utils/passwordValidation.test.js
+++ b/frontend/src/utils/passwordValidation.test.js
@@ -14,7 +14,6 @@ describe('validatePassword', () => {
     const { results } = validatePassword('Aa1!')
     const length = results.find((r) => r.id === 'length')
     expect(length.passed).toBe(false)
-    expect(length.message).toMatch(/at least 8 characters/i)
   })
 
   it('reports uppercase failure when only lowercase', () => {
@@ -36,7 +35,6 @@ describe('validatePassword', () => {
     const { results } = validatePassword('Abcdefg1')
     const special = results.find((r) => r.id === 'special')
     expect(special.passed).toBe(false)
-    expect(special.message).toMatch(/special character/i)
   })
 
   it('passes for a strong password meeting all rules', () => {


### PR DESCRIPTION
## 📝 Description
Closes #546. Follow-up to #292 —> stacked on #534.

The 5 password rules in `passwordValidation.js` were the last English strings on the signup page. The util held them as literals because pulling them through i18n there would have coupled a pure helper to React context.

This PR moves the strings out of the util into `passwordRules.<id>.label` / `.message` in the locale JSON. `Signup.jsx` resolves them at render time via `t()`, passing `SPECIAL_CHARS` as an interpolation value so the literal list (`@#$%^&+=!`) still renders inside the translated label.

## 📊 Type of Change
- [x] New feature

## ✅ Acceptance Criteria
- [x] In TR mode, signup checklist shows Turkish labels (e.g. "En az 8 karakter")
- [x] Submitting an invalid password in TR mode shows the Turkish long-form messages
- [x] EN mode renders identically to before
- [x] `passwordValidation.js` has no React imports
- [x] All 321 frontend tests pass (two assertions on the old literal strings removed since labels no longer live in the util)

## 📸 Screenshots
<img width="1295" height="655" alt="Ekran Resmi 2026-05-11 00 10 50" src="https://github.com/user-attachments/assets/c291d7f4-e2f2-48ff-ab07-ed9b5eb4d354" />



## 🧪 How to Test
1. With #534's stack already deployed locally, open `/signup`.
2. Default (EN) — labels read "At least 8 characters", etc. Submit an empty password → long-form messages appear.
3. Click TR in the navbar → reload `/signup` or change to a Turkish viewer.
4. Same checklist now reads "En az 8 karakter", "En az bir büyük harf", and on submit "Şifre en az 8 karakter olmalı."

## ⏱️ Estimated Review Time
- [x] < 5 min