### PR TITLE
[Web] Translate FeedLocationPickerModal (closes #548)

### DIFF
--- a/frontend/src/components/FeedLocationPickerModal.jsx
+++ b/frontend/src/components/FeedLocationPickerModal.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react'
 import { MapContainer, TileLayer, Marker, Circle, useMap, useMapEvents } from 'react-leaflet'
 import L from 'leaflet'
+import { useTranslation } from 'react-i18next'
 import { feedFilterChipClass } from '../utils/feedFilterChip.js'
 import MapSearchBar from './MapSearchBar.jsx'
 
@@ -63,6 +64,7 @@ export default function FeedLocationPickerModal({
   onFeedCenterChange,
   onLocateUnavailable,
 }) {
+  const { t } = useTranslation()
   const wasOpenRef = useRef(false)
   const [bootCenter, setBootCenter] = useState(null)
   const [pin, setPin] = useState({
@@ -143,7 +145,7 @@ export default function FeedLocationPickerModal({
       className="fixed inset-0 z-[2000] flex flex-col bg-background"
       role="dialog"
       aria-modal="true"
-      aria-label="Choose reference location for community feed"
+      aria-label={t('feed.pickerAriaLabel')}
     >
       <header className="flex shrink-0 items-center justify-between gap-3 px-4 py-3 border-b border-outline-variant/30 bg-surface-container-lowest/95 backdrop-blur-md">
         <button
@@ -151,22 +153,22 @@ export default function FeedLocationPickerModal({
           onClick={onDismiss}
           className="px-4 py-2 rounded-xl font-semibold text-on-surface hover:bg-surface-container-high transition-colors"
         >
-          Cancel
+          {t('feed.pickerCancel')}
         </button>
         <p className="text-sm text-on-surface-variant text-center flex-1 hidden sm:block">
-          Search, tap the map, or use your location. The circle matches your search radius.
+          {t('feed.pickerHelp')}
         </p>
         <button
           type="button"
           onClick={onDismiss}
           className="px-5 py-2 rounded-xl font-semibold bg-primary text-on-primary shadow-sm hover:opacity-95 transition-opacity"
         >
-          Done
+          {t('feed.pickerDone')}
         </button>
       </header>
 
       <p className="sm:hidden px-4 py-2 text-xs text-on-surface-variant border-b border-outline-variant/20">
-        Search, tap the map, or use your location. The circle matches your search radius.
+        {t('feed.pickerHelp')}
       </p>
 
       <div className="flex-1 relative min-h-0">
@@ -211,7 +213,7 @@ export default function FeedLocationPickerModal({
             <span className="material-symbols-outlined text-lg" aria-hidden>
               my_location
             </span>
-            Use my location
+            {t('feed.pickerUseMyLocation')}
           </button>
         </div>
       </div>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -176,6 +176,11 @@
     "disagree": "Disagree",
     "filterReportTypeAria": "Report type: {{label}}",
     "filterEnvironmentAria": "Environment: {{label}}",
+    "pickerAriaLabel": "Choose reference location for community feed",
+    "pickerHelp": "Search, tap the map, or use your location. The circle matches your search radius.",
+    "pickerCancel": "Cancel",
+    "pickerDone": "Done",
+    "pickerUseMyLocation": "Use my location",
     "status": {
       "unverified": "Unverified",
       "verified": "Validated",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -176,6 +176,11 @@
     "disagree": "Katılmıyorum",
     "filterReportTypeAria": "Rapor türü: {{label}}",
     "filterEnvironmentAria": "Ortam: {{label}}",
+    "pickerAriaLabel": "Topluluk akışı için referans konum seç",
+    "pickerHelp": "Ara, haritaya dokun veya konumunu kullan. Daire arama yarıçapınla eşleşir.",
+    "pickerCancel": "İptal",
+    "pickerDone": "Tamam",
+    "pickerUseMyLocation": "Konumumu kullan",
     "status": {
       "unverified": "Doğrulanmadı",
       "verified": "Doğrulandı",


### PR DESCRIPTION
## 📝 Description
Closes #548. Follow-up to #292 — stacked on #534.

Sweeps the remaining English strings from `FeedLocationPickerModal.jsx`: the dialog aria-label, Cancel / Done buttons, the helper sentence (shown in two places , desktop header and mobile sub-header), and the "Use my location" button. New keys live under `feed.picker*` so they sit next to the existing Feed translations.

Nominatim search suggestions remain untranslated by design , they're upstream content.

## 📊 Type of Change
- [x] New feature

## ✅ Acceptance Criteria
- [x] In TR mode, every visible string inside the picker modal renders in Turkish
- [x] EN mode is identical to before
- [x] Suggestion list still shows Nominatim's raw `display_name`
- [x] All 321 frontend tests pass

## 🧪 How to Test
1. With the stacked branch deployed, open the Feed page.
2. Click "Haritadan seç" / "Choose on map" , picker modal opens.
3. Verify modal header + helper + buttons follow the active language.
4. Click "Konumumu kullan" / "Use my location" , error toast text comes from Feed's existing translated `locateFailedPickOnMap` key.

## 📸 Screenshots
**TR mode** — same modal, fully Turkified ("İptal", "Tamam", "Konumumu kullan", helper sentence in Turkish):
<img width="1308" height="693" alt="Ekran Resmi 2026-05-11 00 25 01" src="https://github.com/user-attachments/assets/44b6dcb5-f738-42b2-910a-48d6d2103d37" />


## ⏱️ Estimated Review Time
- [x] < 5 min