### PR TITLE
[Backend] Clear bio + avatarUrl on user anonymization (closes #609)

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
@@ -45,8 +45,10 @@ public class RegisteredUserService {
     private final UserBadgeRepository userBadgeRepository;
     private final PointEventRepository pointEventRepository;
     private final LeaderboardService leaderboardService;
+    private final S3MediaService s3MediaService;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(RegisteredUserService.class);
 
     // Password strength regex pattern: Minimum 8 characters, at least one uppercase letter, one lowercase letter, one digit and one special character
     private static final String PASSWORD_PATTERN = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=!]).{8,}$";
@@ -121,14 +123,31 @@ public class RegisteredUserService {
     /**
      * Anonymizes a user in place so FK references from their reports/comments/votes
      * stay valid while PII is erased. Shared by self-delete (1.1.1.2.12) and admin-delete (1.1.1.3.8).
+     *
+     * Clears: name, email, password, bio, avatarUrl (and deletes the underlying S3 object
+     * when present); sets status to BANNED. S3 errors are logged but don't abort the
+     * anonymization — once the user-facing fields are cleared we never want to roll back
+     * the deletion just because the photo was missing or unreachable.
      */
     @Transactional
     public void anonymizeUser(RegisteredUser target) {
+        String oldAvatarUrl = target.getAvatarUrl();
         target.setName("Deleted User");
         target.setEmail("deleted_" + target.getId() + "@deleted.invalid");
         target.setPassword("$DELETED$");
+        target.setBio(null);
+        target.setAvatarUrl(null);
         target.setStatus(UserStatus.BANNED);
         registeredUserRepository.save(target);
+
+        if (oldAvatarUrl != null && !oldAvatarUrl.isBlank()) {
+            try {
+                s3MediaService.deleteFile(oldAvatarUrl);
+            } catch (Exception e) {
+                log.warn("Failed to delete avatar S3 object during anonymization of user {}: {}",
+                        target.getId(), e.getMessage());
+            }
+        }
     }
 
     /**

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -44,6 +44,7 @@ class RegisteredUserServiceTest {
     @Mock private UserBadgeRepository userBadgeRepository;
     @Mock private PointEventRepository pointEventRepository;
     @Mock private LeaderboardService leaderboardService;
+    @Mock private S3MediaService s3MediaService;
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private JwtUtil jwtUtil;
 
@@ -626,7 +627,36 @@ class RegisteredUserServiceTest {
         assertEquals("Deleted User", saved.getName());
         assertEquals("deleted_1@deleted.invalid", saved.getEmail());
         assertEquals("$DELETED$", saved.getPassword());
+        assertNull(saved.getBio());
+        assertNull(saved.getAvatarUrl());
         assertEquals(UserStatus.BANNED, saved.getStatus());
+        verify(s3MediaService).deleteFile("https://cdn/old.jpg");
+    }
+
+    @Test
+    void deleteSelf_noAvatar_skipsS3Delete() {
+        mockUser.setAvatarUrl(null);
+        when(registeredUserRepository.findByEmail("test@test.com")).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        registeredUserService.deleteSelf("test@test.com");
+
+        verify(s3MediaService, never()).deleteFile(any());
+    }
+
+    @Test
+    void deleteSelf_s3DeleteFails_stillAnonymizes() {
+        when(registeredUserRepository.findByEmail("test@test.com")).thenReturn(Optional.of(mockUser));
+        when(registeredUserRepository.save(any(RegisteredUser.class))).thenAnswer(inv -> inv.getArgument(0));
+        doThrow(new RuntimeException("S3 down")).when(s3MediaService).deleteFile(any());
+
+        registeredUserService.deleteSelf("test@test.com");
+
+        ArgumentCaptor<RegisteredUser> captor = ArgumentCaptor.forClass(RegisteredUser.class);
+        verify(registeredUserRepository).save(captor.capture());
+        assertEquals("Deleted User", captor.getValue().getName());
+        assertNull(captor.getValue().getBio());
+        assertNull(captor.getValue().getAvatarUrl());
     }
 
     @Test


### PR DESCRIPTION
## 📝 Description
Closes #609. Stacks on #594. `RegisteredUserService.anonymizeUser` now clears `bio` and `avatarUrl` alongside name/email/password/status, and deletes the underlying S3 object so the photo doesn't outlive the account.

S3 deletion is wrapped in `try/catch` , a missing or unreachable object logs a warning but does not roll back the anonymization. The user-facing fields are already cleared in the DB by that point, so failing the request would leave an inconsistent state.

Both self-delete (#594) and admin-delete inherit the fix automatically , they share the same helper.

## 📊 Type
Bug / polish

## ✅ Acceptance Criteria
- [x] `bio` is null after self-delete or admin-delete
- [x] `avatarUrl` is null after self-delete or admin-delete
- [x] S3 object is deleted via `S3MediaService.deleteFile(...)` when present
- [x] S3 failure logs a warning but doesn't fail the anonymization (verified by test)
- [x] No avatar → no S3 call (verified by test)
- [x] Existing tests still pass

## 🧪 How to Test
```bash
# Set a bio + upload an avatar, then self-delete
TOKEN=$(curl -s -X POST http://localhost:8080/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"test@test.com","password":"Test1234!"}' | jq -r .token)

curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
  http://localhost:8080/api/users/me -o /dev/null -w "%{http_code}\n"   # 204

curl -s http://localhost:8080/api/users/<id> | jq '{name,email,bio,avatarUrl}'
# { "name":"Deleted User", "email":"deleted_<id>@deleted.invalid", "bio":null, "avatarUrl":null }
```

## ⏱️ Estimated Review Time
~3 min