### PR TITLE
[Mobile] Surface Gamification UI End-to-End

### DIFF
--- a/mobile/lib/models/badge.dart
+++ b/mobile/lib/models/badge.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+/// Mirrors the backend `Badge` enum. Adding a new badge there means adding
+/// an entry to [_meta] here, otherwise it falls back to the unknown-badge
+/// no-op rendering.
+class BadgeMeta {
+  final String label;
+  final IconData icon;
+  final String description;
+  final Color foreground;
+  final Color background;
+  final int tier;
+
+  const BadgeMeta({
+    required this.label,
+    required this.icon,
+    required this.description,
+    required this.foreground,
+    required this.background,
+    required this.tier,
+  });
+}
+
+const Map<String, BadgeMeta> _meta = {
+  'TRUSTED_REPORTER': BadgeMeta(
+    label: 'Trusted Reporter',
+    icon: Icons.verified,
+    description: '10 verified reports',
+    foreground: Color(0xFFB45309),
+    background: Color(0x33FCD34D),
+    tier: 1,
+  ),
+  'EXPERT_MAPPER': BadgeMeta(
+    label: 'Expert Mapper',
+    icon: Icons.workspace_premium,
+    description: '50 verified reports',
+    foreground: Color(0xFF6D28D9),
+    background: Color(0x33C4B5FD),
+    tier: 2,
+  ),
+  'TOP_10': BadgeMeta(
+    label: 'Top 10',
+    icon: Icons.emoji_events,
+    description: 'Currently in the top 10 leaderboard',
+    foreground: Color(0xFF166534),
+    background: Color(0x3386EFAC),
+    tier: 3,
+  ),
+};
+
+BadgeMeta? badgeMeta(String? badge) => badge == null ? null : _meta[badge];
+
+/// Highest-tier badge among a list of enum names. Used wherever the UI
+/// surfaces a single "primary" badge (profile chip, report-author chip).
+String? pickHighestTierBadge(List<String> badges) {
+  if (badges.isEmpty) return null;
+  String? best;
+  int bestTier = -1;
+  for (final b in badges) {
+    final tier = _meta[b]?.tier ?? -1;
+    if (tier > bestTier) {
+      bestTier = tier;
+      best = b;
+    }
+  }
+  return best;
+}

