### PR TITLE
[Web] Translate last hardcoded toast message (closes #557)

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -49,7 +49,8 @@
     "issuesHiddenOther": "{{count}} issues hidden",
     "pinDropHint": "Click on the map to set report location",
     "routeStartHint": "Click on the map to set your starting point",
-    "routeDestHint": "Now click your destination"
+    "routeDestHint": "Now click your destination",
+    "reportSubmittedToast": "Report submitted successfully!"
   },
   "createReport": {
     "title": "New Report",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -49,7 +49,8 @@
     "issuesHiddenOther": "{{count}} sorun gizli",
     "pinDropHint": "Rapor konumu için haritaya tıkla",
     "routeStartHint": "Başlangıç noktası için haritaya tıkla",
-    "routeDestHint": "Şimdi varış noktanı seç"
+    "routeDestHint": "Şimdi varış noktanı seç",
+    "reportSubmittedToast": "Rapor başarıyla gönderildi!"
   },
   "createReport": {
     "title": "Yeni Rapor",

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -758,7 +758,7 @@ function Home() {
             queryClient.invalidateQueries({ queryKey: reportKeys.lists() })
             setNewReportPin(null)
             setNewReportPinLabel('')
-            setToast({ message: 'Report submitted successfully!', type: 'success' })
+            setToast({ message: t('home.reportSubmittedToast'), type: 'success' })
           }}
           onError={(message) => setToast({ message, type: 'error' })}
         />


### PR DESCRIPTION
## 📝 Description
Closes #557. Follow-up to #292 ,stacked on #534.

Swept every `showToast` / `setToast` call site for English literals. Only one was left: `Home.jsx:761` raised `'Report submitted successfully!'` on a successful create-report. Added `home.reportSubmittedToast` to both locales and swapped the literal for a `t()` call.

Verified post-fix: `grep -rn "showToast\|setToast" frontend/src` finds no message strings that aren't already routed through `t(...)`.

## 📊 Type of Change
- [x] Bug fix
- [x] New feature

## ✅ Acceptance Criteria
- [x] `grep -rn "showToast\|setToast" frontend/src` shows no English literals
- [x] EN behaviour identical to before
- [x] TR mode: submitting a report shows "Rapor başarıyla gönderildi!"
- [x] All 321 frontend tests pass

## 📸 Scree
<img width="1285" height="672" alt="Ekran Resmi 2026-05-11 01 00 26" src="https://github.com/user-attachments/assets/008ef9cd-697f-4e9d-93a8-29b1c55ebda2" />
nshots

## 🧪 How to Test
1. Log in, drop a pin, fill in the report panel, submit.
2. Toast appears in active language ("Rapor başarıyla gönderildi!" in TR, "Report submitted successfully!" in EN).

## ⏱️ Estimated Review Time
- [x] < 5 min