### PR TITLE
[Web] Wire gear icon → /settings shell page (closes #588)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Leaderboard from './pages/Leaderboard.jsx'
 import ProfilePage from './pages/ProfilePage.jsx'
 import UserProfilePage from './pages/UserProfilePage.jsx'
 import UserSearchPage from './pages/UserSearchPage.jsx'
+import SettingsPage from './pages/SettingsPage.jsx'
 import RequireAdmin from './components/RequireAdmin.jsx'
 import RequireAuth from './components/RequireAuth.jsx'
 import AdminLayout from './components/admin/AdminLayout.jsx'
@@ -33,6 +34,7 @@ function App() {
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/profile/:userId" element={<UserProfilePage />} />
         <Route path="/search/users" element={<UserSearchPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
       </Route>
       <Route element={<RequireAdmin />}>
         <Route element={<AdminLayout />}>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -181,12 +181,13 @@ function Navbar() {
             )}
           </div>
         )}
-        <button
+        <Link
+          to="/settings"
           className="hidden sm:flex shrink-0 w-10 h-10 rounded-full items-center justify-center hover:bg-surface-container transition-colors"
           aria-label="Settings"
         >
           <span className="material-symbols-outlined text-on-surface-variant">settings</span>
-        </button>
+        </Link>
 
         {isAuthenticated ? (
           <div className="relative ml-1 sm:ml-2">

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,0 +1,17 @@
+import Navbar from '../components/Navbar.jsx'
+
+function SettingsPage() {
+  return (
+    <div className="min-h-screen flex flex-col bg-background">
+      <Navbar />
+      <main className="flex-1 max-w-3xl w-full mx-auto p-4 md:p-8 flex flex-col gap-6">
+        <h1 className="text-3xl font-bold font-headline text-on-surface">Settings</h1>
+        <p className="text-sm text-on-surface-variant">
+          Preferences will appear here.
+        </p>
+      </main>
+    </div>
+  )
+}
+
+export default SettingsPage


### PR DESCRIPTION
## 📝 Description
Closes #588. Three small steps lay the foundation for the gear-driven preferences (1.1.3.*):
1. New `SettingsPage` at `/settings` with a heading and a placeholder line. Reuses `Navbar` so chrome stays consistent.
2. Route registered inside the existing `<RequireAuth>` block , guests redirect to login automatically.
3. Gear icon switches from an inert `<button>` to `<Link to="/settings">`.

Follow-up issues will add the preference rows (theme, language, routing prefs, notifications, account deletion, etc.) one at a time.

## 📊 Type
New feature

## ✅ AC
- [x] Gear navigates to `/settings`
- [x] Auth-gated — logged out → `/login`
- [x] Renders the heading and placeholder body
- [x] Gear is keyboard-focusable with `aria-label`
- [x] 474 frontend tests pass

## 🧪 Test
- Logged in: click gear → settings page opens
- Logged out: visit `/settings` → redirected to `/login`
- Tab to gear, press Enter → opens

## 📷Screenshots
<img width="1296" height="720" alt="Ekran Resmi 2026-05-11 19 11 14" src="https://github.com/user-attachments/assets/9b180094-1e9c-40f7-beed-14dd6eb51889" />


## ⏱️ Review
~2 min