--- a/mobile/lib/models/leaderboard_entry.dart
+++ b/mobile/lib/models/leaderboard_entry.dart
@@ -1,0 +1,46 @@
+/// One row of the public leaderboard. Mirrors the backend
+/// `LeaderboardEntry` record.
+class LeaderboardEntry {
+  /// 1-based rank within the current top-N view. Tied scores share a rank
+  /// (olympic-style — backend produces this directly, the client renders
+  /// what comes back).
+  final int rank;
+  final int userId;
+  final String name;
+  final String? avatarUrl;
+  final int points;
+
+  const LeaderboardEntry({
+    required this.rank,
+    required this.userId,
+    required this.name,
+    required this.avatarUrl,
+    required this.points,
+  });
+
+  factory LeaderboardEntry.fromJson(Map<String, dynamic> json) {
+    return LeaderboardEntry(
+      rank: json['rank'] as int,
+      userId: (json['userId'] as num).toInt(),
+      name: json['name'] as String? ?? 'Unknown',
+      avatarUrl: json['avatarUrl'] as String?,
+      points: (json['points'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+/// Caller's own rank slot in the leaderboard payload. Null when the caller
+/// is anonymous, has opted out, or is no longer active.
+class RankInfo {
+  final int rank;
+  final int points;
+
+  const RankInfo({required this.rank, required this.points});
+
+  factory RankInfo.fromJson(Map<String, dynamic> json) {
+    return RankInfo(
+      rank: json['rank'] as int,
+      points: (json['points'] as num?)?.toInt() ?? 0,
+    );
+  }
+}

--- a/mobile/lib/models/notification_model.dart
+++ b/mobile/lib/models/notification_model.dart
@@ -5,12 +5,14 @@ enum NotificationType {
   statusChange,
   newComment,
   navAlert,
+  badgeAwarded,
   unknown;
 
   static NotificationType fromJson(String? s) => switch (s) {
         'STATUS_CHANGE' => NotificationType.statusChange,
         'NEW_COMMENT' => NotificationType.newComment,
         'NAV_ALERT' => NotificationType.navAlert,
+        'BADGE_AWARDED' => NotificationType.badgeAwarded,
         _ => NotificationType.unknown,
       };
 
@@ -18,6 +20,7 @@ enum NotificationType {
         NotificationType.statusChange => Icons.flag_outlined,
         NotificationType.newComment => Icons.chat_bubble_outline,
         NotificationType.navAlert => Icons.navigation_outlined,
+        NotificationType.badgeAwarded => Icons.workspace_premium,
         NotificationType.unknown => Icons.notifications_outlined,
       };
 
@@ -25,6 +28,7 @@ enum NotificationType {
         NotificationType.statusChange => 'Status update',
         NotificationType.newComment => 'New comment',
         NotificationType.navAlert => 'Nearby alert',
+        NotificationType.badgeAwarded => 'Badge earned',
         NotificationType.unknown => 'Notification',
       };
 }

--- a/mobile/lib/models/report_model.dart
+++ b/mobile/lib/models/report_model.dart
@@ -695,6 +695,11 @@ class ReportModel {
   /// voting card without an extra fetch.
   final FixRequestModel? activeFixRequest;
 
+  /// Highest-tier badge held by the report author. Surfaced as a chip next
+  /// to the author's name on the detail screen. Null when the author has
+  /// no badges yet.
+  final String? authorTopBadge;
+
   const ReportModel({
     required this.reportId,
     required this.userId,
@@ -717,6 +722,7 @@ class ReportModel {
     this.exitLongitude,
     this.lastEditedByUserId,
     this.activeFixRequest,
+    this.authorTopBadge,
   });
 
   factory ReportModel.fromJson(Map<String, dynamic> json) {
@@ -750,6 +756,7 @@ class ReportModel {
               Map<String, dynamic>.from(json['activeFixRequest'] as Map),
             )
           : null,
+      authorTopBadge: json['authorTopBadge'] as String?,
     );
   }
 
@@ -786,6 +793,7 @@ class ReportModel {
       activeFixRequest: activeFixRequest == _kSentinel
           ? this.activeFixRequest
           : activeFixRequest as FixRequestModel?,
+      authorTopBadge: authorTopBadge,
     );
   }
 

--- a/mobile/lib/screens/leaderboard_screen.dart
+++ b/mobile/lib/screens/leaderboard_screen.dart
@@ -1,0 +1,364 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/leaderboard_entry.dart';
+import '../services/api_service.dart';
+import '../services/auth_service.dart';
+import '../theme/app_colors.dart';
+import 'user_profile_screen.dart';
+
+/// Public leaderboard — top-N entries plus the caller's rank when
+/// authenticated. Mirrors the web `/leaderboard` page: olympic-style ranks
+/// (tied scores share a position) and a gold/silver/bronze tone for the
+/// top three.
+class LeaderboardScreen extends StatefulWidget {
+  const LeaderboardScreen({super.key});
+
+  @override
+  State<LeaderboardScreen> createState() => _LeaderboardScreenState();
+}
+
+class _LeaderboardScreenState extends State<LeaderboardScreen> {
+  List<LeaderboardEntry>? _entries;
+  RankInfo? _callerRank;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final api = context.read<AuthService>().api;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final payload = await api.getLeaderboard();
+      if (!mounted) return;
+      final rawEntries = payload['entries'] as List<dynamic>? ?? const [];
+      final rawCaller = payload['callerRank'] as Map<String, dynamic>?;
+      setState(() {
+        _entries = rawEntries
+            .map((e) => LeaderboardEntry.fromJson(e as Map<String, dynamic>))
+            .toList();
+        _callerRank = rawCaller != null ? RankInfo.fromJson(rawCaller) : null;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e is ApiException ? e.userMessage : e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isAuthenticated = context.read<AuthService>().isAuthenticated;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Leaderboard'),
+      ),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: _buildBody(isAuthenticated),
+      ),
+    );
+  }
+
+  Widget _buildBody(bool isAuthenticated) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return _ErrorView(message: _error!, onRetry: _load);
+    }
+    final entries = _entries ?? const <LeaderboardEntry>[];
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+      children: [
+        Text(
+          'Top contributors ranked by points. Tied scores share a rank.',
+          style: TextStyle(
+            fontSize: 13,
+            color: AppColors.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 16),
+        if (_callerRank != null) _YourRankBanner(info: _callerRank!),
+        if (_callerRank != null) const SizedBox(height: 12),
+        if (_callerRank == null && !isAuthenticated)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Text(
+              'Log in to see your own rank on this page.',
+              style: TextStyle(
+                fontSize: 12,
+                color: AppColors.onSurfaceVariant,
+              ),
+            ),
+          ),
+        if (entries.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 32),
+            child: Center(
+              child: Text(
+                'No ranked users yet. Submit a report to get on the board.',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 14,
+                  color: AppColors.onSurfaceVariant,
+                ),
+              ),
+            ),
+          )
+        else
+          ...entries.map(_buildRow),
+      ],
+    );
+  }
+
+  Widget _buildRow(LeaderboardEntry entry) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).push(MaterialPageRoute(
+            builder: (_) => UserProfileScreen(
+              userId: entry.userId,
+              initialName: entry.name,
+              initialAvatarUrl: entry.avatarUrl,
+            ),
+          ));
+        },
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          decoration: BoxDecoration(
+            color: AppColors.cardSurface,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: AppColors.outlineVariant.withValues(alpha: 0.4),
+            ),
+          ),
+          child: Row(
+            children: [
+              _RankCell(rank: entry.rank),
+              const SizedBox(width: 12),
+              _Avatar(url: entry.avatarUrl),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  entry.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.onSurface,
+                  ),
+                ),
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    'POINTS',
+                    style: TextStyle(
+                      fontSize: 9,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 1.2,
+                      color: AppColors.onSurfaceVariant,
+                    ),
+                  ),
+                  Text(
+                    '${entry.points}',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.onSurface,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RankCell extends StatelessWidget {
+  final int rank;
+
+  const _RankCell({required this.rank});
+
+  @override
+  Widget build(BuildContext context) {
+    // Olympic-style podium tones for the top three; everyone else stays
+    // neutral so the eye still picks up the medalists.
+    final (bg, fg) = switch (rank) {
+      1 => (const Color(0xFFFDE68A), const Color(0xFF92400E)), // gold
+      2 => (const Color(0xFFE5E7EB), const Color(0xFF374151)), // silver
+      3 => (const Color(0xFFFED7AA), const Color(0xFF9A3412)), // bronze
+      _ => (
+          AppColors.outlineVariant.withValues(alpha: 0.25),
+          AppColors.onSurfaceVariant
+        ),
+    };
+    return Container(
+      width: 44,
+      height: 36,
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '#$rank',
+        style: TextStyle(
+          fontWeight: FontWeight.w700,
+          fontSize: 13,
+          color: fg,
+        ),
+      ),
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  final String? url;
+
+  const _Avatar({required this.url});
+
+  @override
+  Widget build(BuildContext context) {
+    if (url != null && url!.isNotEmpty) {
+      return CircleAvatar(
+        radius: 18,
+        backgroundImage: NetworkImage(url!),
+      );
+    }
+    return CircleAvatar(
+      radius: 18,
+      backgroundColor: AppColors.outlineVariant.withValues(alpha: 0.3),
+      child: Icon(Icons.person, size: 22, color: AppColors.onSurfaceVariant),
+    );
+  }
+}
+
+class _YourRankBanner extends StatelessWidget {
+  final RankInfo info;
+
+  const _YourRankBanner({required this.info});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: AppColors.primary.withValues(alpha: 0.24),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.person_pin, color: AppColors.primary, size: 24),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'YOUR RANK',
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 1.2,
+                    color: AppColors.onSurfaceVariant,
+                  ),
+                ),
+                Text(
+                  '#${info.rank}',
+                  style: TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w800,
+                    color: AppColors.onSurface,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                'POINTS',
+                style: TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 1.2,
+                  color: AppColors.onSurfaceVariant,
+                ),
+              ),
+              Text(
+                '${info.points}',
+                style: TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w800,
+                  color: AppColors.onSurface,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorView({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.cloud_off, size: 48, color: AppColors.onSurfaceVariant),
+            const SizedBox(height: 12),
+            Text(
+              'Failed to load the leaderboard',
+              style: TextStyle(
+                fontWeight: FontWeight.w700,
+                color: AppColors.onSurface,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: AppColors.onSurfaceVariant),
+            ),
+            const SizedBox(height: 16),
+            FilledButton(onPressed: onRetry, child: const Text('Try again')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/profile_screen.dart
+++ b/mobile/lib/screens/profile_screen.dart
@@ -7,8 +7,10 @@ import '../theme/app_colors.dart';
 import '../services/auth_service.dart';
 import '../services/api_service.dart';
 import '../models/report_model.dart';
+import '../widgets/badge_chip.dart';
 import '../main.dart' show AuthShell;
 import 'avatar_crop_screen.dart';
+import 'leaderboard_screen.dart';
 import 'report_detail_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
@@ -329,6 +331,18 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final stats = _userInfo?['contributionStats'] as Map<String, dynamic>?;
     final reportsSubmitted = stats?['reportsSubmitted'] ?? _userReports.length;
     final routesPlanned = stats?['routesPlanned'] ?? 0;
+    final points = (_userInfo?['points'] as num?)?.toInt() ?? 0;
+    final rank = _userInfo?['rank'] as int?;
+    final leaderboardHidden = (_userInfo?['leaderboardHidden'] as bool?) ?? false;
+    final badges = (_userInfo?['badges'] as List<dynamic>?)
+            ?.map((e) => e as String)
+            .toList() ??
+        const <String>[];
+    final rankLabel = rank != null
+        ? '#$rank'
+        : leaderboardHidden
+            ? 'Hidden'
+            : '—';
 
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
@@ -344,7 +358,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
           const SizedBox(height: 18),
 
-          // Stats cards
+          // Stats cards — REPORTS + ROUTES on the first row, POINTS + RANK on
+          // the second row. Wrap so both rows reflow to a single column on
+          // narrow phones without overflowing.
           Row(
             children: [
               Expanded(
@@ -364,6 +380,58 @@ class _ProfileScreenState extends State<ProfileScreen> {
               ),
             ],
           ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _buildStatCard(
+                  icon: Icons.star_outline,
+                  label: 'POINTS',
+                  value: '$points',
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _buildStatCard(
+                  icon: Icons.leaderboard_outlined,
+                  label: 'RANK',
+                  value: rankLabel,
+                ),
+              ),
+            ],
+          ),
+
+          if (badges.isNotEmpty) ...[
+            const SizedBox(height: 20),
+            Text(
+              'Badges',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            BadgeList(badges: badges),
+          ],
+
+          const SizedBox(height: 16),
+          OutlinedButton.icon(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const LeaderboardScreen()),
+              );
+            },
+            icon: const Icon(Icons.leaderboard_outlined),
+            label: const Text('View leaderboard'),
+            style: OutlinedButton.styleFrom(
+              minimumSize: const Size.fromHeight(44),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 16),
+          _buildLeaderboardVisibilityToggle(leaderboardHidden),
 
           const SizedBox(height: 28),
 
@@ -746,6 +814,82 @@ class _ProfileScreenState extends State<ProfileScreen> {
       ),
     );
   }
