### PR TITLE
[Mobile] Send And Read GeoJSON Geometry On Report And Routing Endpoints

### DIFF
--- a/mobile/lib/models/report_model.dart
+++ b/mobile/lib/models/report_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../utils/geojson.dart';
 import 'fix_request_model.dart';
 
 // ─── Report-level enums ──────────────────────────────────────────────────────
@@ -733,12 +734,23 @@ class ReportModel {
 
   factory ReportModel.fromJson(Map<String, dynamic> json) {
     final rawObjects = (json['objects'] as List<dynamic>?) ?? const [];
+    // Prefer the GeoJSON `geometry` field (RFC 7946); fall back to the legacy
+    // scalar `latitude` / `longitude` for older responses still in flight.
+    final coords = extractLatLon(json);
+    final entry = extractOptionalLatLon(json,
+        geometryKey: 'entryGeometry',
+        latKey: 'entryLatitude',
+        lonKey: 'entryLongitude');
+    final exit = extractOptionalLatLon(json,
+        geometryKey: 'exitGeometry',
+        latKey: 'exitLatitude',
+        lonKey: 'exitLongitude');
     return ReportModel(
       reportId: (json['reportId'] as num).toInt(),
       userId: (json['userId'] as num).toInt(),
       username: json['username'] as String?,
-      latitude: (json['latitude'] as num).toDouble(),
-      longitude: (json['longitude'] as num).toDouble(),
+      latitude: coords?.lat ?? double.nan,
+      longitude: coords?.lon ?? double.nan,
       description: json['description'] as String? ?? '',
       reportType: ReportType.fromJson(json['reportType'] as String?),
       environment: ReportEnvironment.fromJson(json['environment'] as String?),
@@ -756,10 +768,10 @@ class ReportModel {
       objects: rawObjects
           .map((e) => ReportObject.fromJson(e as Map<String, dynamic>))
           .toList(),
-      entryLatitude: (json['entryLatitude'] as num?)?.toDouble(),
-      entryLongitude: (json['entryLongitude'] as num?)?.toDouble(),
-      exitLatitude: (json['exitLatitude'] as num?)?.toDouble(),
-      exitLongitude: (json['exitLongitude'] as num?)?.toDouble(),
+      entryLatitude: entry?.lat,
+      entryLongitude: entry?.lon,
+      exitLatitude: exit?.lat,
+      exitLongitude: exit?.lon,
       lastEditedByUserId: (json['lastEditedByUserId'] as num?)?.toInt(),
       activeFixRequest: json['activeFixRequest'] is Map
           ? FixRequestModel.fromJson(

--- a/mobile/lib/services/api_service.dart
+++ b/mobile/lib/services/api_service.dart
@@ -7,6 +7,7 @@ import '../models/fix_request_model.dart';
 import '../models/notification_model.dart';
 import '../models/report_model.dart';
 import '../models/routing_preferences.dart';
+import '../utils/geojson.dart';
 
 const _baseUrl = 'https://api.mapcess.live';
 const _apiKey = String.fromEnvironment('API_KEY', defaultValue: 'bounswe2026-local-api-key');
@@ -407,10 +408,12 @@ class ApiService {
     required ReportEnvironment environment,
     required List<ReportObject> objects,
   }) async {
+    // Location goes on the wire as a GeoJSON Point per RFC 7946. The backend
+    // still accepts the legacy `latitude` / `longitude` scalars during the
+    // migration but `geometry` is the canonical field.
     final body = {
       'userId': userId,
-      'latitude': latitude,
-      'longitude': longitude,
+      'geometry': geoJsonPoint(latitude, longitude),
       'description': description,
       'reportType': reportType.jsonValue,
       'environment': environment.jsonValue,
@@ -442,11 +445,16 @@ class ApiService {
     List<ReportObject>? objects,
     List<int>? mediaIdsToRemove,
   }) async {
+    // When the caller changes the pin, send the new location as a GeoJSON
+    // Point. The backend treats it as a partial update and only resets the
+    // stored location when `geometry` (or the legacy scalars) is present.
+    final geometry = (latitude != null && longitude != null)
+        ? geoJsonPoint(latitude, longitude)
+        : null;
     final body = <String, dynamic>{
       if (description != null) 'description': description,
       if (environment != null) 'environment': environment.jsonValue,
-      if (latitude != null) 'latitude': latitude,
-      if (longitude != null) 'longitude': longitude,
+      if (geometry != null) 'geometry': geometry,
       if (objects != null) 'objects': objects.map((o) => o.toJson()).toList(),
       if (mediaIdsToRemove != null) 'mediaIdsToRemove': mediaIdsToRemove,
     };
@@ -524,10 +532,9 @@ class ApiService {
           Uri.parse('$_baseUrl/api/routes'),
           headers: _headers,
           body: jsonEncode({
-            'startLat': startLat,
-            'startLon': startLon,
-            'endLat': endLat,
-            'endLon': endLon,
+            // Start / end go on the wire as GeoJSON Points (RFC 7946).
+            'start': geoJsonPoint(startLat, startLon),
+            'end': geoJsonPoint(endLat, endLon),
             // Sent as `null` (not omitted) so the backend's deserializer
             // sees the field and falls back to the user's preference
             // rather than its global default.

--- a/mobile/lib/utils/geojson.dart
+++ b/mobile/lib/utils/geojson.dart
@@ -1,0 +1,75 @@
+/// Helpers for the GeoJSON RFC 7946 wire format used by the backend.
+///
+/// Backend exposes coordinates as GeoJSON geometry objects:
+///   {"type": "Point",      "coordinates": [longitude, latitude]}
+///   {"type": "LineString", "coordinates": [[longitude, latitude], ...]}
+///
+/// `latlong2.LatLng` and `flutter_map` use `LatLng(lat, lng)` order — the
+/// opposite of GeoJSON's `[lon, lat]`. These helpers centralize the swap so
+/// the order flip happens once at the API boundary instead of inline in
+/// every screen.
+library;
+
+/// Build a GeoJSON Point payload from a (lat, lon) pair.
+/// Returns `null` when either coordinate is non-finite.
+Map<String, dynamic>? geoJsonPoint(double latitude, double longitude) {
+  if (latitude.isNaN || longitude.isNaN ||
+      !latitude.isFinite || !longitude.isFinite) {
+    return null;
+  }
+  return {
+    'type': 'Point',
+    'coordinates': [longitude, latitude],
+  };
+}
+
+/// Pick coordinates from a report JSON map, preferring the GeoJSON `geometry`
+/// field and falling back to the legacy scalar `latitude` / `longitude` for
+/// older responses still in flight. Returns `null` when neither shape carries
+/// usable coordinates — callers can then render a placeholder.
+({double lat, double lon})? extractLatLon(Map<String, dynamic> json) {
+  final geometry = json['geometry'];
+  if (geometry is Map &&
+      geometry['type'] == 'Point' &&
+      geometry['coordinates'] is List) {
+    final coords = geometry['coordinates'] as List;
+    if (coords.length >= 2 &&
+        coords[0] is num &&
+        coords[1] is num) {
+      return (lat: (coords[1] as num).toDouble(), lon: (coords[0] as num).toDouble());
+    }
+  }
+  final lat = json['latitude'];
+  final lon = json['longitude'];
+  if (lat is num && lon is num) {
+    return (lat: lat.toDouble(), lon: lon.toDouble());
+  }
+  return null;
+}
+
+/// Same pattern as [extractLatLon] but for the optional entry/exit point
+/// fields on FEATURE (ramp) reports.
+({double lat, double lon})? extractOptionalLatLon(
+  Map<String, dynamic> json, {
+  required String geometryKey,
+  required String latKey,
+  required String lonKey,
+}) {
+  final geometry = json[geometryKey];
+  if (geometry is Map &&
+      geometry['type'] == 'Point' &&
+      geometry['coordinates'] is List) {
+    final coords = geometry['coordinates'] as List;
+    if (coords.length >= 2 &&
+        coords[0] is num &&
+        coords[1] is num) {
+      return (lat: (coords[1] as num).toDouble(), lon: (coords[0] as num).toDouble());
+    }
+  }
+  final lat = json[latKey];
+  final lon = json[lonKey];
+  if (lat is num && lon is num) {
+    return (lat: lat.toDouble(), lon: lon.toDouble());
+  }
+  return null;
+}


### PR DESCRIPTION
# 📝 Send And Read GeoJSON Geometry On Report And Routing Endpoints,

Note: Since mobile sends requests to the live API, we first need to merge #603 to test this.

Fixes #601

Pairs with the backend GeoJSON work (#599 / #603). Adds `mobile/lib/utils/geojson.dart` to centralize the `LatLng(lat, lng)` ↔ GeoJSON `[lon, lat]` swap; `ApiService.createReport` / `updateReport` / `getRoutes` now POST GeoJSON geometry; `ReportModel.fromJson` reads `geometry` / `entryGeometry` / `exitGeometry` first and falls back to the legacy scalar latitude/longitude pairs for older responses.

# 📊 Type of Change
- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactoring
- [ ]  Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests (mobile test suite kept passing)
- [x] All tests passed

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min