### PR TITLE
[Backend] Expand Unit Test Coverage Across Util Repository Services And Controllers

### DIFF
--- a/backend/src/test/java/com/bounswe2026group1/backend/BackendApplicationMainTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/BackendApplicationMainTest.java
@@ -1,0 +1,30 @@
+package com.bounswe2026group1.backend;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.boot.SpringApplication;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Covers {@link BackendApplication#main(String[])} without actually starting the
+ * Spring context, by stubbing the static {@code SpringApplication.run(...)} call.
+ */
+class BackendApplicationMainTest {
+
+    @Test
+    void main_delegatesToSpringApplicationRun() {
+        String[] args = {"--spring.profiles.active=test"};
+
+        try (MockedStatic<SpringApplication> mocked = mockStatic(SpringApplication.class)) {
+            mocked.when(() -> SpringApplication.run(any(Class.class), any(String[].class)))
+                    .thenReturn(null);
+
+            BackendApplication.main(args);
+
+            mocked.verify(() -> SpringApplication.run(eq(BackendApplication.class), eq(args)));
+        }
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/CommentControllerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -247,4 +248,53 @@ class CommentControllerTest {
         verify(commentService, never()).update(any(Long.class), any(UpdateCommentRequest.class));
     }
 
+    // ───── Remaining read endpoints ─────────────────────────────────────────
+
+    @Test
+    void getAll_returnsServiceList() throws Exception {
+        when(commentService.getAll()).thenReturn(java.util.List.of(savedCommentStub()));
+
+        mockMvc.perform(get("/api/comments").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(99))
+                .andExpect(jsonPath("$[0].author.id").value(3));
+    }
+
+    @Test
+    void getByAuthor_returnsServiceList() throws Exception {
+        when(commentService.getByAuthor(eq(3L))).thenReturn(java.util.List.of(savedCommentStub()));
+
+        mockMvc.perform(get("/api/comments/author/3").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(99))
+                .andExpect(jsonPath("$[0].author.id").value(3));
+    }
+
+    @Test
+    void getById_returns404WhenServiceReturnsEmpty() throws Exception {
+        when(commentService.getById(eq(404L))).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/comments/404").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void delete_returns204WhenServiceDeletes() throws Exception {
+        when(commentService.delete(99L)).thenReturn(true);
+
+        mockMvc.perform(delete("/api/comments/99").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNoContent());
+
+        verify(commentService).delete(99L);
+    }
+
+    @Test
+    @WithMockUser(username = AUTHOR_EMAIL)
+    void delete_returns404WhenServiceSignalsNoSuchComment() throws Exception {
+        when(commentService.delete(404L)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/comments/404").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/CustomRoutingProfileControllerUnitTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/CustomRoutingProfileControllerUnitTest.java
@@ -1,0 +1,165 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.dto.routing.CreateCustomRoutingProfileRequest;
+import com.bounswe2026group1.backend.dto.routing.CustomRoutingProfileResponse;
+import com.bounswe2026group1.backend.dto.routing.RoutingPreferencesResponse;
+import com.bounswe2026group1.backend.dto.routing.UpdateCustomRoutingProfileRequest;
+import com.bounswe2026group1.backend.service.CustomRoutingProfileService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CustomRoutingProfileControllerUnitTest {
+
+    private static final String EMAIL = "ada@example.com";
+
+    @Mock
+    private CustomRoutingProfileService service;
+
+    @InjectMocks
+    private CustomRoutingProfileController controller;
+
+    @AfterEach
+    void clearAuth() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void authenticate(String email) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        email, "creds", AuthorityUtils.createAuthorityList("ROLE_USER")));
+    }
+
+    private void anonymous() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new AnonymousAuthenticationToken(
+                        "anon", "anonymousUser",
+                        AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+    }
+
+    @Test
+    void list_authenticated_returnsServiceList() {
+        authenticate(EMAIL);
+        List<CustomRoutingProfileResponse> profiles =
+                List.of(CustomRoutingProfileResponse.builder().id(1L).name("p1").build());
+        when(service.listForEmail(EMAIL)).thenReturn(profiles);
+
+        ResponseEntity<?> result = controller.list();
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertSame(profiles, result.getBody());
+    }
+
+    @Test
+    void list_anonymous_returns401_andSkipsService() {
+        anonymous();
+
+        ResponseEntity<?> result = controller.list();
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
+        assertEquals("Authentication required.", result.getBody());
+        verify(service, never()).listForEmail(anyString());
+    }
+
+    @Test
+    void create_authenticated_returns201WithCreatedProfile() {
+        authenticate(EMAIL);
+        CreateCustomRoutingProfileRequest request = new CreateCustomRoutingProfileRequest();
+        CustomRoutingProfileResponse created =
+                CustomRoutingProfileResponse.builder().id(11L).name("steep").build();
+        when(service.create(EMAIL, request)).thenReturn(created);
+
+        ResponseEntity<?> result = controller.create(request);
+
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+        assertSame(created, result.getBody());
+    }
+
+    @Test
+    void create_noAuth_returns401() {
+        ResponseEntity<?> result = controller.create(new CreateCustomRoutingProfileRequest());
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
+        verify(service, never()).create(anyString(), any());
+    }
+
+    @Test
+    void update_authenticated_returns200WithUpdatedProfile() {
+        authenticate(EMAIL);
+        UpdateCustomRoutingProfileRequest request = new UpdateCustomRoutingProfileRequest();
+        CustomRoutingProfileResponse updated =
+                CustomRoutingProfileResponse.builder().id(11L).name("renamed").build();
+        when(service.update(EMAIL, 11L, request)).thenReturn(updated);
+
+        ResponseEntity<?> result = controller.update(11L, request);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertSame(updated, result.getBody());
+    }
+
+    @Test
+    void update_noAuth_returns401() {
+        ResponseEntity<?> result = controller.update(11L, new UpdateCustomRoutingProfileRequest());
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
+        verify(service, never()).update(anyString(), any(), any());
+    }
+
+    @Test
+    void delete_authenticated_returns204_andDelegates() {
+        authenticate(EMAIL);
+
+        ResponseEntity<?> result = controller.delete(11L);
+
+        assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode());
+        verify(service).delete(EMAIL, 11L);
+    }
+
+    @Test
+    void delete_noAuth_returns401_andSkipsService() {
+        ResponseEntity<?> result = controller.delete(11L);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
+        verify(service, never()).delete(anyString(), any());
+    }
+
+    @Test
+    void activate_authenticated_returns200WithPreferences() {
+        authenticate(EMAIL);
+        RoutingPreferencesResponse prefs = new RoutingPreferencesResponse();
+        when(service.activate(EMAIL, 11L)).thenReturn(prefs);
+
+        ResponseEntity<?> result = controller.activate(11L);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertSame(prefs, result.getBody());
+    }
+
+    @Test
+    void activate_noAuth_returns401() {
+        ResponseEntity<?> result = controller.activate(11L);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
+        verify(service, never()).activate(anyString(), any());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/FixRequestControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/FixRequestControllerTest.java
@@ -7,18 +7,25 @@ import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.service.FixRequestService;
 import com.bounswe2026group1.backend.util.JwtUtil;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.Instant;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -70,5 +77,90 @@ class FixRequestControllerTest {
                 .andExpect(jsonPath("$.id").value(27))
                 .andExpect(jsonPath("$.reportId").value(100))
                 .andExpect(jsonPath("$.agrees").value(4));
+    }
+
+    @Test
+    @WithMockUser(username = EMAIL)
+    void disagree_returnsUpdatedFixRequest() throws Exception {
+        FixRequestResponse body = new FixRequestResponse();
+        body.setId(27L);
+        body.setReportId(100L);
+        body.setSubmittedByUserId(3L);
+        body.setSubmittedByName("Alice");
+        body.setDescription("fixed");
+        body.setState(FixRequestState.OPEN);
+        body.setAgrees(2);
+        body.setDisagrees(1);
+        body.setCreatedAt(Instant.parse("2026-05-01T10:00:00Z"));
+        body.setMediaUrls(java.util.List.of());
+        body.setUserVote(VoteType.DISAGREE);
+
+        when(fixRequestService.disagree(eq(27L), any())).thenReturn(body);
+
+        mockMvc.perform(post("/api/reports/100/fix-requests/27/disagree")
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(27))
+                .andExpect(jsonPath("$.disagrees").value(1))
+                .andExpect(jsonPath("$.userVote").value("DISAGREE"));
+    }
+
+    @Test
+    @WithMockUser(username = EMAIL)
+    void submit_returns201_andPassesFilesAndDescriptionToService() throws Exception {
+        MockMultipartFile file1 = new MockMultipartFile(
+                "files", "before.jpg", "image/jpeg", "first".getBytes());
+        MockMultipartFile file2 = new MockMultipartFile(
+                "files", "after.jpg", "image/jpeg", "second".getBytes());
+
+        FixRequestResponse body = new FixRequestResponse();
+        body.setId(55L);
+        body.setReportId(100L);
+        body.setSubmittedByUserId(3L);
+        body.setSubmittedByName("Alice");
+        body.setDescription("ramp installed");
+        body.setState(FixRequestState.OPEN);
+        body.setAgrees(0);
+        body.setDisagrees(0);
+        body.setCreatedAt(Instant.parse("2026-05-02T09:00:00Z"));
+        body.setMediaUrls(java.util.List.of("https://example.com/a.jpg"));
+
+        when(fixRequestService.submit(eq(100L), any(), eq("ramp installed"), any()))
+                .thenReturn(body);
+
+        mockMvc.perform(multipart("/api/reports/100/fix-requests")
+                        .file(file1)
+                        .file(file2)
+                        .param("description", "ramp installed")
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(55))
+                .andExpect(jsonPath("$.state").value("OPEN"));
+
+        ArgumentCaptor<MultipartFile[]> filesCaptor = ArgumentCaptor.forClass(MultipartFile[].class);
+        verify(fixRequestService).submit(eq(100L), any(), eq("ramp installed"), filesCaptor.capture());
+        assertEquals(2, filesCaptor.getValue().length);
+    }
+
+    @Test
+    @WithMockUser(username = EMAIL)
+    void submit_allowsMissingDescription() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "files", "evidence.jpg", "image/jpeg", "bytes".getBytes());
+
+        FixRequestResponse body = new FixRequestResponse();
+        body.setId(56L);
+        body.setReportId(100L);
+        body.setState(FixRequestState.OPEN);
+        body.setMediaUrls(java.util.List.of());
+
+        when(fixRequestService.submit(eq(100L), any(), isNull(), any())).thenReturn(body);
+
+        mockMvc.perform(multipart("/api/reports/100/fix-requests")
+                        .file(file)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isCreated());
+
+        verify(fixRequestService).submit(eq(100L), any(), isNull(), any());
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RegisteredUserControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RegisteredUserControllerTest.java
@@ -1,7 +1,11 @@
 package com.bounswe2026group1.backend.controller;
 
+import com.bounswe2026group1.backend.dto.LeaderboardVisibilityRequest;
+import com.bounswe2026group1.backend.dto.PointEventResponse;
 import com.bounswe2026group1.backend.dto.UpdateProfileRequest;
 import com.bounswe2026group1.backend.dto.UserProfileDTO;
+import com.bounswe2026group1.backend.model.Badge;
+import com.bounswe2026group1.backend.model.PointReason;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.service.RegisteredUserService;
 import com.bounswe2026group1.backend.service.S3MediaService;
@@ -19,7 +23,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import tools.jackson.databind.ObjectMapper;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.NoSuchElementException;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -301,5 +311,263 @@ class RegisteredUserControllerTest {
 
         verify(registeredUserService, never()).setAvatar(any(), any());
         verify(s3MediaService, never()).deleteFile(any());
+    }
+
+    // ───── GET /api/users (list all) ────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void getAll_returnsServiceList() throws Exception {
+        when(registeredUserService.getAllProfiles()).thenReturn(List.of(ownerProfile));
+
+        mockMvc.perform(get("/api/users").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(OWNER_ID));
+    }
+
+    // ───── GET /api/users/search ────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void search_returns200_andCapsPageSize() throws Exception {
+        Page<UserProfileDTO> page = new PageImpl<>(List.of(ownerProfile));
+        when(registeredUserService.searchUsers(eq("ali"), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/users/search")
+                        .param("q", "ali")
+                        .param("page", "-3")    // clamped to 0
+                        .param("size", "999")    // clamped to 50
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(OWNER_ID));
+
+        verify(registeredUserService).searchUsers(eq("ali"),
+                argThat(p -> p.getPageNumber() == 0 && p.getPageSize() == 50));
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void search_returns400WhenServiceRejectsQuery() throws Exception {
+        when(registeredUserService.searchUsers(eq(""), any(Pageable.class)))
+                .thenThrow(new IllegalArgumentException("query must not be blank"));
+
+        mockMvc.perform(get("/api/users/search")
+                        .param("q", "")
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isBadRequest());
+    }
+
+    // POST /api/users intentionally skipped: this is an "internal" endpoint that takes a raw
+    // JPA RegisteredUser entity. Jackson 3 cannot deserialize that shape cleanly (lazy relations,
+    // many enums with non-null Hibernate defaults), and the endpoint comment recommends clients
+    // use POST /auth/register instead. One line of coverage isn't worth fighting Jackson here.
+
+    // ───── DELETE /api/users/{id} ───────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void delete_returns204WhenServiceDeletes() throws Exception {
+        when(registeredUserService.delete(OWNER_ID)).thenReturn(true);
+
+        mockMvc.perform(delete("/api/users/{id}", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void delete_returns404WhenServiceReportsMissing() throws Exception {
+        when(registeredUserService.delete(404L)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/users/{id}", 404L)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNotFound());
+    }
+
+    // ───── GET /me 404 path ─────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void me_returns404WhenUserNoLongerExists() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL))
+                .thenThrow(new NoSuchElementException("user gone"));
+
+        mockMvc.perform(get("/api/users/me").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNotFound());
+    }
+
+    // ───── 404 paths for updateProfile / uploadAvatar / deleteAvatar ────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void updateProfile_returns404WhenServiceReportsMissing() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        when(registeredUserService.updateProfile(eq(OWNER_ID), any(UpdateProfileRequest.class)))
+                .thenThrow(new NoSuchElementException("gone"));
+
+        mockMvc.perform(put("/api/users/{id}/profile", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateProfileRequest(null, "bio"))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void uploadAvatar_returns404WhenServiceReportsMissing() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        when(s3MediaService.uploadFile(any())).thenReturn("https://bucket.s3.amazonaws.com/a.jpg");
+        when(registeredUserService.setAvatar(eq(OWNER_ID), any()))
+                .thenThrow(new NoSuchElementException("gone"));
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "pic.jpg", "image/jpeg", "bytes".getBytes());
+
+        mockMvc.perform(multipart("/api/users/{id}/profile/avatar", OWNER_ID).file(file)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void deleteAvatar_returns404WhenServiceReportsMissing() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        when(registeredUserService.getProfileById(OWNER_ID))
+                .thenThrow(new NoSuchElementException("gone"));
+
+        mockMvc.perform(delete("/api/users/{id}/profile/avatar", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNotFound());
+    }
+
+    // ───── GET /{id}/badges ─────────────────────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void getBadges_returns200() throws Exception {
+        when(registeredUserService.getBadges(OWNER_ID))
+                .thenReturn(List.of(Badge.TRUSTED_REPORTER, Badge.TOP_10));
+
+        mockMvc.perform(get("/api/users/{id}/badges", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void getBadges_returns404WhenUserMissing() throws Exception {
+        when(registeredUserService.getBadges(404L))
+                .thenThrow(new NoSuchElementException("no user"));
+
+        mockMvc.perform(get("/api/users/{id}/badges", 404L)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNotFound());
+    }
+
+    // ───── GET /{id}/points/history ─────────────────────────────────────────
+
+    private PointEventResponse pointEvent(long id, int delta) {
+        return new PointEventResponse(id, delta, PointReason.REPORT_SUBMIT, null,
+                Instant.parse("2026-05-01T10:00:00Z"));
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void getPointsHistory_ownerReceivesLedger() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        Page<PointEventResponse> page = new PageImpl<>(List.of(pointEvent(1L, 10)));
+        when(registeredUserService.listPointEvents(eq(OWNER_ID), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/users/{id}/points/history", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].delta").value(10));
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void getPointsHistory_nonOwnerNonAdminReturns403() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+
+        mockMvc.perform(get("/api/users/{id}/points/history", OTHER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isForbidden());
+
+        verify(registeredUserService, never()).listPointEvents(any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = "admin@test.com")
+    void getPointsHistory_adminCanViewOthers() throws Exception {
+        UserProfileDTO admin = UserProfileDTO.builder()
+                .id(9L).name("Admin").email("admin@test.com").role("ADMIN")
+                .contributionStats(UserProfileDTO.ContributionStatsDTO.builder().build())
+                .build();
+        when(registeredUserService.getProfileByEmail("admin@test.com")).thenReturn(admin);
+        Page<PointEventResponse> page = new PageImpl<>(List.of(pointEvent(7L, -5)));
+        when(registeredUserService.listPointEvents(eq(OTHER_ID), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/users/{id}/points/history", OTHER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].delta").value(-5));
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void getPointsHistory_returns404WhenLedgerLookupMisses() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        when(registeredUserService.listPointEvents(eq(OWNER_ID), any(Pageable.class)))
+                .thenThrow(new NoSuchElementException("user has no ledger"));
+
+        mockMvc.perform(get("/api/users/{id}/points/history", OWNER_ID)
+                        .header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNotFound());
+    }
+
+    // ───── PATCH /me/leaderboard-visibility ─────────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void setLeaderboardVisibility_authenticated_returns200() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL)).thenReturn(ownerProfile);
+        UserProfileDTO updated = UserProfileDTO.builder()
+                .id(OWNER_ID).name("Owner").email(OWNER_EMAIL).role("USER")
+                .contributionStats(UserProfileDTO.ContributionStatsDTO.builder().build())
+                .leaderboardHidden(true)
+                .build();
+        when(registeredUserService.setLeaderboardHidden(OWNER_ID, true)).thenReturn(updated);
+
+        mockMvc.perform(patch("/api/users/me/leaderboard-visibility")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LeaderboardVisibilityRequest(true))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.leaderboardHidden").value(true));
+    }
+
+    @Test
+    void setLeaderboardVisibility_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(patch("/api/users/me/leaderboard-visibility")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LeaderboardVisibilityRequest(false))))
+                .andExpect(status().isUnauthorized());
+
+        verify(registeredUserService, never()).setLeaderboardHidden(any(), anyBoolean());
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    void setLeaderboardVisibility_returns404WhenUserGone() throws Exception {
+        when(registeredUserService.getProfileByEmail(OWNER_EMAIL))
+                .thenThrow(new NoSuchElementException("user gone"));
+
+        mockMvc.perform(patch("/api/users/me/leaderboard-visibility")
+                        .header("Mapcess-Key", validApiKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LeaderboardVisibilityRequest(true))))
+                .andExpect(status().isNotFound());
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/ReportControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/ReportControllerTest.java
@@ -1,7 +1,9 @@
 package com.bounswe2026group1.backend.controller;
 
+import com.bounswe2026group1.backend.dto.CreateReportRequest;
 import com.bounswe2026group1.backend.dto.ReportFeedQuery;
 import com.bounswe2026group1.backend.dto.ReportResponse;
+import com.bounswe2026group1.backend.dto.UpdateReportRequest;
 import com.bounswe2026group1.backend.model.ReportEnvironment;
 import com.bounswe2026group1.backend.model.ReportType;
 import com.bounswe2026group1.backend.service.ReportService;
@@ -14,10 +16,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
@@ -84,5 +91,116 @@ class ReportControllerTest {
 
         assertEquals(expected, result);
         verify(reportService).feed(null, null, null, null, null, pageable, null);
+    }
+
+    @Test
+    void getAll_passesPrincipalEmailToService() {
+        ReportResponse one = new ReportResponse();
+        List<ReportResponse> expected = List.of(one);
+        when(reportService.getAll("caller@example.com")).thenReturn(expected);
+
+        List<ReportResponse> result = controller.getAll("caller@example.com");
+
+        assertSame(expected, result);
+        verify(reportService).getAll("caller@example.com");
+    }
+
+    @Test
+    void getAll_passesNullForAnonymousCaller() {
+        when(reportService.getAll(null)).thenReturn(List.of());
+
+        List<ReportResponse> result = controller.getAll(null);
+
+        assertEquals(List.of(), result);
+        verify(reportService).getAll(null);
+    }
+
+    @Test
+    void getById_returns200WhenServiceFindsReport() {
+        ReportResponse found = new ReportResponse();
+        when(reportService.getById(99L, "u@example.com")).thenReturn(Optional.of(found));
+
+        ResponseEntity<ReportResponse> result = controller.getById(99L, "u@example.com");
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertSame(found, result.getBody());
+    }
+
+    @Test
+    void getById_returns404WhenServiceReturnsEmpty() {
+        when(reportService.getById(404L, null)).thenReturn(Optional.empty());
+
+        ResponseEntity<ReportResponse> result = controller.getById(404L, null);
+
+        assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+        assertNull(result.getBody());
+    }
+
+    @Test
+    void getByUserId_passesIdToService() {
+        ReportResponse one = new ReportResponse();
+        when(reportService.getByUserId(42L)).thenReturn(List.of(one));
+
+        List<ReportResponse> result = controller.getByUserId(42L);
+
+        assertEquals(List.of(one), result);
+        verify(reportService).getByUserId(42L);
+    }
+
+    @Test
+    void create_returns201AndDelegatesToService() {
+        CreateReportRequest request = new CreateReportRequest();
+        ReportResponse created = new ReportResponse();
+        when(reportService.create(request)).thenReturn(created);
+
+        ResponseEntity<ReportResponse> result = controller.create(request);
+
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+        assertSame(created, result.getBody());
+        verify(reportService).create(request);
+    }
+
+    @Test
+    void update_returns200WithUpdatedReport() {
+        UpdateReportRequest request = new UpdateReportRequest();
+        ReportResponse updated = new ReportResponse();
+        when(reportService.update(7L, request, "owner@example.com")).thenReturn(updated);
+
+        ResponseEntity<ReportResponse> result = controller.update(7L, request, "owner@example.com");
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertSame(updated, result.getBody());
+        verify(reportService).update(7L, request, "owner@example.com");
+    }
+
+    @Test
+    void delete_delegatesToService_returnsVoid() {
+        controller.delete(13L, "owner@example.com");
+
+        verify(reportService).delete(13L, "owner@example.com");
+    }
+
+    @Test
+    void verifyReport_returnsServiceResultWith200() {
+        ReportResponse afterVote = new ReportResponse();
+        when(reportService.verifyReport(5L, "voter@example.com")).thenReturn(afterVote);
+
+        ResponseEntity<ReportResponse> result = controller.verifyReport(5L, "voter@example.com");
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertSame(afterVote, result.getBody());
+        verify(reportService).verifyReport(5L, "voter@example.com");
+    }
+
+    @Test
+    void unverifyReport_returnsServiceResultWith200() {
+        ReportResponse afterVote = new ReportResponse();
+        when(reportService.unverifyReport(5L, "voter@example.com")).thenReturn(afterVote);
+
+        ResponseEntity<ReportResponse> result = controller.unverifyReport(5L, "voter@example.com");
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertSame(afterVote, result.getBody());
+        verify(reportService).unverifyReport(5L, "voter@example.com");
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesControllerUnitTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesControllerUnitTest.java
@@ -1,0 +1,107 @@
+package com.bounswe2026group1.backend.controller;
+
+import com.bounswe2026group1.backend.dto.routing.RoutingPreferencesResponse;
+import com.bounswe2026group1.backend.dto.routing.UpdateRoutingPreferencesRequest;
+import com.bounswe2026group1.backend.service.RoutingPreferencesService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Direct unit tests for {@link RoutingPreferencesController}'s in-controller auth fallback.
+ * The full-context integration test ({@link RoutingPreferencesIntegrationTest}) cannot
+ * exercise these branches because Spring Security's filter chain returns 401 before the
+ * handler runs.
+ */
+@ExtendWith(MockitoExtension.class)
+class RoutingPreferencesControllerUnitTest {
+
+    @Mock
+    private RoutingPreferencesService routingPreferencesService;
+
+    @InjectMocks
+    private RoutingPreferencesController controller;
+
+    @AfterEach
+    void clearAuth() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void get_authenticatedUser_returnsServiceResponse() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        "ada@example.com", "creds", AuthorityUtils.createAuthorityList("ROLE_USER")));
+
+        RoutingPreferencesResponse expected = new RoutingPreferencesResponse();
+        when(routingPreferencesService.getForEmail("ada@example.com")).thenReturn(expected);
+
+        ResponseEntity<?> result = controller.get();
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertSame(expected, result.getBody());
+    }
+
+    @Test
+    void get_anonymousAuth_returns401_andSkipsService() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new AnonymousAuthenticationToken(
+                        "anon", "anonymousUser",
+                        AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+        ResponseEntity<?> result = controller.get();
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
+        assertEquals("Authentication required.", result.getBody());
+        verify(routingPreferencesService, never()).getForEmail(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void get_noAuth_returns401() {
+        ResponseEntity<?> result = controller.get();
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
+        assertEquals("Authentication required.", result.getBody());
+    }
+
+    @Test
+    void put_authenticatedUser_delegatesToServiceWithEmail() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        "ada@example.com", "creds", AuthorityUtils.createAuthorityList("ROLE_USER")));
+
+        UpdateRoutingPreferencesRequest request = new UpdateRoutingPreferencesRequest();
+        RoutingPreferencesResponse expected = new RoutingPreferencesResponse();
+        when(routingPreferencesService.update("ada@example.com", request)).thenReturn(expected);
+
+        ResponseEntity<?> result = controller.put(request);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertSame(expected, result.getBody());
+    }
+
+    @Test
+    void put_noAuth_returns401_andSkipsService() {
+        ResponseEntity<?> result = controller.put(new UpdateRoutingPreferencesRequest());
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
+        assertEquals("Authentication required.", result.getBody());
+        verify(routingPreferencesService, never())
+                .update(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/dto/LeaderboardVisibilityRequestTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/dto/LeaderboardVisibilityRequestTest.java
@@ -1,0 +1,32 @@
+package com.bounswe2026group1.backend.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LeaderboardVisibilityRequestTest {
+
+    @Test
+    void recordExposesValueViaAccessor() {
+        LeaderboardVisibilityRequest hidden = new LeaderboardVisibilityRequest(true);
+        LeaderboardVisibilityRequest visible = new LeaderboardVisibilityRequest(false);
+
+        assertTrue(hidden.leaderboardHidden());
+        assertEquals(Boolean.FALSE, visible.leaderboardHidden());
+    }
+
+    @Test
+    void recordEqualityIsValueBased() {
+        assertEquals(new LeaderboardVisibilityRequest(true), new LeaderboardVisibilityRequest(true));
+        assertNotEquals(new LeaderboardVisibilityRequest(true), new LeaderboardVisibilityRequest(false));
+    }
+
+    @Test
+    void recordAcceptsNullForOptionalConstruction() {
+        LeaderboardVisibilityRequest blank = new LeaderboardVisibilityRequest(null);
+        assertNull(blank.leaderboardHidden());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/dto/PointEventResponseTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/dto/PointEventResponseTest.java
@@ -1,0 +1,43 @@
+package com.bounswe2026group1.backend.dto;
+
+import com.bounswe2026group1.backend.model.PointEvent;
+import com.bounswe2026group1.backend.model.PointReason;
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class PointEventResponseTest {
+
+    @Test
+    void fromEntity_copiesAllFields() {
+        Instant when = Instant.parse("2026-01-15T10:00:00Z");
+        PointEvent event = new PointEvent(new RegisteredUser(), -5, PointReason.VOTE_OPPOSED, 1024L);
+        ReflectionTestUtils.setField(event, "id", 7001L);
+        event.setCreatedAt(when);
+
+        PointEventResponse dto = PointEventResponse.fromEntity(event);
+
+        assertEquals(7001L, dto.id());
+        assertEquals(-5, dto.delta());
+        assertEquals(PointReason.VOTE_OPPOSED, dto.reason());
+        assertEquals(1024L, dto.relatedEntityId());
+        assertEquals(when, dto.createdAt());
+    }
+
+    @Test
+    void fromEntity_passesThroughNullRelatedEntityId() {
+        PointEvent event = new PointEvent(new RegisteredUser(), 10, PointReason.REPORT_SUBMIT, null);
+        event.setCreatedAt(Instant.now());
+
+        PointEventResponse dto = PointEventResponse.fromEntity(event);
+
+        assertNull(dto.relatedEntityId());
+        assertEquals(10, dto.delta());
+        assertEquals(PointReason.REPORT_SUBMIT, dto.reason());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/dto/admin/AdminValidationResponseTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/dto/admin/AdminValidationResponseTest.java
@@ -1,0 +1,34 @@
+package com.bounswe2026group1.backend.dto.admin;
+
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.model.ReportVerification;
+import com.bounswe2026group1.backend.model.VoteType;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AdminValidationResponseTest {
+
+    @Test
+    void fromEntity_copiesIdsNameAndVoteType() {
+        RegisteredUser user = new RegisteredUser();
+        ReflectionTestUtils.setField(user, "id", 42L);
+        user.setName("Alice Example");
+
+        Report report = new Report();
+        ReflectionTestUtils.setField(report, "reportId", 1024L);
+
+        ReportVerification rv = new ReportVerification(user, report, VoteType.AGREE);
+        ReflectionTestUtils.setField(rv, "id", 7001L);
+
+        AdminValidationResponse dto = AdminValidationResponse.fromEntity(rv);
+
+        assertEquals(7001L, dto.getId());
+        assertEquals(42L, dto.getUserId());
+        assertEquals("Alice Example", dto.getUserName());
+        assertEquals(1024L, dto.getReportId());
+        assertEquals(VoteType.AGREE, dto.getVoteType());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/dto/error/RoutingErrorResponseTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/dto/error/RoutingErrorResponseTest.java
@@ -1,0 +1,27 @@
+package com.bounswe2026group1.backend.dto.error;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class RoutingErrorResponseTest {
+
+    @Test
+    void recordExposesErrorAndMessageViaAccessors() {
+        RoutingErrorResponse r = new RoutingErrorResponse("routing_error", "could not compute route");
+
+        assertEquals("routing_error", r.error());
+        assertEquals("could not compute route", r.message());
+    }
+
+    @Test
+    void recordEqualityIsValueBased() {
+        assertEquals(
+                new RoutingErrorResponse("a", "b"),
+                new RoutingErrorResponse("a", "b"));
+        assertNotEquals(
+                new RoutingErrorResponse("a", "b"),
+                new RoutingErrorResponse("a", "c"));
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/exception/GlobalExceptionHandlersTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/exception/GlobalExceptionHandlersTest.java
@@ -1,0 +1,49 @@
+package com.bounswe2026group1.backend.exception;
+
+import com.bounswe2026group1.backend.dto.error.RoutingErrorResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class GlobalExceptionHandlersTest {
+
+    private final GlobalExceptionHandlers handlers = new GlobalExceptionHandlers();
+
+    @Test
+    void handleRouting_returnsStatusFromExceptionAndStableErrorCode() {
+        RoutingException ex = new RoutingException(HttpStatus.BAD_GATEWAY, "ors unreachable");
+
+        ResponseEntity<RoutingErrorResponse> response = handlers.handleRouting(ex);
+
+        assertEquals(HttpStatus.BAD_GATEWAY, response.getStatusCode());
+        RoutingErrorResponse body = response.getBody();
+        assertNotNull(body);
+        assertEquals("routing_error", body.error());
+        assertEquals("ors unreachable", body.message());
+    }
+
+    @Test
+    void handleRouting_defaults500ForBareMessageException() {
+        RoutingException ex = new RoutingException("unexpected");
+
+        ResponseEntity<RoutingErrorResponse> response = handlers.handleRouting(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("unexpected", response.getBody().message());
+    }
+
+    @Test
+    void handleMeasurementValidation_returns400WithErrorBody() {
+        MeasurementValidationException ex = new MeasurementValidationException("ramp height too steep");
+
+        ResponseEntity<Map<String, String>> response = handlers.handleMeasurementValidation(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(Map.of("error", "ramp height too steep"), response.getBody());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/exception/RoutingExceptionTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/exception/RoutingExceptionTest.java
@@ -1,0 +1,48 @@
+package com.bounswe2026group1.backend.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class RoutingExceptionTest {
+
+    @Test
+    void statusMessageConstructor_carriesBothFields() {
+        RoutingException ex = new RoutingException(HttpStatus.BAD_REQUEST, "bad input");
+
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatus());
+        assertEquals("bad input", ex.getMessage());
+        assertNull(ex.getCause());
+    }
+
+    @Test
+    void statusMessageCauseConstructor_preservesCause() {
+        Throwable cause = new IllegalStateException("upstream");
+        RoutingException ex = new RoutingException(HttpStatus.SERVICE_UNAVAILABLE, "ors down", cause);
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, ex.getStatus());
+        assertEquals("ors down", ex.getMessage());
+        assertSame(cause, ex.getCause());
+    }
+
+    @Test
+    void messageOnlyConstructor_defaultsTo500() {
+        RoutingException ex = new RoutingException("boom");
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
+        assertEquals("boom", ex.getMessage());
+    }
+
+    @Test
+    void messageCauseConstructor_defaultsTo500_andPreservesCause() {
+        Throwable cause = new RuntimeException("root");
+        RoutingException ex = new RoutingException("wrapped", cause);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
+        assertEquals("wrapped", ex.getMessage());
+        assertSame(cause, ex.getCause());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/model/SnapTypeTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/model/SnapTypeTest.java
@@ -1,0 +1,19 @@
+package com.bounswe2026group1.backend.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SnapTypeTest {
+
+    @Test
+    void valuesReturnsSingleSupportedKind() {
+        assertArrayEquals(new SnapType[]{SnapType.STAIR}, SnapType.values());
+    }
+
+    @Test
+    void valueOfRoundTripsByName() {
+        assertEquals(SnapType.STAIR, SnapType.valueOf("STAIR"));
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/repository/ReportRepositoryImplTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/repository/ReportRepositoryImplTest.java
@@ -1,0 +1,236 @@
+package com.bounswe2026group1.backend.repository;
+
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.model.ReportEnvironment;
+import com.bounswe2026group1.backend.model.ReportType;
+import com.bounswe2026group1.backend.model.UserRole;
+import com.bounswe2026group1.backend.support.AbstractPostgisIntegrationTest;
+import com.bounswe2026group1.backend.util.GeoUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
+
+    // Istanbul center as the reference point for radius queries
+    private static final double REF_LAT = 41.015137;
+    private static final double REF_LON = 28.979530;
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Autowired
+    private RegisteredUserRepository userRepository;
+
+    @Test
+    void findFeedWithinRadius_returnsOnlyReportsInsideRadius_orderedByDistance() {
+        RegisteredUser user = persistUser("ada-feed@test.com");
+
+        // ~30m east of reference — well inside any sane radius
+        Report near = persistReport(user, REF_LAT, REF_LON + 0.0003,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        // ~110m east
+        Report mid = persistReport(user, REF_LAT, REF_LON + 0.0010,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        // ~5km east — outside a 1km radius
+        Report far = persistReport(user, REF_LAT, REF_LON + 0.05,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+
+        Page<Report> page = reportRepository.findFeedWithinRadius(
+                null, null, REF_LAT, REF_LON, 1.0, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(ids.contains(near.getReportId()));
+        assertTrue(ids.contains(mid.getReportId()));
+        assertFalse(ids.contains(far.getReportId()), "report outside radius must not appear");
+        assertEquals(near.getReportId(), ids.get(0), "nearest report must come first");
+        assertEquals(2L, page.getTotalElements());
+    }
+
+    @Test
+    void findFeedWithinRadius_filtersByReportType() {
+        RegisteredUser user = persistUser("type-filter@test.com");
+        Report obstacle = persistReport(user, REF_LAT, REF_LON + 0.0003,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        Report feature = persistReport(user, REF_LAT, REF_LON + 0.0004,
+                ReportType.FEATURE, ReportEnvironment.OUTDOOR);
+
+        Page<Report> obstacles = reportRepository.findFeedWithinRadius(
+                ReportType.OBSTACLE, null, REF_LAT, REF_LON, 1.0, PageRequest.of(0, 10));
+
+        List<Long> ids = obstacles.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(ids.contains(obstacle.getReportId()));
+        assertFalse(ids.contains(feature.getReportId()));
+        assertEquals(1L, obstacles.getTotalElements());
+    }
+
+    @Test
+    void findFeedWithinRadius_filtersByEnvironment() {
+        RegisteredUser user = persistUser("env-filter@test.com");
+        Report indoor = persistReport(user, REF_LAT, REF_LON + 0.0003,
+                ReportType.OBSTACLE, ReportEnvironment.INDOOR);
+        Report outdoor = persistReport(user, REF_LAT, REF_LON + 0.0004,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+
+        Page<Report> indoorPage = reportRepository.findFeedWithinRadius(
+                null, ReportEnvironment.INDOOR, REF_LAT, REF_LON, 1.0, PageRequest.of(0, 10));
+
+        List<Long> ids = indoorPage.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(ids.contains(indoor.getReportId()));
+        assertFalse(ids.contains(outdoor.getReportId()));
+        assertEquals(1L, indoorPage.getTotalElements());
+    }
+
+    @Test
+    void findFeedWithinRadius_combinesTypeAndEnvironmentFilters() {
+        RegisteredUser user = persistUser("combo-filter@test.com");
+        Report match = persistReport(user, REF_LAT, REF_LON + 0.0003,
+                ReportType.FEATURE, ReportEnvironment.INDOOR);
+        Report wrongType = persistReport(user, REF_LAT, REF_LON + 0.0004,
+                ReportType.OBSTACLE, ReportEnvironment.INDOOR);
+        Report wrongEnv = persistReport(user, REF_LAT, REF_LON + 0.0005,
+                ReportType.FEATURE, ReportEnvironment.OUTDOOR);
+
+        Page<Report> page = reportRepository.findFeedWithinRadius(
+                ReportType.FEATURE, ReportEnvironment.INDOOR,
+                REF_LAT, REF_LON, 1.0, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(ids.contains(match.getReportId()));
+        assertFalse(ids.contains(wrongType.getReportId()));
+        assertFalse(ids.contains(wrongEnv.getReportId()));
+        assertEquals(1L, page.getTotalElements());
+    }
+
+    @Test
+    void findFeedWithinRadius_paginatesWithCorrectTotal() {
+        RegisteredUser user = persistUser("page-radius@test.com");
+        // Persist 3 reports at increasing distances
+        Report r1 = persistReport(user, REF_LAT, REF_LON + 0.0001,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        Report r2 = persistReport(user, REF_LAT, REF_LON + 0.0002,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        Report r3 = persistReport(user, REF_LAT, REF_LON + 0.0003,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+
+        Pageable pageable = PageRequest.of(0, 2);
+        Page<Report> first = reportRepository.findFeedWithinRadius(
+                null, null, REF_LAT, REF_LON, 1.0, pageable);
+
+        assertEquals(2, first.getContent().size());
+        assertEquals(3L, first.getTotalElements(), "total must reflect full match set, not page size");
+        // ordered by distance ASC
+        assertEquals(r1.getReportId(), first.getContent().get(0).getReportId());
+        assertEquals(r2.getReportId(), first.getContent().get(1).getReportId());
+
+        Page<Report> second = reportRepository.findFeedWithinRadius(
+                null, null, REF_LAT, REF_LON, 1.0, PageRequest.of(1, 2));
+        assertEquals(1, second.getContent().size());
+        assertEquals(r3.getReportId(), second.getContent().get(0).getReportId());
+    }
+
+    @Test
+    void findFeedRecent_returnsAllReports_orderedByPublishDateDesc() {
+        RegisteredUser user = persistUser("recent-order@test.com");
+        Report older = persistReportWithPublishDate(user,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR,
+                Instant.now().minusSeconds(3600));
+        Report newer = persistReportWithPublishDate(user,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR,
+                Instant.now());
+
+        Page<Report> page = reportRepository.findFeedRecent(null, null, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertEquals(newer.getReportId(), ids.get(0), "newer report should come first");
+        assertEquals(older.getReportId(), ids.get(1));
+    }
+
+    @Test
+    void findFeedRecent_filtersByReportType() {
+        RegisteredUser user = persistUser("recent-type@test.com");
+        Report obstacle = persistReport(user, REF_LAT, REF_LON,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        Report feature = persistReport(user, REF_LAT, REF_LON,
+                ReportType.FEATURE, ReportEnvironment.OUTDOOR);
+
+        Page<Report> page = reportRepository.findFeedRecent(
+                ReportType.FEATURE, null, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(ids.contains(feature.getReportId()));
+        assertFalse(ids.contains(obstacle.getReportId()));
+        assertEquals(1L, page.getTotalElements());
+    }
+
+    @Test
+    void findFeedRecent_filtersByEnvironment() {
+        RegisteredUser user = persistUser("recent-env@test.com");
+        Report indoor = persistReport(user, REF_LAT, REF_LON,
+                ReportType.OBSTACLE, ReportEnvironment.INDOOR);
+        Report outdoor = persistReport(user, REF_LAT, REF_LON,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+
+        Page<Report> page = reportRepository.findFeedRecent(
+                null, ReportEnvironment.OUTDOOR, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(ids.contains(outdoor.getReportId()));
+        assertFalse(ids.contains(indoor.getReportId()));
+        assertEquals(1L, page.getTotalElements());
+    }
+
+    @Test
+    void findFeedRecent_paginatesWithCorrectTotal() {
+        RegisteredUser user = persistUser("recent-page@test.com");
+        for (int i = 0; i < 3; i++) {
+            persistReportWithPublishDate(user,
+                    ReportType.OBSTACLE, ReportEnvironment.OUTDOOR,
+                    Instant.now().minusSeconds(i * 60L));
+        }
+
+        Page<Report> first = reportRepository.findFeedRecent(null, null, PageRequest.of(0, 2));
+        assertEquals(2, first.getContent().size());
+        assertEquals(3L, first.getTotalElements());
+
+        Page<Report> second = reportRepository.findFeedRecent(null, null, PageRequest.of(1, 2));
+        assertEquals(1, second.getContent().size());
+    }
+
+    private RegisteredUser persistUser(String email) {
+        RegisteredUser u = new RegisteredUser();
+        u.setName("Test");
+        u.setEmail(email);
+        u.setPassword("hashedPassword");
+        u.setRole(UserRole.USER);
+        return userRepository.save(u);
+    }
+
+    private Report persistReport(RegisteredUser user, double lat, double lon,
+                                 ReportType type, ReportEnvironment env) {
+        Report r = new Report(user, GeoUtils.point4326(lat, lon),
+                "test report", type, env);
+        return reportRepository.save(r);
+    }
+
+    private Report persistReportWithPublishDate(RegisteredUser user,
+                                                ReportType type, ReportEnvironment env,
+                                                Instant publishDate) {
+        Report r = new Report(user, GeoUtils.point4326(REF_LAT, REF_LON),
+                "test report", type, env);
+        r.setPublishDate(publishDate);
+        return reportRepository.save(r);
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/AdminReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/AdminReportServiceTest.java
@@ -9,9 +9,15 @@ import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.ReportType;
 import com.bounswe2026group1.backend.repository.ReportRepository;
 import com.bounswe2026group1.backend.util.GeoUtils;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -22,11 +28,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -98,5 +107,119 @@ class AdminReportServiceTest {
         verify(s3MediaService).deleteFile("key/photo.jpg");
         verify(reportRepository).delete(report);
         verify(publicSseService).broadcastReportDeleted(7L);
+    }
+
+    @Test
+    void deleteReport_throwsWhenMissing() {
+        when(reportRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThrows(ResponseStatusException.class,
+                () -> adminReportService.deleteReport(404L));
+
+        verify(s3MediaService, never()).deleteFile(any());
+        verify(publicSseService, never()).broadcastReportDeleted(any());
+    }
+
+    @Test
+    void deleteReport_withMultipleMedia_deletesEach() {
+        Media a = new Media();
+        a.setFilePath("key/a.jpg");
+        Media b = new Media();
+        b.setFilePath("key/b.jpg");
+        report.setMediaList(List.of(a, b));
+
+        when(reportRepository.findById(7L)).thenReturn(Optional.of(report));
+
+        adminReportService.deleteReport(7L);
+
+        verify(s3MediaService).deleteFile("key/a.jpg");
+        verify(s3MediaService).deleteFile("key/b.jpg");
+    }
+
+    // ───── Specification (buildSpec) branch coverage ────────────────────────
+    // The filter lambda only executes when JPA evaluates the Specification.
+    // Capture the spec passed to repository.findAll, then invoke its toPredicate
+    // against Criteria mocks to exercise every if-branch.
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    void buildSpec_appliesEveryFilterWhenAllSupplied() {
+        Pageable p = PageRequest.of(0, 10);
+        when(reportRepository.findAll(any(Specification.class), eq(p)))
+                .thenReturn(new PageImpl<>(List.of(report)));
+
+        Instant from = Instant.parse("2026-01-01T00:00:00Z");
+        Instant to   = Instant.parse("2026-12-31T23:59:59Z");
+        adminReportService.listReports(
+                ReportStatus.PENDING, 42L, ReportEnvironment.INDOOR, ReportType.OBSTACLE,
+                from, to, p);
+
+        ArgumentCaptor<Specification<Report>> captor =
+                ArgumentCaptor.forClass(Specification.class);
+        verify(reportRepository).findAll(captor.capture(), eq(p));
+
+        Root root = mock(Root.class);
+        CriteriaQuery<?> query = mock(CriteriaQuery.class);
+        CriteriaBuilder cb = mock(CriteriaBuilder.class);
+
+        // One sentinel path is enough — the production code only uses these as opaque
+        // arguments to the cb.* matchers (also mocked), so we don't need per-field paths.
+        Path categoryPath = mock(Path.class);
+        Path leaf = mock(Path.class);
+
+        when(root.get(anyString())).thenReturn(leaf);
+        when(root.get("category")).thenReturn(categoryPath);
+        when(categoryPath.get(anyString())).thenReturn(leaf);
+
+        Predicate p1 = mock(Predicate.class);
+        // Force the equal(Expression<?>, Object) overload — production passes
+        // an enum/Long as the second arg, so the (Expression, Expression) overload
+        // would silently swallow the matcher.
+        when(cb.equal(any(jakarta.persistence.criteria.Expression.class), any(Object.class))).thenReturn(p1);
+        when(cb.greaterThanOrEqualTo(any(jakarta.persistence.criteria.Expression.class), any(Instant.class))).thenReturn(p1);
+        when(cb.lessThanOrEqualTo(any(jakarta.persistence.criteria.Expression.class), any(Instant.class))).thenReturn(p1);
+        Predicate combined = mock(Predicate.class);
+        when(cb.and(any(Predicate[].class))).thenReturn(combined);
+
+        Predicate result = captor.getValue().toPredicate(root, query, cb);
+
+        assertEquals(combined, result);
+        // All four equality filters fire
+        verify(cb).equal((jakarta.persistence.criteria.Expression<?>) leaf, (Object) ReportStatus.PENDING);
+        verify(cb).equal((jakarta.persistence.criteria.Expression<?>) leaf, (Object) 42L);
+        verify(cb).equal((jakarta.persistence.criteria.Expression<?>) leaf, (Object) ReportEnvironment.INDOOR);
+        verify(cb).equal((jakarta.persistence.criteria.Expression<?>) leaf, (Object) ReportType.OBSTACLE);
+        // Both date bounds fire
+        verify(cb).greaterThanOrEqualTo(leaf, from);
+        verify(cb).lessThanOrEqualTo(leaf, to);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    void buildSpec_appliesNoFiltersWhenAllNull() {
+        Pageable p = PageRequest.of(0, 10);
+        when(reportRepository.findAll(any(Specification.class), eq(p)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        adminReportService.listReports(null, null, null, null, null, null, p);
+
+        ArgumentCaptor<Specification<Report>> captor =
+                ArgumentCaptor.forClass(Specification.class);
+        verify(reportRepository).findAll(captor.capture(), eq(p));
+
+        Root root = mock(Root.class);
+        CriteriaQuery<?> query = mock(CriteriaQuery.class);
+        CriteriaBuilder cb = mock(CriteriaBuilder.class);
+        Predicate empty = mock(Predicate.class);
+        when(cb.and(any(Predicate[].class))).thenReturn(empty);
+
+        Predicate result = captor.getValue().toPredicate(root, query, cb);
+
+        assertEquals(empty, result);
+        // No filter predicates were built
+        verify(cb, never()).equal(any(jakarta.persistence.criteria.Expression.class), any(Object.class));
+        verify(cb, never()).greaterThanOrEqualTo(any(jakarta.persistence.criteria.Expression.class), any(Instant.class));
+        verify(cb, never()).lessThanOrEqualTo(any(jakarta.persistence.criteria.Expression.class), any(Instant.class));
+        verify(root, never()).get(any(String.class));
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/OrsRoutingClientTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/OrsRoutingClientTest.java
@@ -149,4 +149,233 @@ class OrsRoutingClientTest {
                 }
                 """;
     }
+
+    // ───── Validation branches ──────────────────────────────────────────────
+
+    @Test
+    void fetchDirections_nullStart_throwsRoutingException() {
+        RoutingException ex = assertThrows(RoutingException.class,
+                () -> client.fetchDirections(null, END, TravelMode.WALKING, null));
+        org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("start"));
+    }
+
+    @Test
+    void fetchDirections_nullEnd_throwsRoutingException() {
+        RoutingException ex = assertThrows(RoutingException.class,
+                () -> client.fetchDirections(START, null, TravelMode.WALKING, null));
+        org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("end"));
+    }
+
+    @Test
+    void fetchDirections_nanCoordinates_throwsRoutingException() {
+        Location bad = new Location(Double.NaN, 29.0);
+        assertThrows(RoutingException.class,
+                () -> client.fetchDirections(bad, END, TravelMode.WALKING, null));
+    }
+
+    @Test
+    void fetchDirections_infiniteCoordinates_throwsRoutingException() {
+        Location bad = new Location(41.0, Double.POSITIVE_INFINITY);
+        assertThrows(RoutingException.class,
+                () -> client.fetchDirections(bad, END, TravelMode.WALKING, null));
+    }
+
+    @Test
+    void fetchDirections_longitudeOutOfRange_throwsRoutingException() {
+        Location bad = new Location(41.0, 181.0);
+        assertThrows(RoutingException.class,
+                () -> client.fetchDirections(bad, END, TravelMode.WALKING, null));
+    }
+
+    @Test
+    void mapProfile_nullThrowsRoutingException() {
+        assertThrows(RoutingException.class, () -> client.mapProfile(null));
+    }
+
+    @Test
+    void fetchDirections_blankApiKey_emptyString_throwsRoutingException() {
+        OrsRoutingClient noKeyClient = new OrsRoutingClient(objectMapper, orsHttpClient, "");
+        assertThrows(RoutingException.class,
+                () -> noKeyClient.fetchDirections(START, END, TravelMode.WALKING, null));
+    }
+
+    @Test
+    void fetchDirections_nullApiKey_throwsRoutingException() {
+        OrsRoutingClient noKeyClient = new OrsRoutingClient(objectMapper, orsHttpClient, null);
+        assertThrows(RoutingException.class,
+                () -> noKeyClient.fetchDirections(START, END, TravelMode.WALKING, null));
+    }
+
+    // ───── HTTP failure paths ───────────────────────────────────────────────
+
+    @Test
+    void fetchDirections_wrapsResourceAccessExceptionAsRoutingException() {
+        when(orsHttpClient.postDirections(anyString(), anyString()))
+                .thenThrow(new org.springframework.web.client.ResourceAccessException("timeout"));
+
+        RoutingException ex = assertThrows(RoutingException.class,
+                () -> client.fetchDirections(START, END, TravelMode.WALKING, null));
+        org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("timeout") ||
+                ex.getMessage().contains("connection"));
+    }
+
+    @Test
+    void fetchDirections_wrapsGenericRestClientExceptionAsRoutingException() {
+        when(orsHttpClient.postDirections(anyString(), anyString()))
+                .thenThrow(new org.springframework.web.client.RestClientException("HTTP 500"));
+
+        assertThrows(RoutingException.class,
+                () -> client.fetchDirections(START, END, TravelMode.WALKING, null));
+    }
+
+    // ───── Response-parsing branches ────────────────────────────────────────
+
+    @Test
+    void fetchDirections_errorPayloadInResponse_throwsRoutingException() {
+        String errorJson = """
+                {"error": {"message": "no route found"}}
+                """;
+        when(orsHttpClient.postDirections(anyString(), anyString())).thenReturn(errorJson);
+
+        RoutingException ex = assertThrows(RoutingException.class,
+                () -> client.fetchDirections(START, END, TravelMode.WALKING, null));
+        org.junit.jupiter.api.Assertions.assertTrue(ex.getMessage().contains("no route found"));
+    }
+
+    @Test
+    void fetchDirections_emptyRoutesArray_throwsRoutingException() {
+        when(orsHttpClient.postDirections(anyString(), anyString()))
+                .thenReturn("""
+                        {"routes": []}
+                        """);
+
+        assertThrows(RoutingException.class,
+                () -> client.fetchDirections(START, END, TravelMode.WALKING, null));
+    }
+
+    @Test
+    void fetchDirections_missingRoutesField_throwsRoutingException() {
+        when(orsHttpClient.postDirections(anyString(), anyString()))
+                .thenReturn("{}");
+
+        assertThrows(RoutingException.class,
+                () -> client.fetchDirections(START, END, TravelMode.WALKING, null));
+    }
+
+    @Test
+    void fetchDirections_malformedJson_throwsRoutingException() {
+        when(orsHttpClient.postDirections(anyString(), anyString())).thenReturn("not json");
+
+        assertThrows(RoutingException.class,
+                () -> client.fetchDirections(START, END, TravelMode.WALKING, null));
+    }
+
+    @Test
+    void fetchDirections_geometryAsGeoJsonObject_isSerializedAsString() {
+        String json = """
+                {
+                  "routes": [{
+                    "summary": { "distance": 50, "duration": 30 },
+                    "geometry": { "type": "LineString", "coordinates": [[29.0, 41.0], [29.1, 41.1]] },
+                    "segments": []
+                  }]
+                }
+                """;
+        when(orsHttpClient.postDirections(anyString(), anyString())).thenReturn(json);
+
+        RoutingDirectionsResult result =
+                client.fetchDirections(START, END, TravelMode.WALKING, null);
+
+        org.junit.jupiter.api.Assertions.assertNotNull(result.getGeometry());
+        org.junit.jupiter.api.Assertions.assertTrue(
+                result.getGeometry().contains("LineString"),
+                "GeoJSON geometry must be serialized as a string body, got: " + result.getGeometry());
+    }
+
+    @Test
+    void fetchDirections_missingGeometry_returnsNullGeometry() {
+        String json = """
+                {
+                  "routes": [{
+                    "summary": { "distance": 1, "duration": 1 },
+                    "segments": []
+                  }]
+                }
+                """;
+        when(orsHttpClient.postDirections(anyString(), anyString())).thenReturn(json);
+
+        RoutingDirectionsResult result =
+                client.fetchDirections(START, END, TravelMode.WALKING, null);
+
+        org.junit.jupiter.api.Assertions.assertNull(result.getGeometry());
+    }
+
+    // ───── extractSteps branches ────────────────────────────────────────────
+
+    @Test
+    void fetchDirections_extractsStepInstructionsAndManeuverTypes() {
+        String json = """
+                {
+                  "routes": [{
+                    "summary": { "distance": 100, "duration": 60 },
+                    "segments": [
+                      {
+                        "steps": [
+                          {"instruction": "Head north", "type": 11},
+                          {"instruction": "Turn left", "type": 0}
+                        ]
+                      }
+                    ]
+                  }]
+                }
+                """;
+        when(orsHttpClient.postDirections(anyString(), anyString())).thenReturn(json);
+
+        RoutingDirectionsResult result =
+                client.fetchDirections(START, END, TravelMode.WALKING, null);
+
+        assertEquals(2, result.getSteps().size());
+        assertEquals("Head north", result.getSteps().get(0).getInstruction());
+        assertEquals("Turn left", result.getSteps().get(1).getInstruction());
+    }
+
+    @Test
+    void fetchDirections_segmentWithoutStepsArray_isSkipped() {
+        String json = """
+                {
+                  "routes": [{
+                    "summary": { "distance": 5, "duration": 5 },
+                    "segments": [
+                      {"steps": "not an array"},
+                      {"steps": [{"instruction": "Go", "type": 0}]}
+                    ]
+                  }]
+                }
+                """;
+        when(orsHttpClient.postDirections(anyString(), anyString())).thenReturn(json);
+
+        RoutingDirectionsResult result =
+                client.fetchDirections(START, END, TravelMode.WALKING, null);
+
+        assertEquals(1, result.getSteps().size());
+        assertEquals("Go", result.getSteps().get(0).getInstruction());
+    }
+
+    @Test
+    void fetchDirections_nonArraySegmentsField_yieldsEmptyStepsList() {
+        String json = """
+                {
+                  "routes": [{
+                    "summary": { "distance": 5, "duration": 5 },
+                    "segments": "oops"
+                  }]
+                }
+                """;
+        when(orsHttpClient.postDirections(anyString(), anyString())).thenReturn(json);
+
+        RoutingDirectionsResult result =
+                client.fetchDirections(START, END, TravelMode.WALKING, null);
+
+        org.junit.jupiter.api.Assertions.assertTrue(result.getSteps().isEmpty());
+    }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/OverpassServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/OverpassServiceTest.java
@@ -1,0 +1,171 @@
+package com.bounswe2026group1.backend.service;
+
+import com.bounswe2026group1.backend.exception.RoutingException;
+import com.bounswe2026group1.backend.model.Location;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OverpassServiceTest {
+
+    private HttpServer server;
+    private final AtomicReference<String> currentResponse = new AtomicReference<>("");
+    private OverpassService service;
+
+    @BeforeEach
+    void startStubServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            byte[] body = currentResponse.get().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+
+        service = new OverpassService(JsonMapper.builder().build());
+        // Replace the hardcoded api endpoint with our local stub
+        RestClient testClient = RestClient.builder()
+                .baseUrl("http://127.0.0.1:" + server.getAddress().getPort())
+                .build();
+        ReflectionTestUtils.setField(service, "restClient", testClient);
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private void respondWith(String json) {
+        currentResponse.set(json);
+    }
+
+    @Test
+    void snapToNearestStair_returnsBothEndpoints_forSingleStairResponse() {
+        respondWith("""
+                {
+                  "elements": [
+                    {
+                      "type": "way",
+                      "geometry": [
+                        {"lat": 41.000, "lon": 29.000},
+                        {"lat": 41.001, "lon": 29.001}
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        Location[] result = service.snapToNearestStair(new Location(41.0005, 29.0005));
+
+        assertNotNull(result);
+        assertEquals(2, result.length);
+        assertEquals(41.000, result[0].getLatitude());
+        assertEquals(29.000, result[0].getLongitude());
+        assertEquals(41.001, result[1].getLatitude());
+        assertEquals(29.001, result[1].getLongitude());
+    }
+
+    @Test
+    void snapToNearestStair_picksTheClosestOfMultipleStairs() {
+        respondWith("""
+                {
+                  "elements": [
+                    {
+                      "type": "way",
+                      "geometry": [
+                        {"lat": 41.020, "lon": 29.020},
+                        {"lat": 41.021, "lon": 29.021}
+                      ]
+                    },
+                    {
+                      "type": "way",
+                      "geometry": [
+                        {"lat": 41.000, "lon": 29.000},
+                        {"lat": 41.001, "lon": 29.001}
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        Location[] result = service.snapToNearestStair(new Location(41.0005, 29.0005));
+
+        // The second stair's midpoint (~41.0005, 29.0005) sits exactly under the reported point
+        // and should win over the far stair near 41.0205, 29.0205.
+        assertEquals(41.000, result[0].getLatitude());
+        assertEquals(29.000, result[0].getLongitude());
+    }
+
+    @Test
+    void snapToNearestStair_emptyElements_throwsRoutingExceptionWithRadiusMessage() {
+        respondWith("""
+                {"elements": []}
+                """);
+
+        RoutingException ex = assertThrows(RoutingException.class,
+                () -> service.snapToNearestStair(new Location(41.0, 29.0)));
+        // The thrown message mentions the search radius — keeps user-facing copy intact
+        org.junit.jupiter.api.Assertions.assertTrue(
+                ex.getMessage().contains("stair"));
+    }
+
+    @Test
+    void snapToNearestStair_skipsElementsWithEmptyGeometryArray() {
+        respondWith("""
+                {
+                  "elements": [
+                    {"type": "way", "geometry": []},
+                    {
+                      "type": "way",
+                      "geometry": [
+                        {"lat": 41.000, "lon": 29.000},
+                        {"lat": 41.001, "lon": 29.001}
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        Location[] result = service.snapToNearestStair(new Location(41.0005, 29.0005));
+
+        // First element had empty geometry — parser must skip it; second wins
+        assertEquals(41.000, result[0].getLatitude());
+    }
+
+    @Test
+    void snapToNearestStair_nonArrayElements_throwsRoutingException() {
+        // elements is not an array — parseStairEndpoints returns empty, so the
+        // "no stair found" path triggers
+        respondWith("""
+                {"elements": "oops"}
+                """);
+
+        assertThrows(RoutingException.class,
+                () -> service.snapToNearestStair(new Location(41.0, 29.0)));
+    }
+
+    @Test
+    void snapToNearestStair_malformedJson_throwsRoutingException() {
+        respondWith("not valid json at all");
+
+        assertThrows(RoutingException.class,
+                () -> service.snapToNearestStair(new Location(41.0, 29.0)));
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/PublicSseServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/PublicSseServiceTest.java
@@ -10,9 +10,12 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PublicSseServiceTest {
 
@@ -57,10 +60,129 @@ class PublicSseServiceTest {
         assertEquals(HttpStatus.TOO_MANY_REQUESTS, ex.getStatusCode());
     }
 
+    // ───── Broadcast fan-out coverage ──────────────────────────────────────
+    // Each broadcast helper builds a different PublicSseEvent shape, but they
+    // all funnel through sendToAll(). We use a recording emitter to assert
+    // the emitter actually receives one event per broadcast call.
+
+    private static PublicSseService newServiceWithRoomForOne() {
+        PublicSseService service = new PublicSseService();
+        ReflectionTestUtils.setField(service, "maxConnections", 10);
+        ReflectionTestUtils.setField(service, "maxConnectionsPerSource", 10);
+        ReflectionTestUtils.invokeMethod(service, "initPermitPool");
+        return service;
+    }
+
+    private static Report sampleReport() {
+        Report report = new Report(new RegisteredUser(), GeoUtils.point4326(41.0, 29.0),
+                "desc", ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        report.setReportId(123L);
+        return report;
+    }
+
+    @Test
+    void broadcastReportCreated_sendsOneEventToEveryEmitter() {
+        PublicSseService service = newServiceWithRoomForOne();
+        RecordingEmitter emitter = new RecordingEmitter();
+        service.addEmitterForTest(emitter);
+
+        service.broadcastReportCreated(sampleReport());
+
+        assertEquals(1, emitter.sendCount);
+    }
+
+    @Test
+    void broadcastReportDeleted_sendsOneEvent_andDoesNotRequireFullReport() {
+        PublicSseService service = newServiceWithRoomForOne();
+        RecordingEmitter emitter = new RecordingEmitter();
+        service.addEmitterForTest(emitter);
+
+        service.broadcastReportDeleted(999L);
+
+        assertEquals(1, emitter.sendCount);
+    }
+
+    @Test
+    void broadcastFixRequested_sendsOneEvent() {
+        PublicSseService service = newServiceWithRoomForOne();
+        RecordingEmitter emitter = new RecordingEmitter();
+        service.addEmitterForTest(emitter);
+
+        service.broadcastFixRequested(sampleReport());
+
+        assertEquals(1, emitter.sendCount);
+    }
+
+    @Test
+    void broadcastFixVote_sendsOneEvent() {
+        PublicSseService service = newServiceWithRoomForOne();
+        RecordingEmitter emitter = new RecordingEmitter();
+        service.addEmitterForTest(emitter);
+
+        service.broadcastFixVote(sampleReport());
+
+        assertEquals(1, emitter.sendCount);
+    }
+
+    @Test
+    void broadcastFixed_sendsOneEvent() {
+        PublicSseService service = newServiceWithRoomForOne();
+        RecordingEmitter emitter = new RecordingEmitter();
+        service.addEmitterForTest(emitter);
+
+        service.broadcastFixed(sampleReport());
+
+        assertEquals(1, emitter.sendCount);
+    }
+
+    @Test
+    void broadcastMediaAdded_sendsOneEvent_carryingMediaFields() {
+        PublicSseService service = newServiceWithRoomForOne();
+        RecordingEmitter emitter = new RecordingEmitter();
+        service.addEmitterForTest(emitter);
+
+        Media media = new Media();
+        ReflectionTestUtils.setField(media, "mediaId", 7L);
+        media.setFilePath("s3://bucket/key.jpg");
+
+        service.broadcastMediaAdded(sampleReport(), media);
+
+        assertEquals(1, emitter.sendCount);
+    }
+
+    @Test
+    void broadcastsReachEveryActiveEmitter() {
+        PublicSseService service = newServiceWithRoomForOne();
+        RecordingEmitter a = new RecordingEmitter();
+        RecordingEmitter b = new RecordingEmitter();
+        RecordingEmitter c = new RecordingEmitter();
+        service.addEmitterForTest(a);
+        service.addEmitterForTest(b);
+        service.addEmitterForTest(c);
+
+        service.broadcastReportCreated(sampleReport());
+
+        assertTrue(a.sendCount == 1 && b.sendCount == 1 && c.sendCount == 1,
+                "every emitter must receive the broadcast");
+        assertEquals(3, service.activeEmitterCount());
+    }
+
     private static class FailingEmitter extends SseEmitter {
         @Override
         public synchronized void send(SseEventBuilder builder) throws IOException {
             throw new IOException("forced failure");
+        }
+    }
+
+    /** Counts successful send() calls — used to verify fan-out without spinning up the servlet stack. */
+    private static class RecordingEmitter extends SseEmitter {
+        final List<SseEventBuilder> received = new ArrayList<>();
+        int sendCount;
+
+        @Override
+        public synchronized void send(SseEventBuilder builder) {
+            received.add(builder);
+            sendCount++;
         }
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportLifecycleSchedulerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportLifecycleSchedulerTest.java
@@ -1,0 +1,80 @@
+package com.bounswe2026group1.backend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReportLifecycleSchedulerTest {
+
+    @Mock
+    private FixRequestService fixRequestService;
+
+    @InjectMocks
+    private ReportLifecycleScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(scheduler, "fixWindowDays", 7L);
+        ReflectionTestUtils.setField(scheduler, "deletionDelayDays", 7L);
+    }
+
+    @Test
+    void runCleanup_invokesBothFixRequestServiceMethodsWithConfiguredDurations() {
+        when(fixRequestService.expireOpenFixRequestsOlderThan(Duration.ofDays(7))).thenReturn(3);
+        when(fixRequestService.deleteFixedReportsOlderThan(Duration.ofDays(7))).thenReturn(1);
+
+        scheduler.runCleanup();
+
+        verify(fixRequestService).expireOpenFixRequestsOlderThan(Duration.ofDays(7));
+        verify(fixRequestService).deleteFixedReportsOlderThan(Duration.ofDays(7));
+    }
+
+    @Test
+    void runCleanup_whenNothingExpiredOrDeleted_stillRunsBothMethodsAndDoesNotThrow() {
+        when(fixRequestService.expireOpenFixRequestsOlderThan(any(Duration.class))).thenReturn(0);
+        when(fixRequestService.deleteFixedReportsOlderThan(any(Duration.class))).thenReturn(0);
+
+        scheduler.runCleanup();
+
+        verify(fixRequestService, times(1)).expireOpenFixRequestsOlderThan(any(Duration.class));
+        verify(fixRequestService, times(1)).deleteFixedReportsOlderThan(any(Duration.class));
+    }
+
+    @Test
+    void runCleanup_swallowsExceptionsToAvoidKillingTheSchedule() {
+        when(fixRequestService.expireOpenFixRequestsOlderThan(any(Duration.class)))
+                .thenThrow(new RuntimeException("DB blew up"));
+
+        // Should not throw — the catch-all must keep the schedule alive
+        scheduler.runCleanup();
+
+        verify(fixRequestService).expireOpenFixRequestsOlderThan(any(Duration.class));
+        // Second call is short-circuited because the first throws
+        verify(fixRequestService, times(0)).deleteFixedReportsOlderThan(any(Duration.class));
+    }
+
+    @Test
+    void runCleanup_honorsCustomConfiguredDurations() {
+        ReflectionTestUtils.setField(scheduler, "fixWindowDays", 14L);
+        ReflectionTestUtils.setField(scheduler, "deletionDelayDays", 30L);
+        when(fixRequestService.expireOpenFixRequestsOlderThan(Duration.ofDays(14))).thenReturn(0);
+        when(fixRequestService.deleteFixedReportsOlderThan(Duration.ofDays(30))).thenReturn(0);
+
+        scheduler.runCleanup();
+
+        verify(fixRequestService).expireOpenFixRequestsOlderThan(Duration.ofDays(14));
+        verify(fixRequestService).deleteFixedReportsOlderThan(Duration.ofDays(30));
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -976,4 +976,202 @@ class ReportServiceTest {
         assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
     }
 
+    // ───── addMediaToReport authorization paths ────────────────────────────
+
+    @Test
+    void addMediaToReport_reportMissing_throwsNoSuchElement() {
+        when(reportRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class,
+                () -> reportService.addMediaToReport(404L, "url", "owner@test.com"));
+        verify(mediaRepository, never()).save(any());
+    }
+
+    @Test
+    void addMediaToReport_userNotFound_throws401() {
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("ghost@test.com")).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> reportService.addMediaToReport(1L, "url", "ghost@test.com"));
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
+        verify(mediaRepository, never()).save(any());
+    }
+
+    @Test
+    void addMediaToReport_nonOwnerNonAdmin_throws403() {
+        RegisteredUser intruder = new RegisteredUser();
+        intruder.setId(99L);
+        intruder.setEmail("intruder@test.com");
+        intruder.setRole(UserRole.USER);
+
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("intruder@test.com"))
+                .thenReturn(Optional.of(intruder));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> reportService.addMediaToReport(1L, "url", "intruder@test.com"));
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+        verify(mediaRepository, never()).save(any());
+    }
+
+    @Test
+    void addMediaToReport_adminCanUploadOnAnyReport() {
+        RegisteredUser admin = new RegisteredUser();
+        admin.setId(99L);
+        admin.setEmail("admin@test.com");
+        admin.setRole(UserRole.ADMIN);
+
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("admin@test.com")).thenReturn(Optional.of(admin));
+        when(mediaRepository.save(any(Media.class))).thenAnswer(i -> i.getArgument(0));
+
+        reportService.addMediaToReport(1L, "https://cdn/x.jpg", "admin@test.com");
+
+        verify(mediaRepository).save(any(Media.class));
+    }
+
+    // ───── addMediaToReportBatch full coverage ──────────────────────────────
+
+    @Test
+    void addMediaToReportBatch_persistsAllUrls_andBroadcastsPerMedia() {
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("owner@test.com")).thenReturn(Optional.of(testUser));
+        when(mediaRepository.save(any(Media.class))).thenAnswer(i -> i.getArgument(0));
+
+        List<String> urls = List.of("https://cdn/a.jpg", "https://cdn/b.jpg", "https://cdn/c.jpg");
+        List<Media> result = reportService.addMediaToReportBatch(1L, urls, "owner@test.com");
+
+        assertEquals(3, result.size());
+        verify(mediaRepository, times(3)).save(any(Media.class));
+        verify(publicSseService, times(3))
+                .broadcastMediaAdded(eq(testReport), any(Media.class));
+    }
+
+    @Test
+    void addMediaToReportBatch_emptyList_returnsEmpty_andDoesNotBroadcast() {
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("owner@test.com")).thenReturn(Optional.of(testUser));
+
+        List<Media> result = reportService.addMediaToReportBatch(1L, List.of(), "owner@test.com");
+
+        assertTrue(result.isEmpty());
+        verify(mediaRepository, never()).save(any());
+        verify(publicSseService, never()).broadcastMediaAdded(any(), any());
+    }
+
+    @Test
+    void addMediaToReportBatch_reportMissing_throwsNoSuchElement() {
+        when(reportRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class,
+                () -> reportService.addMediaToReportBatch(404L,
+                        List.of("https://cdn/a.jpg"), "owner@test.com"));
+    }
+
+    @Test
+    void addMediaToReportBatch_userNotFound_throws401() {
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("ghost@test.com")).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> reportService.addMediaToReportBatch(1L,
+                        List.of("https://cdn/a.jpg"), "ghost@test.com"));
+        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
+        verify(mediaRepository, never()).save(any());
+    }
+
+    @Test
+    void addMediaToReportBatch_nonOwnerNonAdmin_throws403() {
+        RegisteredUser intruder = new RegisteredUser();
+        intruder.setId(99L);
+        intruder.setRole(UserRole.USER);
+
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("intruder@test.com"))
+                .thenReturn(Optional.of(intruder));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> reportService.addMediaToReportBatch(1L,
+                        List.of("https://cdn/a.jpg"), "intruder@test.com"));
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+        verify(mediaRepository, never()).save(any());
+    }
+
+    @Test
+    void addMediaToReportBatch_adminCanBulkUploadOnAnyReport() {
+        RegisteredUser admin = new RegisteredUser();
+        admin.setId(99L);
+        admin.setRole(UserRole.ADMIN);
+
+        when(reportRepository.findById(1L)).thenReturn(Optional.of(testReport));
+        when(registeredUserRepository.findByEmail("admin@test.com")).thenReturn(Optional.of(admin));
+        when(mediaRepository.save(any(Media.class))).thenAnswer(i -> i.getArgument(0));
+
+        List<Media> result = reportService.addMediaToReportBatch(1L,
+                List.of("https://cdn/a.jpg", "https://cdn/b.jpg"), "admin@test.com");
+
+        assertEquals(2, result.size());
+    }
+
+    // ───── resolveActiveFixRequests via getAll(email) ────────────────────────
+
+    @Test
+    void getAll_withActiveFixRequest_attachesFixRequestSummaryToReportResponse() {
+        ReflectionTestUtils.setField(testReport, "reportId", 1L);
+        when(reportRepository.findAll()).thenReturn(List.of(testReport));
+
+        FixRequest fixRequest = new FixRequest(testReport, testUser, "fixed");
+        ReflectionTestUtils.setField(fixRequest, "id", 77L);
+
+        when(fixRequestRepository.findOpenFixRequestIdsByReportIds(List.of(1L)))
+                .thenReturn(List.<Object[]>of(new Object[]{1L, 77L}));
+        when(fixRequestRepository.findAllById(List.of(77L)))
+                .thenReturn(List.of(fixRequest));
+        when(registeredUserRepository.findByEmail("owner@test.com"))
+                .thenReturn(Optional.of(testUser));
+        when(fixRequestVoteRepository.findVotesByUserIdAndFixRequestIds(eq(1L), eq(List.of(77L))))
+                .thenReturn(List.<Object[]>of(new Object[]{77L, VoteType.AGREE}));
+
+        List<ReportResponse> result = reportService.getAll("owner@test.com");
+
+        assertEquals(1, result.size());
+        // resolveActiveFixRequests ran and propagated the open fix request
+        assertNotNull(result.get(0).getActiveFixRequest());
+        assertEquals(77L, result.get(0).getActiveFixRequest().getId());
+    }
+
+    @Test
+    void getAll_anonymousCaller_skipsUserVoteLookup_butStillResolvesActiveFix() {
+        ReflectionTestUtils.setField(testReport, "reportId", 1L);
+        when(reportRepository.findAll()).thenReturn(List.of(testReport));
+
+        FixRequest fixRequest = new FixRequest(testReport, testUser, "fixed");
+        ReflectionTestUtils.setField(fixRequest, "id", 77L);
+
+        when(fixRequestRepository.findOpenFixRequestIdsByReportIds(List.of(1L)))
+                .thenReturn(List.<Object[]>of(new Object[]{1L, 77L}));
+        when(fixRequestRepository.findAllById(List.of(77L)))
+                .thenReturn(List.of(fixRequest));
+
+        List<ReportResponse> result = reportService.getAll(null);
+
+        assertEquals(1, result.size());
+        assertNotNull(result.get(0).getActiveFixRequest());
+        // Anonymous caller — the user-vote lookup is short-circuited
+        verify(fixRequestVoteRepository, never()).findVotesByUserIdAndFixRequestIds(any(), any());
+    }
+
+    @Test
+    void getAll_noOpenFixRequests_skipsTheFixRequestLoadEntirely() {
+        ReflectionTestUtils.setField(testReport, "reportId", 1L);
+        when(reportRepository.findAll()).thenReturn(List.of(testReport));
+        when(fixRequestRepository.findOpenFixRequestIdsByReportIds(List.of(1L)))
+                .thenReturn(List.of());
+
+        List<ReportResponse> result = reportService.getAll(null);
+
+        assertEquals(1, result.size());
+        verify(fixRequestRepository, never()).findAllById(anyList());
+    }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/util/GeoUtilsTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/util/GeoUtilsTest.java
@@ -1,0 +1,36 @@
+package com.bounswe2026group1.backend.util;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Point;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class GeoUtilsTest {
+
+    @Test
+    void point4326_swapsToJtsXyOrdering_xIsLongitude_yIsLatitude() {
+        Point p = GeoUtils.point4326(41.015137, 28.979530); // Istanbul
+
+        assertNotNull(p);
+        assertEquals(28.979530, p.getX(), 1e-9, "x must be longitude");
+        assertEquals(41.015137, p.getY(), 1e-9, "y must be latitude");
+    }
+
+    @Test
+    void point4326_setsSrid4326() {
+        Point p = GeoUtils.point4326(0.0, 0.0);
+        assertEquals(4326, p.getSRID());
+    }
+
+    @Test
+    void point4326_handlesNegativeAndZeroCoordinates() {
+        Point south = GeoUtils.point4326(-33.865143, 151.209900); // Sydney
+        assertEquals(151.209900, south.getX(), 1e-9);
+        assertEquals(-33.865143, south.getY(), 1e-9);
+
+        Point origin = GeoUtils.point4326(0.0, 0.0);
+        assertEquals(0.0, origin.getX());
+        assertEquals(0.0, origin.getY());
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/util/JwtUtilTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/util/JwtUtilTest.java
@@ -1,0 +1,154 @@
+package com.bounswe2026group1.backend.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JwtUtilTest {
+
+    private static final String SECRET = "01234567890123456789012345678901"; // 32 bytes — HS256 needs >=256 bits
+    private static final String OTHER_SECRET = "abcdefghijklmnopqrstuvwxyz012345";
+
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() {
+        jwtUtil = new JwtUtil();
+        ReflectionTestUtils.setField(jwtUtil, "secretKey", SECRET);
+    }
+
+    @Test
+    void generateToken_embedsSubjectIdAndRole() {
+        String token = jwtUtil.generateToken(42L, "ada@example.com", "USER");
+
+        Claims claims = parse(token, SECRET);
+        assertEquals("ada@example.com", claims.getSubject());
+        assertEquals(42, claims.get("id", Integer.class));
+        assertEquals("USER", claims.get("role", String.class));
+        assertNotNull(claims.getIssuedAt());
+        assertNotNull(claims.getExpiration());
+        assertTrue(claims.getExpiration().after(claims.getIssuedAt()));
+    }
+
+    @Test
+    void generateToken_setsExpirationRoughly24HoursOut() {
+        long before = System.currentTimeMillis();
+        String token = jwtUtil.generateToken(1L, "x@x.com", "USER");
+        long after = System.currentTimeMillis();
+
+        long expMs = parse(token, SECRET).getExpiration().getTime();
+        long lowerBound = before + 86_400_000L - 1_000L;
+        long upperBound = after + 86_400_000L + 1_000L;
+        assertTrue(expMs >= lowerBound && expMs <= upperBound,
+                "expiration should be ~24h from issue time, got " + expMs);
+    }
+
+    @Test
+    void generateSseToken_carriesSsePurposeAndShortExpiry() {
+        String token = jwtUtil.generateSseToken(7L, "sse@example.com");
+
+        Claims claims = parse(token, SECRET);
+        assertEquals("sse@example.com", claims.getSubject());
+        assertEquals(7, claims.get("id", Integer.class));
+        assertEquals("sse", claims.get("purpose", String.class));
+
+        long lifetime = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
+        assertTrue(lifetime <= 60_000L, "SSE token must expire within 60s, got " + lifetime + "ms");
+    }
+
+    @Test
+    void extractEmail_returnsSubject() {
+        String token = jwtUtil.generateToken(1L, "bob@example.com", "ADMIN");
+        assertEquals("bob@example.com", jwtUtil.extractEmail(token));
+    }
+
+    @Test
+    void extractRole_returnsRoleClaim() {
+        String token = jwtUtil.generateToken(1L, "bob@example.com", "ADMIN");
+        assertEquals("ADMIN", jwtUtil.extractRole(token));
+    }
+
+    @Test
+    void validateToken_acceptsTokenSignedWithSameSecret() {
+        String token = jwtUtil.generateToken(1L, "a@a.com", "USER");
+        assertTrue(jwtUtil.validateToken(token));
+    }
+
+    @Test
+    void validateToken_rejectsTokenSignedWithDifferentSecret() {
+        String foreign = Jwts.builder()
+                .subject("a@a.com")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 60_000L))
+                .signWith(keyFor(OTHER_SECRET))
+                .compact();
+
+        assertFalse(jwtUtil.validateToken(foreign));
+    }
+
+    @Test
+    void validateToken_rejectsExpiredToken() {
+        String expired = Jwts.builder()
+                .subject("a@a.com")
+                .issuedAt(new Date(System.currentTimeMillis() - 120_000L))
+                .expiration(new Date(System.currentTimeMillis() - 60_000L))
+                .signWith(keyFor(SECRET))
+                .compact();
+
+        assertFalse(jwtUtil.validateToken(expired));
+    }
+
+    @Test
+    void validateToken_rejectsMalformedToken() {
+        assertFalse(jwtUtil.validateToken("not-a-jwt"));
+        assertFalse(jwtUtil.validateToken(""));
+        assertFalse(jwtUtil.validateToken("a.b.c"));
+    }
+
+    @Test
+    void isSsePurpose_trueForSseToken_falseForDurableToken() {
+        String sse = jwtUtil.generateSseToken(1L, "x@x.com");
+        String durable = jwtUtil.generateToken(1L, "x@x.com", "USER");
+
+        assertTrue(jwtUtil.isSsePurpose(sse));
+        assertFalse(jwtUtil.isSsePurpose(durable));
+    }
+
+    @Test
+    void isSsePurpose_falseForInvalidToken() {
+        assertFalse(jwtUtil.isSsePurpose("garbage"));
+        assertFalse(jwtUtil.isSsePurpose(""));
+    }
+
+    @Test
+    void durableAndSseTokens_areDistinct() {
+        String a = jwtUtil.generateToken(1L, "x@x.com", "USER");
+        String b = jwtUtil.generateSseToken(1L, "x@x.com");
+        assertNotEquals(a, b);
+    }
+
+    private static SecretKey keyFor(String secret) {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Claims parse(String token, String secret) {
+        return Jwts.parser()
+                .verifyWith(keyFor(secret))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/util/TransactionalEventsTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/util/TransactionalEventsTest.java
@@ -1,0 +1,69 @@
+package com.bounswe2026group1.backend.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TransactionalEventsTest {
+
+    @AfterEach
+    void clearSync() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+    }
+
+    @Test
+    void runAfterCommit_withoutActiveTransaction_runsImmediately() {
+        AtomicInteger counter = new AtomicInteger();
+
+        TransactionalEvents.runAfterCommit(counter::incrementAndGet);
+
+        assertEquals(1, counter.get(), "outside a transaction the action must run inline");
+    }
+
+    @Test
+    void runAfterCommit_insideActiveTransaction_defersUntilAfterCommit() {
+        AtomicInteger counter = new AtomicInteger();
+
+        TransactionSynchronizationManager.initSynchronization();
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+
+        TransactionalEvents.runAfterCommit(counter::incrementAndGet);
+
+        assertEquals(0, counter.get(), "action must not run before commit");
+
+        // Drive the registered synchronizations as Spring would on commit
+        for (TransactionSynchronization sync : TransactionSynchronizationManager.getSynchronizations()) {
+            sync.afterCommit();
+        }
+
+        assertEquals(1, counter.get(), "action must run exactly once after commit");
+    }
+
+    @Test
+    void runAfterCommit_registersOneSynchronizationPerCall() {
+        AtomicInteger counter = new AtomicInteger();
+
+        TransactionSynchronizationManager.initSynchronization();
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+
+        TransactionalEvents.runAfterCommit(counter::incrementAndGet);
+        TransactionalEvents.runAfterCommit(counter::incrementAndGet);
+
+        assertEquals(2, TransactionSynchronizationManager.getSynchronizations().size());
+        assertEquals(0, counter.get());
+
+        for (TransactionSynchronization sync : TransactionSynchronizationManager.getSynchronizations()) {
+            sync.afterCommit();
+        }
+
+        assertEquals(2, counter.get());
+    }
+}


### PR DESCRIPTION
# 📝 Description
Fixes #591 

Raises backend JaCoCo coverage from ~80% to >90% instruction coverage by adding targeted unit tests for previously low-coverage packages. No production code changes — runtime behavior is unchanged.

**Coverage targets hit:**
- `util`: 20% → 100%
- `repository`: 1% → 100% (custom `ReportRepositoryImpl` covered via Testcontainers)
- `aspect`, `dto.error`, `dto.admin`, `exception`: 100%
- `BackendApplication.main`, `SnapType`, untouched DTOs: covered
- Controllers (`Report`, `FixRequest`, `Comment`, `RegisteredUser`, `RoutingPreferences`, `CustomRoutingProfile`): each above 85%
- Services (`ReportService`, `AdminReportService`, `OrsRoutingClient`, `PublicSseService`, `OverpassService`, `ReportLifecycleScheduler`): each above 85%

**Highlights:**
- `OverpassService` jumped from 5.8% → ~95% via a local JDK `HttpServer` stub injected through `ReflectionTestUtils`.
- `RoutingPreferencesController` / `CustomRoutingProfileController` in-controller 401 fallbacks are now covered by direct unit tests (the full-context integration tests are gated by Spring Security and never reach those branches).
- `AdminReportService.buildSpec` Specification lambda is exercised via `ArgumentCaptor` + Criteria mocks, covering every filter combination.

**Intentionally skipped (with rationale):**
- `StatusConstraintMigration` — `@Profile("!test")`, disabled by design under the test profile.
- `OpenRouteServiceConfig` lambdas — would require a small production refactor to inject the ORS base URL, kept out of a test-only PR.
- `POST /api/users` controller path — takes a raw JPA entity that Jackson 3 cannot deserialize cleanly; the endpoint's own docs steer clients to `POST /auth/register`.

# 📊 Type of Change
- [x] New tests
<!-- No bug fix, new feature, refactor, or documentation — pure test additions. -->

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
<img width="1188" height="332" alt="image" src="https://github.com/user-attachments/assets/eccb52cc-7020-4546-993f-b0a168612d54" />

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min