+
+  /// Opt-out toggle for the public leaderboard. Flipping it preserves the
+  /// user's accumulated points on the backend — they re-enter the ranking
+  /// instantly when this flips back.
+  Widget _buildLeaderboardVisibilityToggle(bool hidden) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+      decoration: BoxDecoration(
+        color: AppColors.cardSurface,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(
+          color: AppColors.outlineVariant.withValues(alpha: 0.4),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Hide me from the public leaderboard',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.onSurface,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  'Your points stay accurate either way.',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: AppColors.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Switch.adaptive(
+            value: hidden,
+            onChanged: _saving ? null : _toggleLeaderboardVisibility,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _toggleLeaderboardVisibility(bool nextHidden) async {
+    final api = context.read<AuthService>().api;
+    setState(() => _saving = true);
+    try {
+      final updated = await api.setLeaderboardVisibility(nextHidden);
+      if (!mounted) return;
+      setState(() {
+        _userInfo = updated;
+        _saving = false;
+      });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(nextHidden
+              ? 'You are now hidden from the public leaderboard.'
+              : 'You are visible on the public leaderboard.'),
+        ));
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _saving = false);
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text('Failed to update visibility: ${_userMessage(e)}'),
+      ));
+    }
+  }
+
+  String _userMessage(Object e) =>
+      e is ApiException ? e.userMessage : e.toString();
 
   /// Hero card with a soft brand-tinted gradient and the avatar nested
   /// inside. Replaces the previous flat avatar+text stack and gives the

