### PR TITLE
[Backend] Self-delete endpoint for the authenticated user (closes #594)

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RegisteredUserController.java
@@ -143,6 +143,28 @@ public class RegisteredUserController {
         }
     }
 
+    @DeleteMapping("/me")
+    @Operation(
+            summary = "Delete the authenticated user's own account (1.1.1.2.12)",
+            description = "Anonymizes the caller's name/email/password and bans them, while " +
+                    "preserving their reports/comments/votes so the map history stays intact. " +
+                    "Refuses with 409 when the caller is the last remaining admin."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Deleted (anonymized in place)."),
+            @ApiResponse(responseCode = "401", description = "Authentication required."),
+            @ApiResponse(responseCode = "409", description = "Cannot delete the last admin.")
+    })
+    @SecurityRequirement(name = OpenApiConfig.BEARER_SCHEME)
+    public ResponseEntity<Object> deleteSelf() {
+        String email = currentUserEmailOrNull();
+        if (email == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Authentication required.");
+        }
+        registeredUserService.deleteSelf(email);
+        return ResponseEntity.noContent().build();
+    }
+
     @PutMapping("/{id}/profile")
     @Operation(
             summary = "Update the authenticated user's profile",

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/AdminUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/AdminUserService.java
@@ -21,6 +21,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class AdminUserService {
 
     private final RegisteredUserRepository userRepository;
+    private final RegisteredUserService registeredUserService;
     private final PasswordEncoder passwordEncoder;
 
     public AdminUserResponse getUser(Long id) {
@@ -102,12 +103,7 @@ public class AdminUserService {
                     "Cannot delete the last admin");
         }
 
-        // Anonymize PII in-place so that FK references from reports/comments/verifications stay valid
-        target.setName("Deleted User");
-        target.setEmail("deleted_" + targetId + "@deleted.invalid");
-        target.setPassword("$DELETED$");
-        target.setStatus(UserStatus.BANNED);
-        userRepository.save(target);
+        registeredUserService.anonymizeUser(target);
     }
 
     private RegisteredUser findUser(Long id) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
@@ -9,6 +9,7 @@ import com.bounswe2026group1.backend.dto.UserProfileDTO;
 import com.bounswe2026group1.backend.model.Badge;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.model.UserRole;
+import com.bounswe2026group1.backend.model.UserStatus;
 import com.bounswe2026group1.backend.dto.PointEventResponse;
 import com.bounswe2026group1.backend.repository.PointEventRepository;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
@@ -19,9 +20,12 @@ import com.bounswe2026group1.backend.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -112,6 +116,36 @@ public class RegisteredUserService {
         if (!registeredUserRepository.existsById(id)) return false;
         registeredUserRepository.deleteById(id);
         return true;
+    }
+
+    /**
+     * Anonymizes a user in place so FK references from their reports/comments/votes
+     * stay valid while PII is erased. Shared by self-delete (1.1.1.2.12) and admin-delete (1.1.1.3.8).
+     */
+    @Transactional
+    public void anonymizeUser(RegisteredUser target) {
+        target.setName("Deleted User");
+        target.setEmail("deleted_" + target.getId() + "@deleted.invalid");
+        target.setPassword("$DELETED$");
+        target.setStatus(UserStatus.BANNED);
+        registeredUserRepository.save(target);
+    }
+
+    /**
+     * Self-delete (1.1.1.2.12). Looks up the caller by email and anonymizes them.
+     * If the caller is the only remaining admin, refuses with 409.
+     */
+    @Transactional
+    public void deleteSelf(String callerEmail) {
+        RegisteredUser target = registeredUserRepository.findByEmail(callerEmail)
+                .orElseThrow(() -> new NoSuchElementException("User not found with email: " + callerEmail));
+
+        if (target.getRole() == UserRole.ADMIN
+                && registeredUserRepository.countByRole(UserRole.ADMIN) <= 1) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot delete the last admin");
+        }
+        anonymizeUser(target);
     }
 
     // ───── Profile (issue #302) ─────────────────────────────────────────────

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RegisteredUserControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RegisteredUserControllerTest.java
@@ -83,6 +83,39 @@ class RegisteredUserControllerTest {
                 .andExpect(status().isUnauthorized());
     }
 
