### PR TITLE
[Web] Slide Through Multi-Media When a Video Is Present and Open Media in a Centered Lightbox

### DIFF
--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import {
@@ -36,73 +37,226 @@ function isVideoUrl(url) {
   return VIDEO_EXTENSIONS.some((ext) => path.endsWith(ext))
 }
 
-function ImageCarousel({ allImages, title }) {
-  const [currentIndex, setCurrentIndex] = useState(0)
+// Centered fullscreen viewer for a single media URL or a list. Closes on
+// Escape, backdrop click, or the X button. ArrowLeft/ArrowRight navigate
+// when there is more than one item. Portaled to <body> so the panel's
+// pointer-events-none wrapper doesn't swallow clicks.
+function MediaLightbox({ items, startIndex = 0, title, onClose }) {
+  const [index, setIndex] = useState(startIndex)
 
-  if (!allImages || allImages.length === 0) {
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === 'Escape') onClose()
+      else if (e.key === 'ArrowLeft' && items.length > 1) {
+        setIndex((i) => (i === 0 ? items.length - 1 : i - 1))
+      } else if (e.key === 'ArrowRight' && items.length > 1) {
+        setIndex((i) => (i === items.length - 1 ? 0 : i + 1))
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [items.length, onClose])
+
+  if (!items || items.length === 0) return null
+  if (typeof document === 'undefined') return null
+
+  const current = items[index]
+  const isVideo = isVideoUrl(current)
+
+  function handleBackdrop(e) {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title ? `${title} media viewer` : 'Media viewer'}
+      onClick={handleBackdrop}
+      className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/85 backdrop-blur-sm p-4"
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close viewer"
+        className="absolute top-4 right-4 w-11 h-11 rounded-full bg-white/10 hover:bg-white/20 text-white flex items-center justify-center transition cursor-pointer"
+      >
+        <span className="material-symbols-outlined">close</span>
+      </button>
+
+      {items.length > 1 && (
+        <div className="absolute top-5 left-1/2 -translate-x-1/2 px-3 py-1.5 rounded-full bg-white/10 text-white text-xs font-semibold tracking-wide">
+          {index + 1} / {items.length}
+        </div>
+      )}
+
+      {items.length > 1 && (
+        <>
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setIndex((i) => (i === 0 ? items.length - 1 : i - 1)) }}
+            aria-label="Previous"
+            className="absolute left-4 top-1/2 -translate-y-1/2 w-12 h-12 rounded-full bg-white/10 hover:bg-white/20 text-white flex items-center justify-center transition cursor-pointer"
+          >
+            <span className="material-symbols-outlined text-2xl">chevron_left</span>
+          </button>
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setIndex((i) => (i === items.length - 1 ? 0 : i + 1)) }}
+            aria-label="Next"
+            className="absolute right-4 top-1/2 -translate-y-1/2 w-12 h-12 rounded-full bg-white/10 hover:bg-white/20 text-white flex items-center justify-center transition cursor-pointer"
+          >
+            <span className="material-symbols-outlined text-2xl">chevron_right</span>
+          </button>
+        </>
+      )}
+
+      <div
+        className="max-w-[90vw] max-h-[85vh] flex items-center justify-center"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {isVideo ? (
+          <video
+            key={current}
+            src={current}
+            controls
+            autoPlay
+            playsInline
+            className="max-w-[90vw] max-h-[85vh] rounded-lg bg-black"
+          />
+        ) : (
+          <img
+            src={current}
+            alt={title ? `${title} - Photo ${index + 1}` : `Photo ${index + 1}`}
+            className="max-w-[90vw] max-h-[85vh] object-contain rounded-lg"
+          />
+        )}
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+// Unified slider for any mix of images and videos. Each slide renders an
+// <img> or <video> based on the URL — a video in any slot no longer blocks
+// navigation to the next item (the previous implementation rendered a bare
+// <video> and dropped the carousel entirely when slot 0 was a video).
+// Click an image (or the expand button on a video) to open MediaLightbox.
+function MediaCarousel({ items, title, heightClass = 'h-64' }) {
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [lightboxOpen, setLightboxOpen] = useState(false)
+
+  if (!items || items.length === 0) {
     return (
-      <div className="w-full h-64 bg-surface-container rounded-xl shadow-sm flex items-center justify-center border border-outline-variant/10">
+      <div className={`w-full ${heightClass} bg-surface-container rounded-xl shadow-sm flex items-center justify-center border border-outline-variant/10`}>
         <span className="material-symbols-outlined text-6xl text-outline-variant">image</span>
       </div>
     )
   }
 
+  const safeIndex = Math.min(currentIndex, items.length - 1)
+  const current = items[safeIndex]
+  const isVideo = isVideoUrl(current)
+
   const handlePrev = (e) => {
     e.stopPropagation()
-    setCurrentIndex((prev) => (prev === 0 ? allImages.length - 1 : prev - 1))
+    setCurrentIndex((prev) => (prev === 0 ? items.length - 1 : prev - 1))
   }
 
   const handleNext = (e) => {
     e.stopPropagation()
-    setCurrentIndex((prev) => (prev === allImages.length - 1 ? 0 : prev + 1))
+    setCurrentIndex((prev) => (prev === items.length - 1 ? 0 : prev + 1))
   }
 
   return (
-    <div className="relative w-full h-64 rounded-xl shadow-sm border border-outline-variant/10 overflow-hidden group bg-black/5">
-      <img
-        src={allImages[currentIndex]}
-        alt={`${title} - Photo ${currentIndex + 1}`}
-        className="w-full h-full object-cover transition-opacity duration-300"
-      />
-
-      {/* Navigation Arrows */}
-      {allImages.length > 1 && (
-        <>
+    <>
+      <div className={`relative w-full ${heightClass} rounded-xl shadow-sm border border-outline-variant/10 overflow-hidden group bg-black/5`}>
+        {isVideo ? (
+          <>
+            {/* keyed by URL so React tears down the previous <video> when
+              the user navigates between slides — otherwise the element
+              keeps the old src queued and playback flickers. */}
+            <video
+              key={current}
+              src={current}
+              controls
+              playsInline
+              className="w-full h-full object-cover bg-black"
+            />
+            {/* Native video controls live at the bottom edge, so the
+              expand affordance sits top-right out of the way. */}
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); setLightboxOpen(true) }}
+              aria-label="Open in viewer"
+              className="absolute top-2 right-2 w-9 h-9 rounded-full bg-black/50 hover:bg-black/70 text-white flex items-center justify-center backdrop-blur-sm cursor-pointer z-10"
+            >
+              <span className="material-symbols-outlined text-lg">open_in_full</span>
+            </button>
+          </>
+        ) : (
           <button
-            onClick={handlePrev}
-            className="absolute left-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-black/40 text-white flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity backdrop-blur-sm hover:bg-black/60"
-            aria-label="Previous image"
+            type="button"
+            onClick={() => setLightboxOpen(true)}
+            aria-label={`Open ${title ? title + ' ' : ''}photo ${safeIndex + 1} in viewer`}
+            className="block w-full h-full cursor-zoom-in"
           >
-            <span className="material-symbols-outlined text-xl">chevron_left</span>
+            <img
+              src={current}
+              alt={`${title} - Photo ${safeIndex + 1}`}
+              className="w-full h-full object-cover transition-opacity duration-300"
+            />
           </button>
-          
-          <button
-            onClick={handleNext}
-            className="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-black/40 text-white flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity backdrop-blur-sm hover:bg-black/60"
-            aria-label="Next image"
-          >
-            <span className="material-symbols-outlined text-xl">chevron_right</span>
-          </button>
+        )}
 
-          {/* Dots Indicator */}
-          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5 px-2 py-1 rounded-full bg-black/20 backdrop-blur-sm">
-            {allImages.map((_, i) => (
-              <button
-                key={i}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  setCurrentIndex(i)
-                }}
-                className={`w-1.5 h-1.5 rounded-full transition-all ${
-                  currentIndex === i ? 'bg-white w-3' : 'bg-white/50 hover:bg-white/80'
-                }`}
-                aria-label={`Go to image ${i + 1}`}
-              />
-            ))}
-          </div>
-        </>
+        {items.length > 1 && (
+          <>
+            {/* Always visible — the previous hover-only treatment hid the
+              arrows on touch and was easy to miss with a mouse too. */}
+            <button
+              onClick={handlePrev}
+              className="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/55 hover:bg-black/75 text-white flex items-center justify-center backdrop-blur-sm transition-colors z-10 shadow-md"
+              aria-label="Previous"
+            >
+              <span className="material-symbols-outlined text-xl">chevron_left</span>
+            </button>
+
+            <button
+              onClick={handleNext}
+              className="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/55 hover:bg-black/75 text-white flex items-center justify-center backdrop-blur-sm transition-colors z-10 shadow-md"
+              aria-label="Next"
+            >
+              <span className="material-symbols-outlined text-xl">chevron_right</span>
+            </button>
+
+            <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5 px-2 py-1 rounded-full bg-black/20 backdrop-blur-sm z-10">
+              {items.map((_, i) => (
+                <button
+                  key={i}
+                  onClick={(e) => { e.stopPropagation(); setCurrentIndex(i) }}
+                  className={`w-1.5 h-1.5 rounded-full transition-all ${safeIndex === i ? 'bg-white w-3' : 'bg-white/50 hover:bg-white/80'}`}
+                  aria-label={`Go to media ${i + 1}`}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+
+      {lightboxOpen && (
+        <MediaLightbox
+          items={items}
+          startIndex={safeIndex}
+          title={title}
+          onClose={() => setLightboxOpen(false)}
+        />
       )}
-    </div>
+    </>
   )
 }
 
@@ -500,20 +654,11 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
                 </div>
                 <div className="bg-white p-5 flex flex-col gap-4">
                   {activeFix.mediaUrls && activeFix.mediaUrls.length > 0 && (
-                    isVideoUrl(activeFix.mediaUrls[0]) ? (
-                      <video
-                        src={activeFix.mediaUrls[0]}
-                        controls
-                        playsInline
-                        className="w-full max-h-56 object-cover rounded-lg bg-black"
-                      />
-                    ) : (
-                      <img
-                        src={activeFix.mediaUrls[0]}
-                        alt="Proposed fix"
-                        className="w-full max-h-56 object-cover rounded-lg"
-                      />
-                    )
+                    <MediaCarousel
+                      items={activeFix.mediaUrls}
+                      title="Proposed fix"
+                      heightClass="h-56"
+                    />
                   )}
                   <div className="flex items-center gap-2 text-xs">
                     <div className="w-7 h-7 rounded-full bg-surface-container-high flex items-center justify-center">
@@ -591,21 +736,7 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
               const allMedia = report.media?.length > 0
                 ? report.media.map(m => m.url || m)
                 : (report.mediaUrls?.length > 0 ? report.mediaUrls : (report.image ? [report.image] : []))
-              // If the first attachment is a video, render it directly with
-              // <video> so MP4/MOV play inline. Otherwise use the multi-image
-              // carousel. Mixed lists fall through to image-only carousel —
-              // good enough for now since the upload UI accepts one file.
-              if (allMedia.length > 0 && isVideoUrl(allMedia[0])) {
-                return (
-                  <video
-                    className="w-full h-64 object-cover rounded-xl shadow-sm bg-black"
-                    src={allMedia[0]}
-                    controls
-                    playsInline
-                  />
-                )
-              }
-              return <ImageCarousel allImages={allMedia} title={report.title} />
+              return <MediaCarousel items={allMedia} title={report.title} />
             })()}
           </div>
 