--- a/mobile/lib/screens/report_detail_screen.dart
+++ b/mobile/lib/screens/report_detail_screen.dart
@@ -13,6 +13,7 @@ import '../models/sse_event.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
 import '../services/sse_service.dart';
+import '../widgets/badge_chip.dart';
 import '../main.dart' show MainShell, AuthShell;
 import 'create_fix_request_screen.dart';
 import 'edit_report_screen.dart';
@@ -932,32 +933,41 @@ class _ReportDetailScreenState extends State<ReportDetailScreen> {
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                _isGuest
-                    ? Text(
-                        'User #${report.userId}',
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w600,
-                          color: AppColors.onSurface,
-                        ),
-                      )
-                    : _usernameLoading
-                        ? Container(
-                            width: 90,
-                            height: 14,
-                            decoration: BoxDecoration(
-                              color: AppColors.surfaceContainerHigh,
-                              borderRadius: BorderRadius.circular(6),
-                            ),
-                          )
-                        : Text(
-                            _displayUsername,
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _isGuest
+                        ? Text(
+                            'User #${report.userId}',
                             style: TextStyle(
                               fontSize: 14,
                               fontWeight: FontWeight.w600,
                               color: AppColors.onSurface,
                             ),
-                          ),
+                          )
+                        : _usernameLoading
+                            ? Container(
+                                width: 90,
+                                height: 14,
+                                decoration: BoxDecoration(
+                                  color: AppColors.surfaceContainerHigh,
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                              )
+                            : Text(
+                                _displayUsername,
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                  color: AppColors.onSurface,
+                                ),
+                              ),
+                    if (report.authorTopBadge != null) ...[
+                      const SizedBox(width: 6),
+                      BadgeChip(badge: report.authorTopBadge!, compact: true),
+                    ],
+                  ],
+                ),
                 Text(
                   'Reported ${report.timeAgo}',
                   style: TextStyle(

--- a/mobile/lib/screens/user_profile_screen.dart
+++ b/mobile/lib/screens/user_profile_screen.dart
@@ -5,6 +5,7 @@ import '../models/report_model.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
 import '../theme/app_colors.dart';
+import '../widgets/badge_chip.dart';
 import 'report_detail_screen.dart';
 
 /// Read-only public profile shown when a user taps someone else's avatar
@@ -176,6 +177,17 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
     final reportsSubmitted =
         stats?['reportsSubmitted'] ?? _reports.length;
     final routesPlanned = stats?['routesPlanned'] ?? 0;
+    final points = (_userInfo?['points'] as num?)?.toInt() ?? 0;
+    final rank = _userInfo?['rank'] as int?;
+    final leaderboardHidden =
+        (_userInfo?['leaderboardHidden'] as bool?) ?? false;
+    final badges = (_userInfo?['badges'] as List<dynamic>?)
+            ?.map((e) => e as String)
+            .toList() ??
+        const <String>[];
+    // Foreign profiles intentionally omit the rank tile when the viewed user
+    // opted out — the existence of a hidden rank is private to the owner.
+    final showRankTile = !leaderboardHidden && rank != null;
 
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
@@ -203,6 +215,39 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
               ),
             ],
           ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _buildStatCard(
+                  icon: Icons.star_outline,
+                  label: 'POINTS',
+                  value: '$points',
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: showRankTile
+                    ? _buildStatCard(
+                        icon: Icons.leaderboard_outlined,
+                        label: 'RANK',
+                        value: '#$rank',
+                      )
+                    : const SizedBox.shrink(),
+              ),
+            ],
+          ),
+          if (badges.isNotEmpty) ...[
+            const SizedBox(height: 20),
+            Text(
+              'Badges',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            BadgeList(badges: badges),
+          ],
           const SizedBox(height: 24),
           if (_reports.isNotEmpty) ...[
             Text(

--- a/mobile/lib/services/api_service.dart
+++ b/mobile/lib/services/api_service.dart
@@ -569,6 +569,52 @@ class ApiService {
       return response.reasonPhrase ?? 'Unknown error';
     }
   }
+
+  // ─── Gamification ──────────────────────────────────────────────────────────
+
+  /// Public top-N leaderboard. Token forwarded so the backend can populate
+  /// `callerRank` for authenticated viewers; anonymous callers get a null
+  /// callerRank slot. Returned shape:
+  ///   { entries: [{ rank, userId, name, avatarUrl, points }, ...],
+  ///     callerRank: { rank, points } | null }
+  Future<Map<String, dynamic>> getLeaderboard() async {
+    final response = await http
+        .get(Uri.parse('$_baseUrl/api/leaderboard'), headers: _headers)
+        .timeout(const Duration(seconds: 8));
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    }
+    throw ApiException(response.statusCode, _extractMessage(response));
+  }
+
+  /// Public — returns the list of badge enum names held by a user
+  /// (e.g. ['TRUSTED_REPORTER', 'TOP_10']).
+  Future<List<String>> getUserBadges(int userId) async {
+    final response = await http
+        .get(Uri.parse('$_baseUrl/api/users/$userId/badges'), headers: _headers)
+        .timeout(const Duration(seconds: 6));
+    if (response.statusCode == 200) {
+      final list = jsonDecode(response.body) as List<dynamic>;
+      return list.map((e) => e as String).toList();
+    }
+    throw ApiException(response.statusCode, _extractMessage(response));
+  }
+
+  /// Toggle the caller's leaderboard opt-out flag. Returns the updated profile
+  /// DTO so the screen can refresh its rank display from the same payload.
+  Future<Map<String, dynamic>> setLeaderboardVisibility(bool hidden) async {
+    final response = await http
+        .patch(
+          Uri.parse('$_baseUrl/api/users/me/leaderboard-visibility'),
+          headers: _headers,
+          body: jsonEncode({'leaderboardHidden': hidden}),
+        )
+        .timeout(const Duration(seconds: 6));
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    }
+    throw ApiException(response.statusCode, _extractMessage(response));
+  }
 }
 
 class ApiException implements Exception {

--- a/mobile/lib/widgets/badge_chip.dart
+++ b/mobile/lib/widgets/badge_chip.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import '../models/badge.dart';
+
+/// Badge chip rendered next to a username. `compact = true` collapses to
+/// just the icon (used inline next to the report-author name); the default
+/// renders an icon + label chip used on profile pages.
+class BadgeChip extends StatelessWidget {
+  final String badge;
+  final bool compact;
+
+  const BadgeChip({super.key, required this.badge, this.compact = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = badgeMeta(badge);
+    if (meta == null) return const SizedBox.shrink();
+
+    if (compact) {
+      return Tooltip(
+        message: '${meta.label} — ${meta.description}',
+        child: Container(
+          width: 22,
+          height: 22,
+          decoration: BoxDecoration(
+            color: meta.background,
+            shape: BoxShape.circle,
+          ),
+          alignment: Alignment.center,
+          child: Icon(meta.icon, color: meta.foreground, size: 14),
+        ),
+      );
+    }
+
+    return Tooltip(
+      message: meta.description,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: meta.background,
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(meta.icon, color: meta.foreground, size: 14),
+            const SizedBox(width: 6),
+            Text(
+              meta.label,
+              style: TextStyle(
+                color: meta.foreground,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Strip of all badges held by a user. Renders nothing when the list is
+/// empty so the caller doesn't need a guard.
+class BadgeList extends StatelessWidget {
+  final List<String> badges;
+
+  const BadgeList({super.key, required this.badges});
+
+  @override
+  Widget build(BuildContext context) {
+    if (badges.isEmpty) return const SizedBox.shrink();
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: badges.map((b) => BadgeChip(badge: b)).toList(),
+    );
+  }
+}


### PR DESCRIPTION
# 📝 Description
Mobile parallel of the web gamification rollout. Wires the gamification backend API into the Flutter app — `BADGE_AWARDED` notification, `ReportResponse.authorTopBadge`, `/api/leaderboard`, opt-out toggle, badge endpoint.

- `ApiService` gains `getLeaderboard`, `getUserBadges`, and `setLeaderboardVisibility`.
- `NotificationModel` learns the `BADGE_AWARDED` type and renders a `workspace_premium` icon for badge alerts.
- New models: `Badge` constants (icon + label + tier per backend enum value), `LeaderboardEntry`, `RankInfo`. `pickHighestTierBadge` helper for any UI surface that shows a single primary badge.
- New `BadgeChip` widget (compact + standard sizes) and `BadgeList` strip.
- `ProfileScreen`: 4-tile stat layout (Reports / Routes / Points / Rank), Badges section, "Hide me from the public leaderboard" Switch, and a "View leaderboard" button. Rank shows `#N`, `Hidden` (opted out), or `—` (no rank yet).
- `UserProfileScreen`: same Points/Rank/Badges treatment for foreign profiles. The Rank tile is omitted entirely when the viewed user opted out — the existence of a hidden rank is private to the owner. No visibility toggle on someone else's profile.
- `LeaderboardScreen`: top-N list, tied scores share rank (olympic — backend produces this, the client renders it), gold/silver/bronze tones for the top three, "Your rank" banner when the caller is authenticated and ranked, "log in" hint for anonymous viewers, empty state copy, pull-to-refresh, and per-row navigation to `UserProfileScreen`.
- `ReportModel.authorTopBadge` is forwarded from the API and surfaced as a compact `BadgeChip` next to the author username on the report detail screen. Falls back to nothing when the author has no badges yet.

Fixes #272 #264

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
<img width="268" height="449" alt="image" src="https://github.com/user-attachments/assets/0de97f42-ab6b-4e0c-8f7e-19ce2e891b5d" />
<img width="522" height="1056" alt="002" src="https://github.com/user-attachments/assets/0e1437a5-9613-406c-95bb-2144f9b0649d" />
<img width="278" height="77" alt="003" src="https://github.com/user-attachments/assets/2efb4c72-20cd-4967-9008-ee331e8fa867" />
<img width="267" height="104" alt="004" src="https://github.com/user-attachments/assets/0d7a8839-be47-4c91-abae-dd31a1489d5d" />

# ⏱️ Estimated Review Time
- [x] 5-15 min
