### PR TITLE
[Web] Send And Read GeoJSON Geometry On Report And Routing Endpoints

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -21,6 +21,7 @@ import {
   isReportVisible,
   excludedCount,
 } from '../utils/mapFilters.js'
+import { geoJsonPoint, leafletPathFromLineString } from '../utils/geojson.js'
 import { useTheme } from '../context/ThemeContext.jsx'
 
 // First-visit onboarding flag. Cleared once the user dismisses or completes the
@@ -377,8 +378,8 @@ function Home() {
         method: 'POST',
         headers,
         body: JSON.stringify({
-          startLat: origin.lat, startLon: origin.lng,
-          endLat: dest.lat, endLon: dest.lng,
+          start: geoJsonPoint(origin.lat, origin.lng),
+          end: geoJsonPoint(dest.lat, dest.lng),
           mode: null,
         }),
       })
@@ -389,7 +390,11 @@ function Home() {
       // the new server-side count when the user navigates to /profile.
       if (token) queryClient.invalidateQueries({ queryKey: currentUserKey })
       const mapped = data.map(r => ({
-        coords: decodePolyline(r.geometry),
+        // Prefer the GeoJSON LineString over the legacy encoded polyline string.
+        // Older responses without `geoJsonGeometry` still work via the fallback.
+        coords: r.geoJsonGeometry
+          ? leafletPathFromLineString(r.geoJsonGeometry)
+          : decodePolyline(r.geometry),
         hasObstacles: r.hasObstacles,
         label: r.routeLabel,
         distance: r.distanceMeters,

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -1,5 +1,6 @@
 import { apiFetch } from './api.js'
 import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
+import { geoJsonPoint, reportLatLng } from '../utils/geojson.js'
 
 /**
  * Fetch all reports from the backend.
@@ -196,6 +197,11 @@ export function mapReport(r) {
       : `${labels.join(' & ')} Issue`
   })()
 
+  // Prefer the GeoJSON geometry the backend emits; fall back to the legacy
+  // scalar fields so older responses (and the still-deprecated mobile DTOs)
+  // keep working during the migration.
+  const coords = reportLatLng(r) ?? { lat: r.latitude, lng: r.longitude }
+
   return {
     id: r.reportId,
     title,
@@ -209,7 +215,8 @@ export function mapReport(r) {
     fixedAt: r.fixedAt || null,
     // Prefer the backend-provided label (reverse-geocoded once at create time);
     // fall back to rounded coordinates for older rows where the column is null.
-    location: r.locationLabel || formatReportLocation(r.latitude, r.longitude),
+    // Coords come from the GeoJSON helper so legacy scalars still work.
+    location: r.locationLabel || formatReportLocation(coords.lat, coords.lng),
     reportedBy: `User #${r.userId}`,
     ownerId: r.userId,
     agrees: r.agrees,
@@ -221,8 +228,9 @@ export function mapReport(r) {
     objects,
     image: r.mediaUrls && r.mediaUrls.length > 0 ? r.mediaUrls[0] : null,
     mediaUrls: r.mediaUrls ?? [],
-    latitude: r.latitude,
-    longitude: r.longitude,
+    latitude: coords.lat,
+    longitude: coords.lng,
+    geometry: r.geometry ?? geoJsonPoint(r.latitude, r.longitude),
     activeFixRequest: mapFixRequest(r.activeFixRequest),
     authorTopBadge: r.authorTopBadge ?? null,
   }
@@ -231,12 +239,21 @@ export function mapReport(r) {
 /**
  * Submit a new report.
  * POST /api/reports
+ *
+ * Sends location as a GeoJSON Point per RFC 7946 (coordinates in [lon, lat] order).
  */
 export async function createReport({ userId, latitude, longitude, description, reportType, environment, objects, token }) {
   return apiFetch('/api/reports', {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
-    body: JSON.stringify({ userId, latitude, longitude, description, reportType, environment, objects }),
+    body: JSON.stringify({
+      userId,
+      geometry: geoJsonPoint(latitude, longitude),
+      description,
+      reportType,
+      environment,
+      objects,
+    }),
   })
 }
 

--- a/frontend/src/utils/geojson.js
+++ b/frontend/src/utils/geojson.js
@@ -1,0 +1,68 @@
+/**
+ * Helpers for the GeoJSON RFC 7946 wire format used by the backend.
+ *
+ * The backend exposes coordinates as GeoJSON geometry objects:
+ *   { type: "Point",      coordinates: [longitude, latitude] }
+ *   { type: "LineString", coordinates: [[longitude, latitude], ...] }
+ *
+ * Leaflet, by contrast, uses [latitude, longitude] order everywhere — these
+ * helpers exist so the order swap happens once at the API boundary instead
+ * of being inlined throughout the map components.
+ */
+
+/** Build a GeoJSON Point from a (lat, lng) pair. */
+export function geoJsonPoint(latitude, longitude) {
+  const lat = Number(latitude)
+  const lon = Number(longitude)
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null
+  return { type: 'Point', coordinates: [lon, lat] }
+}
+
+/**
+ * Extract a Leaflet-friendly { lat, lng } from a GeoJSON Point.
+ * Returns null for missing/malformed geometry.
+ */
+export function latLngFromGeoJson(geometry) {
+  if (!geometry || geometry.type !== 'Point') return null
+  const [lon, lat] = geometry.coordinates || []
+  if (!Number.isFinite(lon) || !Number.isFinite(lat)) return null
+  return { lat, lng: lon }
+}
+
+/**
+ * Pick coordinates from an API report, preferring the GeoJSON `geometry`
+ * field and falling back to the legacy `latitude`/`longitude` scalars
+ * for backwards compatibility while the migration is in flight.
+ *
+ * Returns null when neither shape carries usable coordinates — callers can
+ * then render an "unavailable" placeholder. Note the explicit null/empty
+ * guards on the scalar fallback: `Number(null)` is 0, so without them a
+ * missing pair would silently render as the gulf of guinea.
+ */
+export function reportLatLng(report) {
+  if (!report) return null
+  const fromGeometry = latLngFromGeoJson(report.geometry)
+  if (fromGeometry) return fromGeometry
+  if (report.latitude == null || report.longitude == null) return null
+  if (report.latitude === '' || report.longitude === '') return null
+  const lat = Number(report.latitude)
+  const lng = Number(report.longitude)
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
+  return { lat, lng }
+}
+
+/**
+ * Convert a GeoJSON LineString into the [lat, lng] tuple array that Leaflet's
+ * `Polyline` component expects.
+ */
+export function leafletPathFromLineString(lineString) {
+  if (!lineString || lineString.type !== 'LineString') return []
+  const coords = lineString.coordinates || []
+  const path = []
+  for (const pair of coords) {
+    if (!Array.isArray(pair) || pair.length < 2) continue
+    const [lon, lat] = pair
+    if (Number.isFinite(lon) && Number.isFinite(lat)) path.push([lat, lon])
+  }
+  return path
+}


### PR DESCRIPTION
# 📝 Send And Read GeoJSON Geometry On Report And Routing Endpoints

Fixes #600

Pairs with the backend GeoJSON work (#599 / #603). Adds `frontend/src/utils/geojson.js` to keep the Leaflet `[lat, lng]` ↔ GeoJSON `[lon, lat]` swap in one place; `createReport` and the routing call in `Home.jsx` now post GeoJSON geometry; `mapReport` and the polyline renderer prefer the new fields and fall back to the legacy scalar / encoded polyline shapes for in-flight responses.

# 📊 Type of Change
- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactoring
- [ ]  Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min