### PR TITLE
[Web] Translate remaining hardcoded strings (Route, Report, CreateFix, Preset editor, Routing prefs, Avatar) (closes #574)

### DIFF
--- a/frontend/src/components/AvatarUploader.jsx
+++ b/frontend/src/components/AvatarUploader.jsx
@@ -89,11 +89,11 @@ function AvatarUploader({ currentAvatarUrl, isUploading, isDeleting, onUpload, o
 
   async function handleDelete() {
     if (!currentAvatarUrl) return
-    if (!window.confirm('Remove your avatar?')) return
+    if (!window.confirm(t('avatar.removeConfirm'))) return
     try {
       await onDelete()
     } catch (e) {
-      setError(e.message || 'Failed to remove avatar.')
+      setError(e.message || t('avatar.removeFailed'))
     }
   }
 

--- a/frontend/src/components/AvatarUploader.jsx
+++ b/frontend/src/components/AvatarUploader.jsx
@@ -77,7 +77,7 @@ function AvatarUploader({ currentAvatarUrl, isUploading, isDeleting, onUpload, o
       setPendingFile(null)
       setPreviewUrl(null)
     } catch (e) {
-      setError(e.message || 'Failed to upload avatar.')
+      setError(e.message || t('avatar.uploadFailed'))
     }
   }
 

--- a/frontend/src/components/CustomPresetEditorModal.jsx
+++ b/frontend/src/components/CustomPresetEditorModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
 import {
   CONSTRAINT_OBJECT_TYPES,
@@ -64,6 +65,7 @@ function CustomPresetEditorModal({
   busy,
   errorMessage,
 }) {
+  const { t } = useTranslation()
   const isEdit = mode === 'edit'
   const closeButtonRef = useRef(null)
 
@@ -118,7 +120,7 @@ function CustomPresetEditorModal({
   async function handleSave() {
     setLocalError('')
     if (nameInvalid) {
-      setLocalError(`Name must be ${NAME_MIN}–${NAME_MAX} characters.`)
+      setLocalError(t('presetEditor.nameLengthError', { min: NAME_MIN, max: NAME_MAX }))
       return
     }
     try {
@@ -128,7 +130,7 @@ function CustomPresetEditorModal({
         preferredTravelMode: travelMode,
       })
     } catch (e) {
-      setLocalError(e.message || 'Failed to save.')
+      setLocalError(e.message || t('presetEditor.saveFailed'))
     }
   }
 
@@ -138,7 +140,7 @@ function CustomPresetEditorModal({
     try {
       await onDelete()
     } catch (e) {
-      setLocalError(e.message || 'Failed to delete.')
+      setLocalError(e.message || t('presetEditor.deleteFailed'))
     }
   }
 
@@ -172,25 +174,25 @@ function CustomPresetEditorModal({
         <div className="flex-1 overflow-y-auto p-5 flex flex-col gap-5">
           <div className="flex flex-col gap-1">
             <label htmlFor="preset-name" className="text-sm font-bold text-on-surface px-1">
-              Preset name
+              {t('presetEditor.presetName')}
             </label>
             <input
               id="preset-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               maxLength={NAME_MAX}
-              placeholder="e.g. Work commute"
+              placeholder={t('presetEditor.presetNamePlaceholder')}
               className="w-full px-4 py-2.5 bg-surface-container border-none rounded-xl focus:ring-2 focus:ring-primary/40"
             />
             <p className={`text-xs text-right ${nameInvalid ? 'text-error' : 'text-on-surface-variant'}`}>
               {trimmedName.length === 0
-                ? `Required (${NAME_MIN}–${NAME_MAX} characters)`
+                ? t('presetEditor.presetNameHelper', { min: NAME_MIN, max: NAME_MAX })
                 : `${trimmedName.length}/${NAME_MAX}`}
             </p>
           </div>
 
           <fieldset className="flex flex-col gap-2">
-            <legend className="text-sm font-bold text-on-surface px-1 mb-1">Travel mode</legend>
+            <legend className="text-sm font-bold text-on-surface px-1 mb-1">{t('presetEditor.travelMode')}</legend>
             <div className="flex gap-3 flex-wrap">
               {TRAVEL_MODES.map(tm => (
                 <label key={tm.value} className="inline-flex items-center gap-2 cursor-pointer">

--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 
 import {
   agreeReport,
@@ -709,7 +709,7 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
                       <span className="material-symbols-outlined text-on-surface-variant" style={{ fontSize: '14px' }}>person</span>
                     </div>
                     <p>
-                      <span className="font-bold text-on-surface">{activeFix.submittedByName || 'Anonymous'}</span>
+                      <span className="font-bold text-on-surface">{activeFix.submittedByName || t('report.anonymousAuthor')}</span>
                       <span className="text-on-surface-variant"> says this is fixed</span>
                     </p>
                   </div>
@@ -1111,12 +1111,15 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
                 </div>
               ) : (
                 <p className="text-sm text-on-surface-variant bg-surface-container-lowest p-4 rounded-xl border border-outline-variant/10">
-                  <a href="/login" className="font-bold text-primary hover:underline">Log in</a> to leave a comment.
+                  <Trans
+                    i18nKey="report.loginToComment"
+                    components={[<a key="login-link" href="/login" className="font-bold text-primary hover:underline" />]}
+                  />
                 </p>
               )}
 
               {commentsLoading ? (
-                <p className="text-sm text-on-surface-variant italic">Loading comments...</p>
+                <p className="text-sm text-on-surface-variant italic">{t('report.loadingComments')}</p>
               ) : comments.length === 0 ? (
                 <p className="text-sm text-on-surface-variant italic">{t('report.noCommentsYet')}</p>
               ) : (
@@ -1129,7 +1132,7 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
                       <div className="flex flex-col gap-1 flex-1">
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-2">
-                            <p className="text-sm font-bold text-on-surface">{comment.author?.name || 'Anonymous'}</p>
+                            <p className="text-sm font-bold text-on-surface">{comment.author?.name || t('report.anonymousAuthor')}</p>
                             <p className="text-xs text-outline">{formatDate(comment.createdAt)}</p>
                           </div>
                           {userId && comment.author?.id == userId && (

--- a/frontend/src/components/RoutePanel.jsx
+++ b/frontend/src/components/RoutePanel.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 
 /**
  * RoutePanel
@@ -39,6 +40,7 @@ function RoutePanel({
   onSelectRoute,
   onReset,
 }) {
+  const { t } = useTranslation()
   const [originQuery, setOriginQuery] = useState('')
   const [destQuery, setDestQuery] = useState('')
   const [originSuggestions, setOriginSuggestions] = useState([])
@@ -259,7 +261,7 @@ function RoutePanel({
                     type="text"
                     value={originQuery}
                     onChange={handleOriginChange}
-                    placeholder="Search or click map…"
+                    placeholder={t('routePanel.searchOrClickMap')}
                     className="w-full bg-transparent text-sm font-semibold text-on-surface placeholder:text-on-surface-variant/50 outline-none"
                   />
                 </div>
@@ -297,7 +299,7 @@ function RoutePanel({
                 <span className={`material-symbols-outlined text-sm ${userLocation ? 'text-primary' : 'text-on-surface-variant'}`}>my_location</span>
               </div>
               <span className={`text-sm font-semibold ${userLocation ? 'text-primary' : 'text-on-surface-variant'}`}>
-                {userLocation ? 'Use my current location' : 'Location not available'}
+                {userLocation ? t('routePanel.useMyCurrentLocation') : t('routePanel.locationNotAvailable')}
               </span>
             </button>
           )}
@@ -308,7 +310,7 @@ function RoutePanel({
               <button
                 onClick={onSwap}
                 className="w-8 h-8 rounded-full bg-surface-container border border-outline-variant/30 flex items-center justify-center hover:bg-primary/10 hover:text-primary hover:border-primary/30 transition-colors z-10"
-                aria-label="Swap origin and destination"
+                aria-label={t('routePanel.swapOriginDestination')}
               >
                 <span className="material-symbols-outlined text-sm">swap_vert</span>
               </button>
@@ -346,7 +348,7 @@ function RoutePanel({
                     type="text"
                     value={destQuery}
                     onChange={handleDestChange}
-                    placeholder={routeOrigin ? 'Search or click map…' : 'Set origin first'}
+                    placeholder={routeOrigin ? t('routePanel.searchOrClickMap') : t('routePanel.setOriginFirst')}
                     disabled={!routeOrigin}
                     className="w-full bg-transparent text-sm font-semibold text-on-surface placeholder:text-on-surface-variant/50 outline-none disabled:cursor-not-allowed"
                   />

--- a/frontend/src/components/RoutingPreferencesSection.jsx
+++ b/frontend/src/components/RoutingPreferencesSection.jsx
@@ -134,7 +134,7 @@ function RoutingPreferencesSection() {
   if (isPending) {
     return (
       <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6">
-        <p className="text-sm text-on-surface-variant">Loading routing preferences…</p>
+        <p className="text-sm text-on-surface-variant">{t('routing.loading')}</p>
       </section>
     )
   }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -426,7 +426,8 @@
     "dropToPreview": "Drop image to preview…",
     "hint": "JPEG or PNG, max 15 MB. You can also drag-and-drop into this box.",
     "removeConfirm": "Remove your avatar?",
-    "removeFailed": "Failed to remove avatar."
+    "removeFailed": "Failed to remove avatar.",
+    "uploadFailed": "Failed to upload avatar."
   },
   "routing": {
     "title": "Routing preferences",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -174,7 +174,32 @@
     "createFixRuleCopy": "Other users will vote on your fix. It confirms as Fixed when at least 5 people agree and consensus reaches 60% — then it auto-deletes after 7 days.",
     "createFixCancel": "Cancel",
     "createFixSubmit": "Submit Fix Report",
-    "createFixSubmitting": "Submitting…"
+    "createFixSubmitting": "Submitting…",
+    "loadingComments": "Loading comments...",
+    "loginToComment": "<0>Log in</0> to leave a comment.",
+    "anonymousAuthor": "Anonymous"
+  },
+  "routePanel": {
+    "searchOrClickMap": "Search or click map…",
+    "setOriginFirst": "Set origin first",
+    "useMyCurrentLocation": "Use my current location",
+    "locationNotAvailable": "Location not available",
+    "swapOriginDestination": "Swap origin and destination"
+  },
+  "createFix": {
+    "whatChanged": "What changed?",
+    "optional": "(optional)",
+    "descriptionPlaceholder": "A new ramp was installed last week.",
+    "helperText": "Other users will vote on your fix. It confirms as <1>Fixed</1> when at least 5 people agree <3>and</3> consensus reaches 60% — then it auto-deletes after 7 days."
+  },
+  "presetEditor": {
+    "nameLengthError": "Name must be {{min}}–{{max}} characters.",
+    "saveFailed": "Failed to save.",
+    "deleteFailed": "Failed to delete.",
+    "presetName": "Preset name",
+    "presetNamePlaceholder": "e.g. Work commute",
+    "presetNameHelper": "Required ({{min}}–{{max}} characters)",
+    "travelMode": "Travel mode"
   },
   "feed": {
     "title": "Community feed",
@@ -399,7 +424,9 @@
     "removing": "Removing…",
     "cancel": "Cancel",
     "dropToPreview": "Drop image to preview…",
-    "hint": "JPEG or PNG, max 15 MB. You can also drag-and-drop into this box."
+    "hint": "JPEG or PNG, max 15 MB. You can also drag-and-drop into this box.",
+    "removeConfirm": "Remove your avatar?",
+    "removeFailed": "Failed to remove avatar."
   },
   "routing": {
     "title": "Routing preferences",
@@ -408,6 +435,7 @@
     "active": "Active",
     "ruleOne": "{{count}} rule",
     "ruleOther": "{{count}} rules",
+    "loading": "Loading routing preferences…",
     "createCustom": "Create custom preset",
     "atCapTitle": "You can save at most {{max}} custom presets.",
     "saveFailed": "Failed to save preset.",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -426,7 +426,8 @@
     "dropToPreview": "Önizleme için bırak…",
     "hint": "JPEG veya PNG, en fazla 15 MB. Bu kutuya sürükleyip bırakabilirsin.",
     "removeConfirm": "Profil resminiz kaldırılsın mı?",
-    "removeFailed": "Profil resmi kaldırılamadı."
+    "removeFailed": "Profil resmi kaldırılamadı.",
+    "uploadFailed": "Profil resmi yüklenemedi."
   },
   "routing": {
     "title": "Rota tercihleri",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -174,7 +174,32 @@
     "createFixRuleCopy": "Diğer kullanıcılar düzeltmeni oylayacak. En az 5 kişi katılır ve uzlaşı %60'a ulaşırsa Düzeltildi olarak doğrulanır — sonra 7 gün içinde otomatik silinir.",
     "createFixCancel": "İptal",
     "createFixSubmit": "Düzeltme Raporunu Gönder",
-    "createFixSubmitting": "Gönderiliyor…"
+    "createFixSubmitting": "Gönderiliyor…",
+    "loadingComments": "Yorumlar yükleniyor...",
+    "loginToComment": "Yorum bırakmak için <0>giriş yapın</0>.",
+    "anonymousAuthor": "Anonim"
+  },
+  "routePanel": {
+    "searchOrClickMap": "Arayın veya haritaya tıklayın…",
+    "setOriginFirst": "Önce başlangıcı seçin",
+    "useMyCurrentLocation": "Mevcut konumumu kullan",
+    "locationNotAvailable": "Konum bilgisi yok",
+    "swapOriginDestination": "Başlangıç ve varışı değiştir"
+  },
+  "createFix": {
+    "whatChanged": "Ne değişti?",
+    "optional": "(isteğe bağlı)",
+    "descriptionPlaceholder": "Geçen hafta yeni bir rampa kuruldu.",
+    "helperText": "Diğer kullanıcılar düzeltmenize oy verecek. En az 5 kişi katıldığında <3>ve</3> mutabakat %60'a ulaştığında <1>Düzeltildi</1> olarak onaylanır — ardından 7 gün sonra otomatik silinir."
+  },
+  "presetEditor": {
+    "nameLengthError": "İsim {{min}}–{{max}} karakter olmalı.",
+    "saveFailed": "Kaydedilemedi.",
+    "deleteFailed": "Silinemedi.",
+    "presetName": "Hazır ayar adı",
+    "presetNamePlaceholder": "ör. İş yolu",
+    "presetNameHelper": "Zorunlu ({{min}}–{{max}} karakter)",
+    "travelMode": "Ulaşım modu"
   },
   "feed": {
     "title": "Topluluk akışı",
@@ -399,7 +424,9 @@
     "removing": "Kaldırılıyor…",
     "cancel": "İptal",
     "dropToPreview": "Önizleme için bırak…",
-    "hint": "JPEG veya PNG, en fazla 15 MB. Bu kutuya sürükleyip bırakabilirsin."
+    "hint": "JPEG veya PNG, en fazla 15 MB. Bu kutuya sürükleyip bırakabilirsin.",
+    "removeConfirm": "Profil resminiz kaldırılsın mı?",
+    "removeFailed": "Profil resmi kaldırılamadı."
   },
   "routing": {
     "title": "Rota tercihleri",
@@ -408,6 +435,7 @@
     "active": "Aktif",
     "ruleOne": "{{count}} kural",
     "ruleOther": "{{count}} kural",
+    "loading": "Rota tercihleri yükleniyor…",
     "createCustom": "Özel hazır ayar oluştur",
     "atCapTitle": "En fazla {{max}} özel hazır ayar kaydedebilirsin.",
     "saveFailed": "Hazır ayar kaydedilemedi.",


### PR DESCRIPTION
## 📝 Description
Closes #574. Wraps the ~22 hardcoded strings the audit flagged in `t()` and adds matching EN/TR entries.

Surfaces touched:
- RoutePanel -> search placeholders, swap aria, use-my-location states
- ReportPanel -> comments login prompt (Trans for inline link), loading text, anonymous author (×2)
- CreateFixRequestPanel -> section label, description placeholder, helper text (Trans for inline `<strong>`)
- CustomPresetEditorModal -> preset name, placeholder, helper, travel mode legend, save/delete failure fallbacks
- RoutingPreferencesSection -> loading state
- AvatarUploader -> remove confirm + error fallback

## 📊 Type
i18n

## ✅ Acceptance Criteria
- [x] All 22 audited strings now go through `t()`
- [x] EN + TR locale entries added; no untranslated TR keys
- [x] `npm run test:run` passes (321/321)

## 🧪 Test
- Switch EN ↔ TR while:
  - opening a Route panel (placeholders, swap button tooltip, use-my-location button)
  - viewing a Report's comments section logged out (login prompt) and logged in (Loading state, Anonymous fallback on a comment without an author)
  - opening the Create Fix sheet (placeholder + helper line)
  - opening the custom routing preset editor (form labels, error fallbacks)
  - landing on Routing Preferences with a slow connection (loading line)
  - clicking Remove on the avatar uploader (confirm + error path)

## 📸 Screenshots
<img width="691" height="328" alt="Ekran Resmi 2026-05-11 11 50 00" src="https://github.com/user-attachments/assets/cedf86cb-f725-4504-bf8c-3fd6f7977945" />




## ⏱️ Review Time
~5 min