+    // ───── DELETE /me (self-delete, 1.1.1.2.12) ──────────────────────────────
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("DELETE /me returns 204 and delegates to service")
+    void deleteSelf_authenticated_returns204() throws Exception {
+        mockMvc.perform(delete("/api/users/me").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isNoContent());
+
+        verify(registeredUserService).deleteSelf(OWNER_EMAIL);
+    }
+
+    @Test
+    @DisplayName("DELETE /me returns 401 when no auth")
+    void deleteSelf_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(delete("/api/users/me").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isUnauthorized());
+
+        verify(registeredUserService, never()).deleteSelf(any());
+    }
+
+    @Test
+    @WithMockUser(username = OWNER_EMAIL)
+    @DisplayName("DELETE /me returns 409 when caller is the last admin")
+    void deleteSelf_lastAdmin_returns409() throws Exception {
+        doThrow(new org.springframework.web.server.ResponseStatusException(
+                org.springframework.http.HttpStatus.CONFLICT, "Cannot delete the last admin"))
+                .when(registeredUserService).deleteSelf(OWNER_EMAIL);
+
+        mockMvc.perform(delete("/api/users/me").header("Mapcess-Key", validApiKey))
+                .andExpect(status().isConflict());
+    }
+
     // ───── GET /{id} ─────────────────────────────────────────────────────────
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/AdminUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/AdminUserServiceTest.java
@@ -33,6 +33,9 @@ class AdminUserServiceTest {
     private RegisteredUserRepository userRepository;
 
     @Mock
+    private RegisteredUserService registeredUserService;
+
+    @Mock
     private PasswordEncoder passwordEncoder;
 
     @InjectMocks
@@ -224,16 +227,12 @@ class AdminUserServiceTest {
     // --- deleteUser ---
 
     @Test
-    void deleteUser_Success_AnonymizesPii() {
+    void deleteUser_Success_DelegatesAnonymization() {
         when(userRepository.findById(2L)).thenReturn(Optional.of(regularUser));
-        when(userRepository.save(regularUser)).thenReturn(regularUser);
 
         adminUserService.deleteUser(2L, "admin@test.com");
 
-        assertEquals("Deleted User", regularUser.getName());
-        assertTrue(regularUser.getEmail().startsWith("deleted_"));
-        assertEquals(UserStatus.BANNED, regularUser.getStatus());
-        verify(userRepository).save(regularUser);
+        verify(registeredUserService).anonymizeUser(regularUser);
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -610,4 +610,66 @@ class RegisteredUserServiceTest {
         assertEquals(0, dtos.getTotalElements());
         verify(reportRepository, never()).countByCreatedByIdIn(anyCollection());
     }
+
+    // --- SELF-DELETE TESTS (1.1.1.2.12) ---
+
+    @Test
+    void deleteSelf_anonymizesPiiAndBansUser() {
+        when(registeredUserRepository.findByEmail("test@test.com")).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        registeredUserService.deleteSelf("test@test.com");
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        RegisteredUser saved = captor.getValue();
+        assertEquals("Deleted User", saved.getName());
+        assertEquals("deleted_1@deleted.invalid", saved.getEmail());
+        assertEquals("$DELETED$", saved.getPassword());
+        assertEquals(UserStatus.BANNED, saved.getStatus());
+    }
+
+    @Test
+    void deleteSelf_lastAdmin_throwsConflict() {
+        RegisteredUser admin = new RegisteredUser();
+        admin.setId(7L);
+        admin.setEmail("admin@test.com");
+        admin.setName("Admin");
+        admin.setRole(UserRole.ADMIN);
+        admin.setStatus(UserStatus.ACTIVE);
+        when(registeredUserRepository.findByEmail("admin@test.com")).thenReturn(Optional.of(admin));
+        when(registeredUserRepository.countByRole(UserRole.ADMIN)).thenReturn(1L);
+
+        org.springframework.web.server.ResponseStatusException ex = assertThrows(
+                org.springframework.web.server.ResponseStatusException.class,
+                () -> registeredUserService.deleteSelf("admin@test.com"));
+        assertEquals(org.springframework.http.HttpStatus.CONFLICT, ex.getStatusCode());
+        verify(registeredUserRepository, never()).save(any(RegisteredUser.class));
+    }
+
+    @Test
+    void deleteSelf_adminNotLast_anonymizes() {
+        RegisteredUser admin = new RegisteredUser();
+        admin.setId(7L);
+        admin.setEmail("admin@test.com");
+        admin.setName("Admin");
+        admin.setRole(UserRole.ADMIN);
+        admin.setStatus(UserStatus.ACTIVE);
+        when(registeredUserRepository.findByEmail("admin@test.com")).thenReturn(Optional.of(admin));
+        when(registeredUserRepository.countByRole(UserRole.ADMIN)).thenReturn(2L);
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        registeredUserService.deleteSelf("admin@test.com");
+
+        verify(registeredUserRepository).save(any(RegisteredUser.class));
+    }
+
+    @Test
+    void deleteSelf_unknownEmail_throwsNoSuchElement() {
+        when(registeredUserRepository.findByEmail("ghost@test.com")).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class,
+                () -> registeredUserService.deleteSelf("ghost@test.com"));
+        verify(registeredUserRepository, never()).save(any(RegisteredUser.class));
+    }
 }


### PR DESCRIPTION
## 📝 Description
Closes #594 : requirement **1.1.1.2.12**. Authenticated users can permanently delete their own account via `DELETE /api/users/me`. PII is wiped while reports / comments / votes stay attached to an anonymized row so map history isn't broken.

Anonymization recipe (matches existing admin-delete): name → `Deleted User`, email → `deleted_{id}@deleted.invalid`, password → `$DELETED$`, status → `BANNED`.

Commits:
1. New `RegisteredUserService.anonymizeUser` helper + `deleteSelf(callerEmail)`
2. `AdminUserService.deleteUser` delegates to the shared helper (no behavior change)
3. New `DELETE /api/users/me` endpoint in `RegisteredUserController`
4. Service + controller tests

## 📊 Type of Change
- [x] New feature

## ✅ Acceptance Criteria
- [x] `DELETE /api/users/me` returns 204 for an authenticated regular user; row is anonymized in place
- [x] Last-admin self-deletion → 409
- [x] Unauthenticated request → 401
- [x] Admin-delete still works (refactored, same outputs)
- [x] Service-level unit tests for happy path / last-admin / unknown email
- [x] Controller-level tests for 204 / 401 / 409

## 🧪 How to Test
```
TOKEN=$(curl -s -X POST http://localhost:8080/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"alice@test.com","password":"Test1234!"}' | jq -r .token)

curl -s -o /dev/null -w "%{http_code}\n" -X DELETE \
  -H "Authorization: Bearer $TOKEN" \
  http://localhost:8080/api/users/me      # 204

curl -s http://localhost:8080/api/users/<that-id> | jq '{name,email}'
# { "name": "Deleted User", "email": "deleted_<id>@deleted.invalid" }
```

## ⏱️ Estimated Review Time
~5 min