--- a/frontend/src/components/ReportPanel.test.jsx
+++ b/frontend/src/components/ReportPanel.test.jsx
@@ -474,5 +474,38 @@ describe('ReportPanel', () => {
       })
       expect(container.querySelector('video')).toBeTruthy()
     })
+
+    test('renders prev/next/dot controls when the report has multiple images via mediaUrls', () => {
+      renderPanel({
+        report: {
+          ...report,
+          mediaUrls: [
+            'https://cdn.example.com/a.jpg',
+            'https://cdn.example.com/b.jpg',
+            'https://cdn.example.com/c.jpg',
+          ],
+        },
+      })
+      expect(screen.getByLabelText('Previous')).toBeInTheDocument()
+      expect(screen.getByLabelText('Next')).toBeInTheDocument()
+      expect(screen.getByLabelText('Go to media 1')).toBeInTheDocument()
+      expect(screen.getByLabelText('Go to media 3')).toBeInTheDocument()
+    })
+
+    test('renders prev/next/dot controls when the report has multiple media via report.media (post-upload shape)', () => {
+      renderPanel({
+        report: {
+          ...report,
+          media: [
+            { id: 1, url: 'https://cdn.example.com/a.jpg' },
+            { id: 2, url: 'https://cdn.example.com/b.jpg' },
+          ],
+        },
+      })
+      expect(screen.getByLabelText('Previous')).toBeInTheDocument()
+      expect(screen.getByLabelText('Next')).toBeInTheDocument()
+      expect(screen.getByLabelText('Go to media 1')).toBeInTheDocument()
+      expect(screen.getByLabelText('Go to media 2')).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
# 📝 Description
Fixes #554

The report panel's `ImageCarousel` collapsed to a single `<video>` and dropped its prev/next/dot controls whenever the report's media list contained a video, so users could not reach the other attached images. There was also no way to view media at full size.

This PR replaces it with a unified `MediaCarousel` that renders `<img>` or `<video>` per slide, keeps the carousel controls live regardless of slide type, and adds a portaled `MediaLightbox` opened by clicking a slide (or the expand affordance on a video). The same component is now used by the active fix card.

# 📊 Type of Change
- [x] Bug fix
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed (346/346 frontend, including 2 new multi-image carousel cases)

# 📸 Screenshots / Recordings

<img width="1587" height="877" alt="PR0555_003" src="https://github.com/user-attachments/assets/bd1445fa-b56f-4c05-bac5-3c7159b052ba" />
<img width="1657" height="776" alt="PR0555_001" src="https://github.com/user-attachments/assets/57117da0-4bb7-42b6-ad1c-c5e3d0e3f0f0" />


<img width="1736" height="851" alt="PR0555_002" src="https://github.com/user-attachments/assets/84f7c3c2-7952-4f80-be13-4eef5bca9aa4" />


# ⏱️ Estimated Review Time
- [x] 5-15 min