### PR TITLE
[Web] Align onboarding tutorial close button with unified panel style (closes #576)

### DIFF
--- a/frontend/src/components/OnboardingTutorial.jsx
+++ b/frontend/src/components/OnboardingTutorial.jsx
@@ -466,7 +466,7 @@ export default function OnboardingTutorial({ onClose }) {
             type="button"
             onClick={onClose}
             aria-label="Close tutorial"
-            className="w-9 h-9 rounded-full hover:bg-surface-container-low flex items-center justify-center cursor-pointer text-on-surface-variant"
+            className="w-9 h-9 rounded-full bg-error/10 text-error flex items-center justify-center hover:bg-error/20 transition-colors cursor-pointer"
           >
             <span className="material-symbols-outlined text-xl">close</span>
           </button>


### PR DESCRIPTION
## 📝 Description
Closes #576. Brings the OnboardingTutorial X button in line with the three panels unified in #565 , same `bg-error/10 text-error hover:bg-error/20`.

## ✅ Acceptance Criteria
- [x] Tutorial close button matches CreateReportPanel, RoutePanel, ReportPanel

## 🧪 Test
- Open the tutorial (e.g. `/?tutorial=1`) → X is now red-tinted in both themes

## 📸 Screenshot
<img width="717" height="597" alt="Ekran Resmi 2026-05-11 15 28 20" src="https://github.com/user-attachments/assets/a44d7be1-676f-4979-8266-2ac940f162d2" />


## ⏱️ Review
~1 min