### PR TITLE
[Backend] Implement Multiple Media Files when Editing Reports

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/MediaController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/MediaController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -66,7 +67,8 @@ public class MediaController {
     })
     public ResponseEntity<?> uploadMediaForReport(
             @PathVariable("id") Long reportId,
-            @RequestParam("file") MultipartFile[] files) {
+            @RequestParam("file") MultipartFile[] files,
+            @AuthenticationPrincipal String email) {
 
         if (files == null || files.length == 0) {
             return ResponseEntity.badRequest().body("No files provided.");
@@ -85,7 +87,7 @@ public class MediaController {
             }
 
             // 3. Link all uploaded files to the database
-            List<com.bounswe2026group1.backend.model.Media> savedMediaList = reportService.addMediaToReportBatch(reportId, uploadedUrls);
+            List<com.bounswe2026group1.backend.model.Media> savedMediaList = reportService.addMediaToReportBatch(reportId, uploadedUrls, email);
             
             // 4. Format the response as an array of objects [{ "id": 1, "url": "https..." }]
             List<Map<String, Object>> responseBody = new ArrayList<>();

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
@@ -56,6 +56,10 @@ public class ReportResponse {
             example = "2026-05-08T09:10:00Z", nullable = true)
     private Instant fixedAt;
 
+    @Schema(description = "Database IDs of the media files attached to the report.",
+            example = "[1, 2, 3]")
+    private List<Long> mediaIds;
+
     @Schema(description = "Public S3 URLs for any photos or videos attached to the report.",
             example = "[\"https://mapcess-prod.s3.amazonaws.com/reports/1024-1.jpg\"]")
     private List<String> mediaUrls;
@@ -125,6 +129,7 @@ public class ReportResponse {
         r.setDisagrees(report.getDisagrees());
         r.setPublishDate(report.getPublishDate());
         r.setFixedAt(report.getFixedAt());
+        r.setMediaIds(report.getMediaList().stream().map(Media::getId).toList());
         r.setMediaUrls(report.getMediaList().stream().map(Media::getFilePath).toList());
         r.setUserVote(userVote);
         r.setActiveFixRequest(activeFixRequest);

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -215,6 +215,12 @@ public class ReportService {
         RegisteredUser editor = registeredUserRepository.findByEmail(editorEmail)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
 
+        boolean isOwner = report.getCreatedBy().getId().equals(editor.getId());
+        boolean isAdmin = editor.getRole() == UserRole.ADMIN;
+        if (!isOwner && !isAdmin) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You are not the owner of this report");
+        }
+
         Map<String, Object[]> diff = new LinkedHashMap<>();
 
         if (request.getDescription() != null && !request.getDescription().equals(report.getDescription())) {
@@ -447,9 +453,17 @@ public class ReportService {
         return target;
     }
 
-    public Media addMediaToReport(Long reportId, String mediaUrl) {
+    public Media addMediaToReport(Long reportId, String mediaUrl, String email) {
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new NoSuchElementException("Report not found with id: " + reportId));
+
+        RegisteredUser requester = registeredUserRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
+        boolean isOwner = report.getCreatedBy().getId().equals(requester.getId());
+        boolean isAdmin = requester.getRole() == UserRole.ADMIN;
+        if (!isOwner && !isAdmin) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You are not the owner of this report");
+        }
         Media media = new Media();
         media.setReport(report);
         media.setFilePath(mediaUrl);
@@ -459,9 +473,17 @@ public class ReportService {
     }
 
     @Transactional
-    public List<Media> addMediaToReportBatch(Long reportId, List<String> mediaUrls) {
+    public List<Media> addMediaToReportBatch(Long reportId, List<String> mediaUrls, String email) {
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new NoSuchElementException("Report not found with id: " + reportId));
+
+        RegisteredUser requester = registeredUserRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
+        boolean isOwner = report.getCreatedBy().getId().equals(requester.getId());
+        boolean isAdmin = requester.getRole() == UserRole.ADMIN;
+        if (!isOwner && !isAdmin) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You are not the owner of this report");
+        }
         List<Media> savedMediaList = new ArrayList<>();
         for (String mediaUrl : mediaUrls) {
             Media media = new Media();

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/MediaControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/MediaControllerTest.java
@@ -55,7 +55,7 @@ class MediaControllerTest {
                 "file", "photo.jpg", "image/jpeg", "fake-bytes".getBytes());
 
         when(s3MediaService.uploadFile(any())).thenReturn(RETURNED_URL);
-        when(reportService.addMediaToReportBatch(eq(1L), any()))
+        when(reportService.addMediaToReportBatch(eq(1L), any(), any()))
                 .thenReturn(java.util.List.of(stubMedia(10L, RETURNED_URL)));
 
         mockMvc.perform(multipart(UPLOAD_URL, 1L).file(file)
@@ -73,7 +73,7 @@ class MediaControllerTest {
         String expectedUrl = "https://bucket.s3.amazonaws.com/some-uuid_pic.png";
 
         when(s3MediaService.uploadFile(any())).thenReturn(expectedUrl);
-        when(reportService.addMediaToReportBatch(eq(5L), any()))
+        when(reportService.addMediaToReportBatch(eq(5L), any(), any()))
                 .thenReturn(java.util.List.of(stubMedia(20L, expectedUrl)));
 
         mockMvc.perform(multipart(UPLOAD_URL, 5L).file(file)
@@ -90,14 +90,14 @@ class MediaControllerTest {
                 "file", "photo.jpg", "image/jpeg", "bytes".getBytes());
 
         when(s3MediaService.uploadFile(any())).thenReturn(RETURNED_URL);
-        when(reportService.addMediaToReportBatch(eq(42L), any()))
+        when(reportService.addMediaToReportBatch(eq(42L), any(), any()))
                 .thenReturn(java.util.List.of(stubMedia(30L, RETURNED_URL)));
 
         mockMvc.perform(multipart(UPLOAD_URL, 42L).file(file)
                         .header("Mapcess-Key", validApiKey))
                 .andExpect(status().isCreated());
 
-        verify(reportService, times(1)).addMediaToReportBatch(eq(42L), any());
+        verify(reportService, times(1)).addMediaToReportBatch(eq(42L), any(), any());
     }
 
     // ── 400 Bad Request ───────────────────────────────────────────────────────
@@ -134,7 +134,7 @@ class MediaControllerTest {
 
         when(s3MediaService.uploadFile(any())).thenReturn(RETURNED_URL);
         doThrow(new NoSuchElementException("Report not found with id: 99"))
-                .when(reportService).addMediaToReportBatch(eq(99L), any());
+                .when(reportService).addMediaToReportBatch(eq(99L), any(), any());
 
         mockMvc.perform(multipart(UPLOAD_URL, 99L).file(file)
                         .header("Mapcess-Key", validApiKey))

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -212,6 +212,24 @@ class ReportServiceTest {
     }
 
     @Test
+    void update_notOwner_throws403() {
+        RegisteredUser otherUser = new RegisteredUser();
+        otherUser.setId(2L);
+        otherUser.setEmail("other@test.com");
+
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("other@test.com")).thenReturn(Optional.of(otherUser));
+
+        UpdateReportRequest updateRequest = new UpdateReportRequest();
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> reportService.update(1L, updateRequest, "other@test.com"));
+
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+        verify(reportRepository, never()).save(any(Report.class));
+    }
+
+    @Test
     void update_withMediaIdsToRemove_deletesS3FilesAndRemovesFromList() {
         Media media = new Media();
         media.setFilePath("https://bucket.s3.amazonaws.com/file.jpg");
@@ -393,9 +411,10 @@ class ReportServiceTest {
     @Test
     void addMediaToReport_broadcastsMediaAdded() {
         when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("owner@test.com")).thenReturn(Optional.of(testUser));
         when(mediaRepository.save(any(Media.class))).thenAnswer(i -> i.getArguments()[0]);
 
-        reportService.addMediaToReport(1L, "https://cdn.example/media.jpg");
+        reportService.addMediaToReport(1L, "https://cdn.example/media.jpg", "owner@test.com");
 
         verify(mediaRepository).save(any(Media.class));
         verify(publicSseService).broadcastMediaAdded(eq(testReport), any(Media.class));


### PR DESCRIPTION
# 📝 Description
Fixes #559. This PR extends the report update functionality to support managing multiple media files and resolves critical authorization loopholes in the report lifecycle.

**Key Implementation Details:**
- **Authorization & Security:** Fixed a security bug where any authenticated user could edit any report or upload media to it. Added ownership checks to `ReportService` and `MediaController` to ensure only the report author or an admin can modify data.
- **Media Deletion:** Integrated the use of `mediaIdsToRemove` in the update payload. The backend correctly unlinks these records and triggers deletion from S3 storage via `S3MediaService` to prevent orphaned files.
- **Exposing Media IDs:** Updated `ReportResponse` to include a `mediaIds` field alongside `mediaUrls`. This allows the frontend to map thumbnails to their database IDs for targeted removal.
- **Media Addition:** Secured and verified the batch-upload endpoint (`POST /api/reports/{id}/media`) to support adding multiple new files during the report edit lifecycle.
- **Testing:** Updated `ReportServiceTest` and `MediaControllerTest` to cover the new method signatures and verify the 403 Forbidden scenarios.

# 📊 Type of Change
- [x] Bug fix (Security/Authorization)
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
 
# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
*N/A - Backend logic and API contract updates.*

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [x] 5-15 min
- [ ] > 15 min
