### PR TITLE
[Backend] Adopt GeoJSON RFC 7946 For Report And Route Coordinates

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/RouteController.java
@@ -125,8 +125,8 @@ public class RouteController {
         try {
             RouteResponse first = options.get(0);
             Route record = Route.builder()
-                    .startLocation(new Location(request.getStartLat(), request.getStartLon()))
-                    .endLocation(new Location(request.getEndLat(), request.getEndLon()))
+                    .startLocation(new Location(request.effectiveStartLat(), request.effectiveStartLon()))
+                    .endLocation(new Location(request.effectiveEndLat(), request.effectiveEndLon()))
                     .distance((int) Math.round(first.getDistanceMeters()))
                     .duration((int) Math.round(first.getDurationSeconds()))
                     .travelMode(first.getMode())

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/CreateReportRequest.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/CreateReportRequest.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.dto;
 
+import com.bounswe2026group1.backend.dto.geo.GeoJsonPoint;
 import com.bounswe2026group1.backend.model.ReportEnvironment;
 import com.bounswe2026group1.backend.model.ReportType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,13 +19,34 @@ public class CreateReportRequest {
     @Schema(description = "Id of the user creating the report (the authenticated caller).", example = "42")
     private Long userId;
 
-    @Schema(description = "WGS84 latitude.", example = "41.085", minimum = "-90", maximum = "90",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private double latitude;
+    @Schema(description = "Report location as a GeoJSON Point (RFC 7946). " +
+            "Either `geometry` OR (`latitude`, `longitude`) must be supplied — `geometry` wins when both are present. " +
+            "Coordinates are [longitude, latitude] in WGS84.")
+    private GeoJsonPoint geometry;
 
-    @Schema(description = "WGS84 longitude.", example = "29.045", minimum = "-180", maximum = "180",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private double longitude;
+    @Schema(description = "WGS84 latitude. Deprecated — supply `geometry` instead. Ignored when `geometry` is present.",
+            example = "41.085", minimum = "-90", maximum = "90", deprecated = true)
+    private Double latitude;
+
+    @Schema(description = "WGS84 longitude. Deprecated — supply `geometry` instead. Ignored when `geometry` is present.",
+            example = "29.045", minimum = "-180", maximum = "180", deprecated = true)
+    private Double longitude;
+
+    /** Effective latitude, preferring the GeoJSON geometry over the legacy scalar. */
+    public double effectiveLatitude() {
+        if (geometry != null && geometry.getCoordinates() != null && geometry.getCoordinates().length >= 2) {
+            return geometry.getCoordinates()[1];
+        }
+        return latitude != null ? latitude : Double.NaN;
+    }
+
+    /** Effective longitude, preferring the GeoJSON geometry over the legacy scalar. */
+    public double effectiveLongitude() {
+        if (geometry != null && geometry.getCoordinates() != null && geometry.getCoordinates().length >= 2) {
+            return geometry.getCoordinates()[0];
+        }
+        return longitude != null ? longitude : Double.NaN;
+    }
 
     @Schema(description = "Free-text description of the issue. Hard-capped at 1000 characters.",
             example = "Construction blocks the ramp on the south side of the bridge.",

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.dto;
 
+import com.bounswe2026group1.backend.dto.geo.GeoJsonPoint;
 import com.bounswe2026group1.backend.model.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -22,10 +23,19 @@ public class ReportResponse {
     @Schema(description = "Id of the user who submitted the report.", example = "42")
     private Long userId;
 
-    @Schema(description = "WGS84 latitude.", example = "41.085", minimum = "-90", maximum = "90")
+    @Schema(description = "Report location as a GeoJSON Point (RFC 7946). " +
+            "Coordinates are [longitude, latitude] in WGS84. Prefer reading this over the deprecated " +
+            "scalar `latitude` / `longitude` fields below.")
+    private GeoJsonPoint geometry;
+
+    @Schema(description = "WGS84 latitude. Deprecated — use `geometry.coordinates[1]` instead. " +
+            "Retained for backwards compatibility with older mobile builds.",
+            example = "41.085", minimum = "-90", maximum = "90", deprecated = true)
     private double latitude;
 
-    @Schema(description = "WGS84 longitude.", example = "29.045", minimum = "-180", maximum = "180")
+    @Schema(description = "WGS84 longitude. Deprecated — use `geometry.coordinates[0]` instead. " +
+            "Retained for backwards compatibility with older mobile builds.",
+            example = "29.045", minimum = "-180", maximum = "180", deprecated = true)
     private double longitude;
 
     @Schema(description = "Free-text description (≤ 1000 chars).",
@@ -74,20 +84,28 @@ public class ReportResponse {
     @Schema(description = "Objects (door, ramp, elevator…) that the report refers to.")
     private List<ReportObjectResponse> objects;
 
-    @Schema(description = "Latitude of the obstacle's entry point, when applicable.",
-            example = "41.0851", nullable = true)
+    @Schema(description = "Obstacle entry point as a GeoJSON Point, when applicable (FEATURE reports with ramp object).",
+            nullable = true)
+    private GeoJsonPoint entryGeometry;
+
+    @Schema(description = "Obstacle exit point as a GeoJSON Point, when applicable (FEATURE reports with ramp object).",
+            nullable = true)
+    private GeoJsonPoint exitGeometry;
+
+    @Schema(description = "Latitude of the obstacle's entry point. Deprecated — use `entryGeometry`.",
+            example = "41.0851", nullable = true, deprecated = true)
     private Double entryLatitude;
 
-    @Schema(description = "Longitude of the obstacle's entry point, when applicable.",
-            example = "29.0449", nullable = true)
+    @Schema(description = "Longitude of the obstacle's entry point. Deprecated — use `entryGeometry`.",
+            example = "29.0449", nullable = true, deprecated = true)
     private Double entryLongitude;
 
-    @Schema(description = "Latitude of the obstacle's exit point, when applicable.",
-            example = "41.0853", nullable = true)
+    @Schema(description = "Latitude of the obstacle's exit point. Deprecated — use `exitGeometry`.",
+            example = "41.0853", nullable = true, deprecated = true)
     private Double exitLatitude;
 
-    @Schema(description = "Longitude of the obstacle's exit point, when applicable.",
-            example = "29.0451", nullable = true)
+    @Schema(description = "Longitude of the obstacle's exit point. Deprecated — use `exitGeometry`.",
+            example = "29.0451", nullable = true, deprecated = true)
     private Double exitLongitude;
 
     @Schema(description = "Id of the user who last edited the report (or null if never edited since creation).",
@@ -118,6 +136,7 @@ public class ReportResponse {
         r.setReportId(report.getReportId());
         r.setUserId(report.getCreatedBy().getId());
         if (report.getLocation() != null) {
+            r.setGeometry(GeoJsonPoint.fromJts(report.getLocation()));
             r.setLatitude(report.getLocation().getY());
             r.setLongitude(report.getLocation().getX());
         }
@@ -136,10 +155,12 @@ public class ReportResponse {
         r.setObjects(objectResponses != null ? objectResponses : Collections.emptyList());
 
         if (report.getEntryPoint() != null) {
+            r.setEntryGeometry(GeoJsonPoint.fromLocation(report.getEntryPoint()));
             r.setEntryLatitude(report.getEntryPoint().getLatitude());
             r.setEntryLongitude(report.getEntryPoint().getLongitude());
         }
         if (report.getExitPoint() != null) {
+            r.setExitGeometry(GeoJsonPoint.fromLocation(report.getExitPoint()));
             r.setExitLatitude(report.getExitPoint().getLatitude());
             r.setExitLongitude(report.getExitPoint().getLongitude());
         }

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/UpdateReportRequest.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/UpdateReportRequest.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.dto;
 
+import com.bounswe2026group1.backend.dto.geo.GeoJsonPoint;
 import com.bounswe2026group1.backend.model.ReportEnvironment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -22,13 +23,41 @@ public class UpdateReportRequest {
     @Schema(description = "New environment.", example = "OUTDOOR")
     private ReportEnvironment environment;
 
-    @Schema(description = "New WGS84 latitude.", example = "41.086",
-            minimum = "-90", maximum = "90", nullable = true)
+    @Schema(description = "New location as a GeoJSON Point (RFC 7946). " +
+            "Send this OR (`latitude`, `longitude`); `geometry` wins when both are present. " +
+            "Coordinates are [longitude, latitude] in WGS84.",
+            nullable = true)
+    private GeoJsonPoint geometry;
+
+    @Schema(description = "New WGS84 latitude. Deprecated — supply `geometry` instead.",
+            example = "41.086", minimum = "-90", maximum = "90", nullable = true, deprecated = true)
     private Double latitude;
 
-    @Schema(description = "New WGS84 longitude.", example = "29.044",
-            minimum = "-180", maximum = "180", nullable = true)
+    @Schema(description = "New WGS84 longitude. Deprecated — supply `geometry` instead.",
+            example = "29.044", minimum = "-180", maximum = "180", nullable = true, deprecated = true)
     private Double longitude;
+
+    /**
+     * Effective new latitude, or {@code null} when no location update was requested.
+     * Prefers the GeoJSON geometry over the legacy scalar.
+     */
+    public Double effectiveLatitude() {
+        if (geometry != null && geometry.getCoordinates() != null && geometry.getCoordinates().length >= 2) {
+            return geometry.getCoordinates()[1];
+        }
+        return latitude;
+    }
+
+    /**
+     * Effective new longitude, or {@code null} when no location update was requested.
+     * Prefers the GeoJSON geometry over the legacy scalar.
+     */
+    public Double effectiveLongitude() {
+        if (geometry != null && geometry.getCoordinates() != null && geometry.getCoordinates().length >= 2) {
+            return geometry.getCoordinates()[0];
+        }
+        return longitude;
+    }
 
     @Schema(description = "Replacement list of attached objects. " +
             "Sending `null` leaves the existing objects untouched; sending an empty list clears them.")

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/geo/GeoJsonLineString.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/geo/GeoJsonLineString.java
@@ -1,0 +1,41 @@
+package com.bounswe2026group1.backend.dto.geo;
+
+import com.bounswe2026group1.backend.model.Location;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * GeoJSON {@code LineString} geometry, per
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.4">RFC 7946 §3.1.4</a>.
+ *
+ * <p>Each position in {@code coordinates} is {@code [longitude, latitude]}.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "GeoJSON LineString (RFC 7946). Each position is [longitude, latitude] in WGS84.")
+public class GeoJsonLineString {
+
+    @Schema(description = "GeoJSON geometry type discriminator. Always \"LineString\".",
+            example = "LineString", allowableValues = {"LineString"})
+    private String type = "LineString";
+
+    @Schema(description = "Ordered list of WGS84 positions. Each entry is [longitude, latitude] (RFC 7946).",
+            example = "[[29.045, 41.085], [29.046, 41.086]]")
+    private double[][] coordinates;
+
+    public static GeoJsonLineString fromLocations(List<Location> path) {
+        if (path == null || path.isEmpty()) return null;
+        double[][] coords = new double[path.size()][2];
+        for (int i = 0; i < path.size(); i++) {
+            Location p = path.get(i);
+            coords[i][0] = p.getLongitude();
+            coords[i][1] = p.getLatitude();
+        }
+        return new GeoJsonLineString("LineString", coords);
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/geo/GeoJsonPoint.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/geo/GeoJsonPoint.java
@@ -1,0 +1,79 @@
+package com.bounswe2026group1.backend.dto.geo;
+
+import com.bounswe2026group1.backend.model.Location;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+
+/**
+ * GeoJSON {@code Point} geometry, per
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.2">RFC 7946 §3.1.2</a>.
+ *
+ * <p>Coordinates are stored as {@code [longitude, latitude]} — the order
+ * mandated by the spec. This is the opposite of Leaflet's {@code LatLng}
+ * and most legacy {@code (lat, lng)} APIs; clients consuming this DTO must
+ * not assume {@code [lat, lng]} order.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "GeoJSON Point (RFC 7946). Coordinates are [longitude, latitude] in WGS84.")
+public class GeoJsonPoint {
+
+    @Schema(description = "GeoJSON geometry type discriminator. Always \"Point\".",
+            example = "Point", allowableValues = {"Point"})
+    private String type = "Point";
+
+    @Schema(description = "WGS84 coordinates as [longitude, latitude] (RFC 7946 §3.1.1).",
+            example = "[29.045, 41.085]",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private double[] coordinates;
+
+    public static GeoJsonPoint of(double latitude, double longitude) {
+        return new GeoJsonPoint("Point", new double[]{longitude, latitude});
+    }
+
+    public static GeoJsonPoint fromJts(Point point) {
+        if (point == null) return null;
+        return new GeoJsonPoint("Point", new double[]{point.getX(), point.getY()});
+    }
+
+    public static GeoJsonPoint fromLocation(Location location) {
+        if (location == null) return null;
+        return of(location.getLatitude(), location.getLongitude());
+    }
+
+    /** @return longitude (coordinates[0]) or NaN when coordinates are absent. */
+    public double longitude() {
+        return coordinates != null && coordinates.length >= 2 ? coordinates[0] : Double.NaN;
+    }
+
+    /** @return latitude (coordinates[1]) or NaN when coordinates are absent. */
+    public double latitude() {
+        return coordinates != null && coordinates.length >= 2 ? coordinates[1] : Double.NaN;
+    }
+
+    /**
+     * Validate that {@code type} is {@code "Point"} and that coordinates are
+     * present, finite, and within WGS84 range. Throws
+     * {@link IllegalArgumentException} on any violation.
+     */
+    public void validate() {
+        if (!"Point".equals(type)) {
+            throw new IllegalArgumentException("GeoJSON geometry type must be \"Point\", got: " + type);
+        }
+        if (coordinates == null || coordinates.length < 2) {
+            throw new IllegalArgumentException("GeoJSON Point requires a [longitude, latitude] coordinates array");
+        }
+        double lon = coordinates[0];
+        double lat = coordinates[1];
+        if (!Double.isFinite(lon) || !Double.isFinite(lat)) {
+            throw new IllegalArgumentException("GeoJSON Point coordinates must be finite numbers");
+        }
+        if (lat < -90.0 || lat > 90.0 || lon < -180.0 || lon > 180.0) {
+            throw new IllegalArgumentException("GeoJSON Point coordinates out of WGS84 range");
+        }
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RouteRequest.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RouteRequest.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.dto.routing;
 
+import com.bounswe2026group1.backend.dto.geo.GeoJsonPoint;
 import com.bounswe2026group1.backend.model.TravelMode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -9,26 +10,70 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "Routing request for `POST /api/routes`.")
+@Schema(description = "Routing request for `POST /api/routes`. " +
+        "Supply either GeoJSON `start` + `end` (RFC 7946 Points) OR the legacy " +
+        "`startLat`/`startLon`/`endLat`/`endLon` scalars. The GeoJSON fields win when both are present.")
 public class RouteRequest {
 
-    @Schema(description = "WGS84 latitude of the route's start point.", example = "41.085",
-            minimum = "-90", maximum = "90", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "Route start as a GeoJSON Point (RFC 7946). " +
+            "Coordinates are [longitude, latitude] in WGS84.")
+    private GeoJsonPoint start;
+
+    @Schema(description = "Route end as a GeoJSON Point (RFC 7946). " +
+            "Coordinates are [longitude, latitude] in WGS84.")
+    private GeoJsonPoint end;
+
+    @Schema(description = "WGS84 latitude of the route's start point. Deprecated — supply `start` instead.",
+            example = "41.085", minimum = "-90", maximum = "90", deprecated = true)
     private double startLat;
 
-    @Schema(description = "WGS84 longitude of the route's start point.", example = "29.045",
-            minimum = "-180", maximum = "180", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "WGS84 longitude of the route's start point. Deprecated — supply `start` instead.",
+            example = "29.045", minimum = "-180", maximum = "180", deprecated = true)
     private double startLon;
 
-    @Schema(description = "WGS84 latitude of the route's end point.", example = "41.090",
-            minimum = "-90", maximum = "90", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "WGS84 latitude of the route's end point. Deprecated — supply `end` instead.",
+            example = "41.090", minimum = "-90", maximum = "90", deprecated = true)
     private double endLat;
 
-    @Schema(description = "WGS84 longitude of the route's end point.", example = "29.050",
-            minimum = "-180", maximum = "180", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "WGS84 longitude of the route's end point. Deprecated — supply `end` instead.",
+            example = "29.050", minimum = "-180", maximum = "180", deprecated = true)
     private double endLon;
 
     @Schema(description = "Travel mode requested.", example = "WALKING",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private TravelMode mode;
+
+    /**
+     * Legacy convenience constructor matching the pre-GeoJSON wire shape. Kept so callers
+     * that still hand-build a request from scalar lat/lon pairs (and the test suite) keep
+     * compiling. Sets the GeoJSON {@code start} / {@code end} fields to {@code null}; the
+     * {@code effective*} accessors fall back to the scalars in that case.
+     */
+    public RouteRequest(double startLat, double startLon, double endLat, double endLon, TravelMode mode) {
+        this(null, null, startLat, startLon, endLat, endLon, mode);
+    }
+
+    /** Effective start latitude, preferring the GeoJSON {@code start} field over the legacy scalar. */
+    public double effectiveStartLat() {
+        return start != null && start.getCoordinates() != null && start.getCoordinates().length >= 2
+                ? start.getCoordinates()[1] : startLat;
+    }
+
+    /** Effective start longitude, preferring the GeoJSON {@code start} field over the legacy scalar. */
+    public double effectiveStartLon() {
+        return start != null && start.getCoordinates() != null && start.getCoordinates().length >= 2
+                ? start.getCoordinates()[0] : startLon;
+    }
+
+    /** Effective end latitude, preferring the GeoJSON {@code end} field over the legacy scalar. */
+    public double effectiveEndLat() {
+        return end != null && end.getCoordinates() != null && end.getCoordinates().length >= 2
+                ? end.getCoordinates()[1] : endLat;
+    }
+
+    /** Effective end longitude, preferring the GeoJSON {@code end} field over the legacy scalar. */
+    public double effectiveEndLon() {
+        return end != null && end.getCoordinates() != null && end.getCoordinates().length >= 2
+                ? end.getCoordinates()[0] : endLon;
+    }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RouteResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/routing/RouteResponse.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.dto.routing;
 
+import com.bounswe2026group1.backend.dto.geo.GeoJsonLineString;
 import com.bounswe2026group1.backend.model.Location;
 import com.bounswe2026group1.backend.model.TravelMode;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -30,9 +31,15 @@ public class RouteResponse {
     @Schema(description = "Travel mode used for this option.", example = "WALKING")
     private TravelMode mode;
 
-    @Schema(description = "Encoded polyline (Google polyline algorithm) describing the route geometry.",
+    @Schema(description = "Encoded polyline (Google polyline algorithm) describing the route geometry. " +
+            "Compact wire format kept for clients that already decode polylines; new integrations should prefer `geoJsonGeometry`.",
             example = "u{~vF...")
     private String geometry;
+
+    @Schema(description = "Route geometry as a GeoJSON LineString (RFC 7946). " +
+            "Each position is [longitude, latitude] in WGS84.",
+            nullable = true)
+    private GeoJsonLineString geoJsonGeometry;
 
     @Schema(description = "Turn-by-turn step list.")
     private List<RouteStep> steps;

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -158,8 +158,22 @@ public class ReportService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "reportType is required");
         }
 
-        Location reportedPoint = new Location(request.getLatitude(), request.getLongitude());
-        Point reportLocation = GeoUtils.point4326(request.getLatitude(), request.getLongitude());
+        if (request.getGeometry() != null) {
+            try {
+                request.getGeometry().validate();
+            } catch (IllegalArgumentException e) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+            }
+        }
+        double lat = request.effectiveLatitude();
+        double lon = request.effectiveLongitude();
+        if (!Double.isFinite(lat) || !Double.isFinite(lon)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Report location is required — supply `geometry` (GeoJSON Point) or `latitude`/`longitude`");
+        }
+
+        Location reportedPoint = new Location(lat, lon);
+        Point reportLocation = GeoUtils.point4326(lat, lon);
         Report report = new Report(user, reportLocation, request.getDescription(),
                 request.getReportType(), request.getEnvironment());
 
@@ -233,13 +247,22 @@ public class ReportService {
             report.setEnvironment(request.getEnvironment());
         }
 
-        if (request.getLatitude() != null && Math.abs(request.getLatitude() - report.getLocation().getY()) > 1e-9) {
-            diff.put("latitude", new Object[]{report.getLocation().getY(), request.getLatitude()});
-            report.setLocation(GeoUtils.point4326(request.getLatitude(), report.getLocation().getX()));
+        if (request.getGeometry() != null) {
+            try {
+                request.getGeometry().validate();
+            } catch (IllegalArgumentException e) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+            }
         }
-        if (request.getLongitude() != null && Math.abs(request.getLongitude() - report.getLocation().getX()) > 1e-9) {
-            diff.put("longitude", new Object[]{report.getLocation().getX(), request.getLongitude()});
-            report.setLocation(GeoUtils.point4326(report.getLocation().getY(), request.getLongitude()));
+        Double newLat = request.effectiveLatitude();
+        Double newLon = request.effectiveLongitude();
+        if (newLat != null && Math.abs(newLat - report.getLocation().getY()) > 1e-9) {
+            diff.put("latitude", new Object[]{report.getLocation().getY(), newLat});
+            report.setLocation(GeoUtils.point4326(newLat, report.getLocation().getX()));
+        }
+        if (newLon != null && Math.abs(newLon - report.getLocation().getX()) > 1e-9) {
+            diff.put("longitude", new Object[]{report.getLocation().getX(), newLon});
+            report.setLocation(GeoUtils.point4326(report.getLocation().getY(), newLon));
         }
 
         if (request.getObjects() != null) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.service;
 
+import com.bounswe2026group1.backend.dto.geo.GeoJsonLineString;
 import com.bounswe2026group1.backend.dto.routing.RouteRequest;
 import com.bounswe2026group1.backend.dto.routing.RouteResponse;
 import com.bounswe2026group1.backend.dto.routing.RouteStep;
@@ -83,8 +84,8 @@ public class RouteService {
         boolean isWheelchairCaller = preferredMode == TravelMode.WHEELCHAIR;
         String wheelchairLabel = isWheelchairCaller ? "Accessible Route" : "Wheelchair Route";
 
-        Location start = new Location(request.getStartLat(), request.getStartLon());
-        Location end = new Location(request.getEndLat(), request.getEndLon());
+        Location start = new Location(request.effectiveStartLat(), request.effectiveStartLon());
+        Location end = new Location(request.effectiveEndLat(), request.effectiveEndLon());
 
         // Build avoid polygons once — reused for routes 2 and 3. Three-state
         // contract on `constraints`: null skips avoidance entirely, empty set
@@ -110,6 +111,7 @@ public class RouteService {
                     .durationSeconds(fastestResult.getDurationSeconds())
                     .mode(TravelMode.WALKING)
                     .geometry(fastestResult.getGeometry())
+                    .geoJsonGeometry(GeoJsonLineString.fromLocations(pathPoints))
                     .steps(fastestResult.getSteps())
                     .hasObstacles(hasObstacles)
                     .build());
@@ -129,6 +131,8 @@ public class RouteService {
                         .durationSeconds(accessibleResult.getDurationSeconds())
                         .mode(TravelMode.WALKING)
                         .geometry(accessibleResult.getGeometry())
+                        .geoJsonGeometry(GeoJsonLineString.fromLocations(
+                                PolylineDecoder.decode(accessibleResult.getGeometry())))
                         .steps(accessibleResult.getSteps())
                         .hasObstacles(false)
                         .build());
@@ -153,6 +157,8 @@ public class RouteService {
                         .durationSeconds(wheelchairResult.getDurationSeconds())
                         .mode(TravelMode.WHEELCHAIR)
                         .geometry(wheelchairResult.getGeometry())
+                        .geoJsonGeometry(GeoJsonLineString.fromLocations(
+                                PolylineDecoder.decode(wheelchairResult.getGeometry())))
                         .steps(wheelchairResult.getSteps())
                         .hasObstacles(false)
                         .build();
@@ -195,6 +201,7 @@ public class RouteService {
                                 .durationSeconds(totalDuration)
                                 .mode(TravelMode.WHEELCHAIR)
                                 .geometry(PolylineEncoder.encode(combinedPath))
+                                .geoJsonGeometry(GeoJsonLineString.fromLocations(combinedPath))
                                 .steps(combinedSteps)
                                 .hasObstacles(false)
                                 .build();


### PR DESCRIPTION
# 📝 Adopt GeoJSON RFC 7946 For Report And Route Coordinates

Fixes #599

Brings the report and routing endpoints in line with [GeoJSON RFC 7946](https://datatracker.ietf.org/doc/html/rfc7946). Adds `GeoJsonPoint` / `GeoJsonLineString` DTOs, exposes `geometry` on `ReportResponse` and `geoJsonGeometry` on `RouteResponse`, and lets create / update / route requests carry GeoJSON Points in place of the legacy scalar lat/lon pairs. Legacy fields stay on the wire (deprecated) so the web and mobile clients keep working until they cut over.

# 📊 Type of Change
- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactoring
- [ ]  Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# ⏱️ Estimated Review Time
- [x] 5-15 min
- [ ] < 5 min
- [ ] > 15 min