### PR TITLE
[Web] Danger Zone delete-account section on /profile (closes #602)

### DIFF
--- a/frontend/src/components/DangerZoneSection.jsx
+++ b/frontend/src/components/DangerZoneSection.jsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useDeleteAccount } from '../hooks/useProfile.js'
+
+/**
+ * "Danger zone" section for ProfilePage. Closes #602 (1.1.1.2.12).
+ *
+ * One destructive button → confirm modal that requires typing the user's own
+ * email to enable the actual delete action. On success the auth state is
+ * cleared (handled by useDeleteAccount) and the user is redirected to `/`.
+ * Server-side anonymization preserves the user's reports/comments/votes.
+ */
+function DangerZoneSection({ email }) {
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  return (
+    <section className="bg-error/5 border border-error/30 rounded-2xl p-6 flex flex-col gap-3">
+      <h2 className="text-xl font-bold font-headline text-error">Danger zone</h2>
+      <p className="text-sm text-on-surface-variant">
+        Permanently delete your account. Your reports, comments, and validation
+        votes stay on the map but are anonymized — they'll show as submitted by
+        "Deleted User". This cannot be undone.
+      </p>
+      <div>
+        <button
+          type="button"
+          onClick={() => setShowConfirm(true)}
+          className="px-4 py-2 rounded-lg bg-error text-on-error font-semibold cursor-pointer hover:bg-error/90 transition-colors"
+        >
+          Delete my account
+        </button>
+      </div>
+
+      {showConfirm && (
+        <DeleteAccountConfirmModal
+          email={email}
+          onClose={() => setShowConfirm(false)}
+        />
+      )}
+    </section>
+  )
+}
+
+function DeleteAccountConfirmModal({ email, onClose }) {
+  const navigate = useNavigate()
+  const deleteAccountMutation = useDeleteAccount()
+  const [typedEmail, setTypedEmail] = useState('')
+  const [serverError, setServerError] = useState('')
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+    function onKey(e) {
+      if (e.key === 'Escape' && !deleteAccountMutation.isPending) onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose, deleteAccountMutation.isPending])
+
+  const matches = typedEmail.trim().toLowerCase() === (email ?? '').toLowerCase()
+  const disabled = !matches || deleteAccountMutation.isPending
+
+  async function handleConfirm() {
+    setServerError('')
+    try {
+      await deleteAccountMutation.mutateAsync()
+      // Modal will unmount with the page; navigate as the page renders the
+      // logged-out shell anyway, so this is mostly a UX nicety.
+      navigate('/')
+    } catch (e) {
+      setServerError(e.message || 'Failed to delete account.')
+    }
+  }
+
+  function handleBackdrop(e) {
+    if (e.target === e.currentTarget && !deleteAccountMutation.isPending) onClose()
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Confirm account deletion"
+      onClick={handleBackdrop}
+      className="fixed inset-0 z-[1500] flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className="bg-surface-container-lowest rounded-2xl shadow-xl w-full max-w-md flex flex-col p-6 gap-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-bold font-headline text-on-surface">Delete account</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={deleteAccountMutation.isPending}
+            aria-label="Close"
+            className="w-9 h-9 rounded-full bg-error/10 text-error flex items-center justify-center hover:bg-error/20 transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            <span className="material-symbols-outlined">close</span>
+          </button>
+        </div>
+
+        <p className="text-sm text-on-surface-variant">
+          This permanently deletes your account. To confirm, type your email
+          (<span className="font-semibold text-on-surface">{email}</span>) below.
+        </p>
+
+        <label htmlFor="confirm-email" className="text-xs font-bold uppercase tracking-wider text-on-surface-variant">
+          Confirm email
+        </label>
+        <input
+          ref={inputRef}
+          id="confirm-email"
+          type="email"
+          autoComplete="off"
+          value={typedEmail}
+          onChange={(e) => setTypedEmail(e.target.value)}
+          disabled={deleteAccountMutation.isPending}
+          className="w-full px-4 py-2.5 rounded-xl bg-surface-container text-on-surface border border-outline-variant/30 focus:outline-none focus:ring-2 focus:ring-error/40 disabled:opacity-50"
+        />
+
+        {serverError && (
+          <p role="alert" className="text-sm text-error">
+            {serverError}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 mt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={deleteAccountMutation.isPending}
+            className="px-4 py-2 rounded-lg bg-surface-container text-on-surface font-semibold cursor-pointer disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={disabled}
+            className="px-4 py-2 rounded-lg bg-error text-on-error font-semibold cursor-pointer disabled:opacity-50 hover:bg-error/90 transition-colors"
+          >
+            {deleteAccountMutation.isPending ? 'Deleting…' : 'Delete account'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default DangerZoneSection

--- a/frontend/src/hooks/useProfile.js
+++ b/frontend/src/hooks/useProfile.js
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '../context/AuthContext.jsx'
 import {
   deleteAvatar as deleteAvatarRequest,
+  deleteCurrentUser as deleteCurrentUserRequest,
   updateProfile as updateProfileRequest,
   uploadAvatar as uploadAvatarRequest,
 } from '../services/userService.js'
@@ -37,6 +38,22 @@ export function useDeleteAvatar() {
     mutationFn: () => deleteAvatarRequest(userId, token),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: currentUserKey })
+    },
+  })
+}
+
+// Self-delete (1.1.1.2.12). The caller's row is anonymized server-side;
+// we clear the caller's session here so they're logged out client-side.
+// Does not invalidate any other cache — the session goes away and most
+// queries refetch as guest on the next mount.
+export function useDeleteAccount() {
+  const { token, logout } = useAuth()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => deleteCurrentUserRequest(token),
+    onSuccess: () => {
+      queryClient.clear()
+      logout()
     },
   })
 }

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -5,6 +5,7 @@ import AvatarUploader from '../components/AvatarUploader.jsx'
 import BadgeList from '../components/BadgeList.jsx'
 import MyReportsSection from '../components/MyReportsSection.jsx'
 import RoutingPreferencesSection from '../components/RoutingPreferencesSection.jsx'
