### PR TITLE
[Web] Send Accept-Language header so backend can localize errors (closes #562)

### DIFF
--- a/frontend/src/components/CreateReportPanel.jsx
+++ b/frontend/src/components/CreateReportPanel.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../context/AuthContext.jsx'
 import { createReport, mapReport } from '../services/reportService.js'
+import { currentLanguageTag } from '../services/api.js'
 import { OBJECT_TYPES, localizeObjectType } from '../utils/objectTypeConfig.js'
 import ObjectTutorialModal from './ObjectTutorialModal.jsx'
 
@@ -260,7 +261,7 @@ function CreateReportPanel({ position, positionLabel, onClose, onCreated, onErro
         imageFiles.forEach(file => formData.append('file', file))
         const mediaRes = await fetch(`${import.meta.env.VITE_API_URL}/api/reports/${created.reportId}/media`, {
           method: 'POST',
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: `Bearer ${token}`, 'Accept-Language': currentLanguageTag() },
           body: formData,
         })
         if (mediaRes.ok) {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -14,6 +14,7 @@ import Toast from '../components/Toast.jsx'
 import MapSearchBar from '../components/MapSearchBar.jsx'
 import OnboardingTutorial from '../components/OnboardingTutorial.jsx'
 import { useReports, reportKeys } from '../hooks/useReports.js'
+import { currentLanguageTag } from '../services/api.js'
 import { currentUserKey } from '../hooks/useCurrentUser.js'
 import MapFilters from '../components/MapFilters.jsx'
 import {
@@ -360,7 +361,7 @@ function Home() {
       // contribution stats only when a Bearer token is supplied (see
       // RouteController.java). Without this header, /profile's "Routes
       // planned" counter never increments for signed-in users.
-      const headers = { 'Content-Type': 'application/json' }
+      const headers = { 'Content-Type': 'application/json', 'Accept-Language': currentLanguageTag() }
       if (token) headers.Authorization = `Bearer ${token}`
       const res = await fetch(`${import.meta.env.VITE_API_URL}/api/routes`, {
         method: 'POST',

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,19 @@
+import i18n from '../i18n/index.js'
+
 const BASE_URL = import.meta.env.VITE_API_URL
 const API_KEY = import.meta.env.VITE_API_KEY
+
+/**
+ * Current UI language as a backend-friendly tag (`'en'` or `'tr'`). Backed by
+ * i18next's resolved language so it follows whatever the LanguageSwitcher
+ * last set. Used to populate `Accept-Language` on outgoing requests so the
+ * backend (#560) can localize error messages.
+ */
+export function currentLanguageTag() {
+  const lang = (i18n.resolvedLanguage || i18n.language || 'en').toLowerCase()
+  // Strip region (e.g. en-US → en). Backend's supported locales are en + tr.
+  return lang.split('-')[0]
+}
 
 function pickErrorMessage(payload, fallback) {
   if (payload == null || typeof payload !== 'object') return fallback
@@ -15,7 +29,11 @@ export async function apiFetch(path, options = {}) {
     throw new Error('API URL is not configured. Set VITE_API_URL (see .env.example).')
   }
 
-  const merged = { 'Mapcess-Key': API_KEY, ...headers }
+  const merged = {
+    'Mapcess-Key': API_KEY,
+    'Accept-Language': currentLanguageTag(),
+    ...headers,
+  }
   if (skipJsonContentType) {
     delete merged['Content-Type']
   } else if (!merged['Content-Type'] && rest.body != null && typeof rest.body === 'string') {

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -1,4 +1,4 @@
-import { apiFetch } from './api.js'
+import { apiFetch, currentLanguageTag } from './api.js'
 import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
 
 /**
@@ -64,6 +64,7 @@ export async function submitFixRequest(reportId, file, description, token) {
       headers: {
         Authorization: `Bearer ${token}`,
         'Mapcess-Key': import.meta.env.VITE_API_KEY,
+        'Accept-Language': currentLanguageTag(),
       },
       body: formData,
     }

--- a/frontend/src/services/reportService.test.js
+++ b/frontend/src/services/reportService.test.js
@@ -9,7 +9,7 @@ import {
 } from './reportService.js'
 import { apiFetch } from './api.js'
 
-vi.mock('./api.js', () => ({ apiFetch: vi.fn() }))
+vi.mock('./api.js', () => ({ apiFetch: vi.fn(), currentLanguageTag: vi.fn(() => 'en') }))
 
 describe('reportService — fix request helpers', () => {
   beforeEach(() => {

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,4 +1,4 @@
-import { apiFetch } from './api.js'
+import { apiFetch, currentLanguageTag } from './api.js'
 
 function authHeaders(token) {
   return { Authorization: `Bearer ${token}` }
@@ -41,7 +41,7 @@ export async function uploadAvatar(id, file, token) {
 
   const res = await fetch(`${import.meta.env.VITE_API_URL}/api/users/${id}/profile/avatar`, {
     method: 'POST',
-    headers: authHeaders(token),
+    headers: { ...authHeaders(token), 'Accept-Language': currentLanguageTag() },
     body: formData,
   })
 

--- a/frontend/src/services/userService.test.js
+++ b/frontend/src/services/userService.test.js
@@ -1,7 +1,7 @@
 import { getCurrentUser, getUserById, searchUsers } from './userService.js'
 import { apiFetch } from './api.js'
 
-vi.mock('./api.js', () => ({ apiFetch: vi.fn() }))
+vi.mock('./api.js', () => ({ apiFetch: vi.fn(), currentLanguageTag: vi.fn(() => 'en') }))
 
 describe('userService', () => {
   beforeEach(() => vi.clearAllMocks())


### PR DESCRIPTION
## 📝 Description
Closes #562. Follow-up to #292 , stacked on #534.

#560 adds backend-side i18n keyed off `Accept-Language`. To make those localized messages actually visible, the frontend has to advertise the active language. This PR routes every outbound request's `Accept-Language` from i18next.

- New `currentLanguageTag()` helper in `services/api.js` reads `i18n.resolvedLanguage`, strips region (`en-US` → `en`), defaults to `en`.
- `apiFetch` includes `Accept-Language` in the merged headers (consumers can still override).
- Raw `fetch()` callsites (avatar upload, media upload, fix-request upload, routes POST) now add the same header inline.
- Tests: existing service mocks of `./api.js` extended to expose `currentLanguageTag` so they don't break with the new import.

Skipped: Nominatim search calls in `MapSearchBar` / `RoutePanel` , external service, not ours.

## 📊 Type of Change
- [x] New feature

## ✅ Acceptance Criteria
- [x] DevTools Network tab shows `Accept-Language: tr` on requests when TR is active, `en` when EN
- [x] After #560 merges: triggering a backend error in TR mode (e.g. signup with duplicate email) shows the Turkish message
- [x] EN mode is unchanged
- [x] All 321 frontend tests pass

## 🧪 How to Test
1. With this branch and #560's backend deployed, click TR in the navbar.
2. Open DevTools → Network.
3. Trigger any backend call (signup, view profile, vote on a report). Check the request headers , `Accept-Language: tr` is present.
4. Trigger an error in TR mode (e.g. signup with a duplicate email). The response body and the rendered toast/inline message are in Turkish.
5. Flip to EN, repeat , header is `en`, message is English.

## ⏱️ Estimated Review Time
- [x] < 5 min