+import DangerZoneSection from '../components/DangerZoneSection.jsx'
 import { useAuth } from '../context/AuthContext.jsx'
 import { useCurrentUser } from '../hooks/useCurrentUser.js'
 import { useDeleteAvatar, useUpdateProfile, useUploadAvatar } from '../hooks/useProfile.js'
@@ -253,6 +254,8 @@ function ProfilePage() {
             <RoutingPreferencesSection />
 
             <MyReportsSection userId={userId} />
+
+            <DangerZoneSection email={user.email} />
           </>
         )}
       </main>

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -49,6 +49,16 @@ export async function deleteAvatar(id, token) {
   })
 }
 
+// Owner-only self-delete (#594, 1.1.1.2.12). The backend anonymizes the
+// caller in place — name/email/password are scrubbed and the account is
+// banned, while reports/comments/votes stay attached to the anonymized row.
+export async function deleteCurrentUser(token) {
+  return apiFetch('/api/users/me', {
+    method: 'DELETE',
+    headers: authHeaders(token),
+  })
+}
+
 // ───── Gamification ──────────────────────────────────────────────────────
 
 // Public — no token needed. Anonymous callers can view a user's badges.


### PR DESCRIPTION
## 📝 Description
Closes #602 : requirement **1.1.1.2.12**. Adds the frontend half of self-delete, calling the `DELETE /api/users/me` endpoint shipped in #594. On success the client clears its session and redirects to `/`; the server anonymizes the row so reports/comments/votes remain attached to a "Deleted User" placeholder.

Atomic commits:
1. `userService.deleteCurrentUser(token)` → DELETE `/api/users/me`
2. `useDeleteAccount()` mutation , on success: `queryClient.clear()` + `logout()`
3. `DangerZoneSection` component with email-typed confirm modal (Escape/backdrop close, disabled while pending, surfaces server errors inline)
4. Mounted at the bottom of `ProfilePage` below `MyReportsSection`

## 📊 Type
New feature

## 📸 Screenshots
<img width="1243" height="680" alt="Ekran Resmi 2026-05-11 19 51 04" src="https://github.com/user-attachments/assets/e9622276-98ff-44c1-a618-d9fb94ce522f" />

<img width="1281" height="713" alt="Ekran Resmi 2026-05-11 19 51 34" src="https://github.com/user-attachments/assets/8747dcc6-8e55-48b8-9de1-301da1ccd589" />

## ✅ Acceptance Criteria
- [x] `/profile` shows a Danger zone section at the bottom (red accents)
- [x] Clicking Delete opens a confirm modal; confirm button disabled until the user types their own email
- [x] Wrong email keeps the action disabled
- [x] On 204: session cleared, redirected to `/`
- [x] On 409 (last admin): error shown inline in the modal, session preserved
- [x] No regressions , 474 frontend tests pass

## 🧪 Test
- Log in, scroll to bottom of `/profile` → Danger zone visible
- Click Delete → modal opens, confirm disabled
- Type wrong email → still disabled
- Type own email → confirm enabled; click → redirected to `/`, navbar shows logged-out state
- Reload `/profile` after deletion → redirected to `/login`
- `gh api repos/.../users/<id>` (or `/admin/users`) → row shows "Deleted User" / `deleted_<id>@deleted.invalid`
- For the only-admin case → confirm shows the 409 error inline; session intact

## ⏱️ Review Time
~5 min