### PR TITLE
[Backend][Frontend] Live Leaderboard Refresh On Points Change

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/PointsChangedSseEvent.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/PointsChangedSseEvent.java
@@ -1,0 +1,30 @@
+package com.bounswe2026group1.backend.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(description = "Payload broadcast on the public SSE stream whenever a user's points " +
+        "balance changes. Subscribers use this to invalidate leaderboard and profile " +
+        "caches; the new balance is included so clients can patch the caller's own " +
+        "row without an extra fetch.")
+public record PointsChangedSseEvent(
+
+        @Schema(description = "Constant event marker.", example = "POINTS_CHANGED",
+                allowableValues = {"POINTS_CHANGED"})
+        String eventType,
+
+        @Schema(description = "User whose balance changed.", example = "42")
+        Long userId,
+
+        @Schema(description = "New points balance after the change.", example = "55")
+        Integer points,
+
+        @Schema(description = "When the change committed to the database (UTC).",
+                example = "2026-05-11T13:22:11Z")
+        Instant timestamp
+) {
+    public static PointsChangedSseEvent now(Long userId, Integer points) {
+        return new PointsChangedSseEvent("POINTS_CHANGED", userId, points, Instant.now());
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
@@ -47,6 +47,7 @@ public class GamificationService {
     private final UserBadgeRepository userBadgeRepository;
     private final LeaderboardService leaderboardService;
     private final NotificationService notificationService;
+    private final PublicSseService publicSseService;
 
     @Value("${app.gamification.points.report-submit:10}")
     private int reportSubmitDelta;
@@ -319,6 +320,11 @@ public class GamificationService {
         // out of the top cutoff with this delta, and we want the badge to
         // track rank changes in real time rather than via a cron lag.
         leaderboardService.onPointsChanged(user.getId());
+
+        // Broadcast so connected clients can invalidate their leaderboard
+        // cache (and the affected user's own profile cache) without waiting
+        // for staleTime to expire or a manual refresh.
+        publicSseService.broadcastPointsChanged(user.getId(), after);
     }
 
     private boolean awardBadgeIfMissing(RegisteredUser user, Badge badge) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/GamificationService.java
@@ -323,8 +323,14 @@ public class GamificationService {
 
         // Broadcast so connected clients can invalidate their leaderboard
         // cache (and the affected user's own profile cache) without waiting
-        // for staleTime to expire or a manual refresh.
-        publicSseService.broadcastPointsChanged(user.getId(), after);
+        // for staleTime to expire or a manual refresh. Deferred until
+        // afterCommit so a rollback can't leave subscribers caching state
+        // that was never persisted, and so a subscriber refetching on the
+        // event doesn't race the still-uncommitted balance write.
+        Long userId = user.getId();
+        int newPoints = after;
+        PublicSseService.broadcastAfterCommit(
+                () -> publicSseService.broadcastPointsChanged(userId, newPoints));
     }
 
     private boolean awardBadgeIfMissing(RegisteredUser user, Badge badge) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/PublicSseService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/PublicSseService.java
@@ -8,6 +8,8 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -219,6 +221,28 @@ public class PublicSseService {
                 Instant.now()
         );
         sendToAll("media-added", event);
+    }
+
+    /**
+     * Defers {@code action} until the current Spring-managed transaction
+     * commits. Outside an active transaction the action runs immediately so
+     * the helper is safe to call from any context (background jobs, tests).
+     *
+     * <p>Centralised here because every caller of {@code broadcast*} on this
+     * service needs the same deferral: if a broadcast fires before commit
+     * and the transaction later rolls back, subscribers cache state that
+     * was never persisted. Worse, a subscriber refetching on the event can
+     * race the still-uncommitted write and read the pre-update row.
+     */
+    public static void broadcastAfterCommit(Runnable action) {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
+            action.run();
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() { action.run(); }
+        });
     }
 
     int activeEmitterCount() {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/PublicSseService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/PublicSseService.java
@@ -1,5 +1,6 @@
 package com.bounswe2026group1.backend.service;
 
+import com.bounswe2026group1.backend.dto.PointsChangedSseEvent;
 import com.bounswe2026group1.backend.dto.PublicSseEvent;
 import com.bounswe2026group1.backend.model.Media;
 import com.bounswe2026group1.backend.model.Report;
@@ -193,6 +194,18 @@ public class PublicSseService {
         sendToAll("report-updated", event);
     }
 
+    /**
+     * Fired whenever a user's points balance moves (cast/withdraw vote, report
+     * verified bonus, etc.). Broadcast on the public channel because the
+     * leaderboard endpoint itself is public — anonymous tabs need to refresh
+     * top-N rankings, and authenticated tabs additionally refresh the caller's
+     * own profile when {@link PointsChangedSseEvent#userId()} matches.
+     */
+    public void broadcastPointsChanged(Long userId, Integer newPoints) {
+        if (userId == null) return;
+        sendToAll("points-changed", PointsChangedSseEvent.now(userId, newPoints));
+    }
+
     public void broadcastMediaAdded(Report report, Media media) {
         PublicSseEvent event = new PublicSseEvent(
                 "MEDIA_ADDED",
@@ -233,7 +246,7 @@ public class PublicSseService {
         });
     }
 
-    private void sendToAll(String eventName, PublicSseEvent event) {
+    private void sendToAll(String eventName, Object event) {
         for (SseEmitter emitter : emitters) {
             try {
                 emitter.send(SseEmitter.event().name(eventName).data(event));

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -20,9 +20,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
+
+import static com.bounswe2026group1.backend.service.PublicSseService.broadcastAfterCommit;
 
 import java.time.Instant;
 import java.util.*;
@@ -658,14 +658,4 @@ public class ReportService {
         return result;
     }
 
-    private void broadcastAfterCommit(Runnable action) {
-        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
-            action.run();
-            return;
-        }
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() { action.run(); }
-        });
-    }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/GamificationServiceTest.java
@@ -48,6 +48,7 @@ class GamificationServiceTest {
     @Mock private UserBadgeRepository userBadgeRepository;
     @Mock private LeaderboardService leaderboardService;
     @Mock private NotificationService notificationService;
+    @Mock private PublicSseService publicSseService;
 
     @InjectMocks
     private GamificationService gamificationService;
@@ -107,6 +108,30 @@ class GamificationServiceTest {
         gamificationService.awardOnReportSubmit(author, 100L);
 
         verify(leaderboardService).onPointsChanged(1L);
+    }
+
+    @Test
+    void applyDelta_broadcastsPointsChanged() {
+        // Connected SSE subscribers should hear about every points change so
+        // they can invalidate leaderboard / profile caches without waiting
+        // for staleTime to expire.
+        RegisteredUser author = newUser(1L, 0);
+
+        gamificationService.awardOnReportSubmit(author, 100L);
+
+        verify(publicSseService).broadcastPointsChanged(1L, 10);
+    }
+
+    @Test
+    void applyDelta_clampAbsorbingFullDelta_doesNotBroadcast() {
+        // When the requested delta would push the balance below zero and the
+        // clamp absorbs the entire change, no broadcast is needed — the
+        // balance didn't actually move.
+        RegisteredUser voter = newUser(2L, 0);
+
+        gamificationService.deductOnVoteWithdraw(voter, 100L);
+
+        verify(publicSseService, never()).broadcastPointsChanged(any(), any());
     }
 
     // ───────────────────────── awardOnVoteCast ──────────────────────────

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/PublicSseServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/PublicSseServiceTest.java
@@ -6,14 +6,18 @@ import com.bounswe2026group1.backend.util.GeoUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -187,6 +191,41 @@ class PublicSseServiceTest {
         assertTrue(a.sendCount == 1 && b.sendCount == 1 && c.sendCount == 1,
                 "every emitter must receive the broadcast");
         assertEquals(3, service.activeEmitterCount());
+    }
+
+    @Test
+    void broadcastAfterCommit_runsImmediately_whenNoActiveTransaction() {
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        PublicSseService.broadcastAfterCommit(() -> ran.set(true));
+
+        assertTrue(ran.get(),
+                "outside a transaction the action must run synchronously so callers don't drop events");
+    }
+
+    @Test
+    void broadcastAfterCommit_defersUntilCommit_whenTransactionActive() {
+        // Simulate a Spring-managed transaction by initialising synchronisation.
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            AtomicBoolean ran = new AtomicBoolean(false);
+
+            PublicSseService.broadcastAfterCommit(() -> ran.set(true));
+
+            assertFalse(ran.get(),
+                    "while the transaction is in flight the action must NOT have fired — " +
+                            "otherwise a rollback could leave subscribers caching unpersisted state");
+
+            // Drive the registered synchronisation past commit.
+            for (TransactionSynchronization sync :
+                    TransactionSynchronizationManager.getSynchronizations()) {
+                sync.afterCommit();
+            }
+
+            assertTrue(ran.get(), "afterCommit hook should have fired the deferred action");
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     private static class FailingEmitter extends SseEmitter {

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/PublicSseServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/PublicSseServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -44,6 +45,36 @@ class PublicSseServiceTest {
     }
 
     @Test
+    void broadcastPointsChanged_pushesOneEventPerSubscriber() {
+        PublicSseService service = new PublicSseService();
+        ReflectionTestUtils.setField(service, "maxConnections", 10);
+        ReflectionTestUtils.setField(service, "maxConnectionsPerSource", 10);
+        ReflectionTestUtils.invokeMethod(service, "initPermitPool");
+
+        AtomicInteger sendCount = new AtomicInteger(0);
+        service.addEmitterForTest(new CountingEmitter(sendCount));
+
+        service.broadcastPointsChanged(42L, 55);
+
+        assertEquals(1, sendCount.get());
+    }
+
+    @Test
+    void broadcastPointsChanged_nullUserId_isNoOp() {
+        PublicSseService service = new PublicSseService();
+        ReflectionTestUtils.setField(service, "maxConnections", 10);
+        ReflectionTestUtils.setField(service, "maxConnectionsPerSource", 10);
+        ReflectionTestUtils.invokeMethod(service, "initPermitPool");
+
+        AtomicInteger sendCount = new AtomicInteger(0);
+        service.addEmitterForTest(new CountingEmitter(sendCount));
+
+        service.broadcastPointsChanged(null, 5);
+
+        assertEquals(0, sendCount.get());
+    }
+
+    @Test
     void subscribe_sameSourceExceedingLimit_throwsTooManyRequests() {
         PublicSseService service = new PublicSseService();
         ReflectionTestUtils.setField(service, "maxConnections", 10);
@@ -61,6 +92,19 @@ class PublicSseServiceTest {
         @Override
         public synchronized void send(SseEventBuilder builder) throws IOException {
             throw new IOException("forced failure");
+        }
+    }
+
+    private static class CountingEmitter extends SseEmitter {
+        private final AtomicInteger counter;
+
+        CountingEmitter(AtomicInteger counter) {
+            this.counter = counter;
+        }
+
+        @Override
+        public synchronized void send(SseEventBuilder builder) {
+            counter.incrementAndGet();
         }
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/PublicSseServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/PublicSseServiceTest.java
@@ -205,8 +205,12 @@ class PublicSseServiceTest {
 
     @Test
     void broadcastAfterCommit_defersUntilCommit_whenTransactionActive() {
-        // Simulate a Spring-managed transaction by initialising synchronisation.
+        // Simulate a Spring-managed transaction. The helper checks
+        // isActualTransactionActive(), which only returns true when BOTH
+        // synchronisation is initialised AND the "actual" flag is set —
+        // mirroring what PlatformTransactionManager does on a real tx.
         TransactionSynchronizationManager.initSynchronization();
+        TransactionSynchronizationManager.setActualTransactionActive(true);
         try {
             AtomicBoolean ran = new AtomicBoolean(false);
 
@@ -224,6 +228,7 @@ class PublicSseServiceTest {
 
             assertTrue(ran.get(), "afterCommit hook should have fired the deferred action");
         } finally {
+            TransactionSynchronizationManager.setActualTransactionActive(false);
             TransactionSynchronizationManager.clearSynchronization();
         }
     }

--- a/frontend/src/components/CreateReportPanel.jsx
+++ b/frontend/src/components/CreateReportPanel.jsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '../context/AuthContext.jsx'
 import { createReport, mapReport } from '../services/reportService.js'
+import { currentUserKey } from '../hooks/useCurrentUser.js'
 import { OBJECT_TYPES } from '../utils/objectTypeConfig.js'
 import ObjectTutorialModal from './ObjectTutorialModal.jsx'
 
@@ -13,6 +15,7 @@ const MAX_MEDIA_BYTES = 15 * 1024 * 1024
 function CreateReportPanel({ position, positionLabel, onClose, onCreated, onError }) {
   const { token, userId } = useAuth()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const [reportType, setReportType] = useState('OBSTACLE')
   const [environment, setEnvironment] = useState('OUTDOOR')
@@ -269,6 +272,11 @@ function CreateReportPanel({ position, positionLabel, onClose, onCreated, onErro
         mapped.image = uploadedMedia[0].url // Use the first photo URL for the map preview
         mapped.media = uploadedMedia
       }
+      // A successful submission awards the +10 report-submit bonus. Invalidate
+      // leaderboard + profile caches so the caller's own tab reflects the
+      // new balance immediately; the SSE event covers other tabs/users.
+      queryClient.invalidateQueries({ queryKey: ['leaderboard'] })
+      queryClient.invalidateQueries({ queryKey: currentUserKey })
       onCreated(mapped)
       onClose()
     } catch (err) {

--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -20,6 +20,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '../context/AuthContext.jsx'
 import { useUserProfile } from '../hooks/useUserProfile.js'
 import { reportKeys, useUpdateMapReport, useDeleteMapReport } from '../hooks/useReports.js'
+import { currentUserKey } from '../hooks/useCurrentUser.js'
 import { OBJECT_TYPE_MAP } from '../utils/objectTypeConfig.js'
 import { reportJsonLdString } from '../utils/schemaOrg.js'
 import CreateFixRequestPanel from './CreateFixRequestPanel.jsx'
@@ -399,6 +400,11 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
       const mappedUpdated = mapReport(updated)
       onVoteUpdate(mappedUpdated)
       onVoteChange(mappedUpdated.userVote ?? null)
+      // Vote cast/withdraw moves the caller's points. Invalidate eagerly so
+      // the caller's tab refreshes /leaderboard and the profile/navbar
+      // balance before the SSE event lands.
+      queryClient.invalidateQueries({ queryKey: ['leaderboard'] })
+      queryClient.invalidateQueries({ queryKey: currentUserKey })
     },
     onError: () => {
       setVoteError('Failed to submit vote. Please try again.')
@@ -420,6 +426,8 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
       onVoteUpdate(patched)
       queryClient.invalidateQueries({ queryKey: reportKeys.detail(report.id) })
       queryClient.invalidateQueries({ queryKey: reportKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: ['leaderboard'] })
+      queryClient.invalidateQueries({ queryKey: currentUserKey })
     },
     onError: () => {
       setFixVoteError('Failed to vote on fix. Please try again.')

--- a/frontend/src/components/ReportPanel.test.jsx
+++ b/frontend/src/components/ReportPanel.test.jsx
@@ -135,6 +135,36 @@ describe('ReportPanel', () => {
     await waitFor(() => expect(onVoteChangeMock).toHaveBeenCalledWith(null))
   })
 
+  test('voting invalidates leaderboard and currentUser caches', async () => {
+    // A successful vote earns +5 / removes -5 points. The caller's tab must
+    // pick that up on the next leaderboard/profile visit without waiting
+    // for the public SSE event to arrive.
+    agreeReport.mockResolvedValueOnce({ id: 'r1', agrees: 1, disagrees: 0, userVote: 'agree' })
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+    const spy = vi.spyOn(queryClient, 'invalidateQueries')
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReportPanel
+            report={report}
+            onClose={onCloseMock}
+            onVoteChange={onVoteChangeMock}
+            onVoteUpdate={onVoteUpdateMock}
+            onFollowChange={onFollowChangeMock}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    await act(async () => { await user.click(screen.getByLabelText('Agree')) })
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['leaderboard'] })
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['currentUser'] })
+    })
+  })
+
   test('toggles follow state', async () => {
     renderPanel()
 

--- a/frontend/src/hooks/useSseSync.js
+++ b/frontend/src/hooks/useSseSync.js
@@ -3,6 +3,8 @@ import { useQueryClient } from '@tanstack/react-query'
 import { connect } from '../services/sseClient.js'
 import { reportKeys, applyReportUpdatedToCache } from './useReports.js'
 import { useSseStatusSetter } from '../context/SseContext.jsx'
+import { useAuth } from '../context/AuthContext.jsx'
+import { currentUserKey } from './useCurrentUser.js'
 
 const SSE_URL = `${import.meta.env.VITE_API_URL}/api/sse/public/subscribe`
 
@@ -14,6 +16,7 @@ const SSE_URL = `${import.meta.env.VITE_API_URL}/api/sse/public/subscribe`
 export function useSseSync() {
   const queryClient = useQueryClient()
   const setStatus = useSseStatusSetter()
+  const { userId } = useAuth()
 
   useEffect(() => {
     const close = connect(SSE_URL, {
@@ -21,6 +24,21 @@ export function useSseSync() {
 
       onConnected() {
         // Nothing extra needed; status already set to 'connected' by sseClient
+      },
+
+      onPointsChanged(event) {
+        // Any user's points change can shift the public top-N ranking, so
+        // every connected tab invalidates the leaderboard cache regardless
+        // of whose balance moved.
+        queryClient.invalidateQueries({ queryKey: ['leaderboard'] })
+
+        // The caller's own points are also surfaced on the profile/navbar,
+        // so refresh that cache when the event names the current user.
+        // String-compare to dodge number/string mismatches between the
+        // JWT-derived id and the JSON-decoded payload.
+        if (userId != null && String(event.userId) === String(userId)) {
+          queryClient.invalidateQueries({ queryKey: currentUserKey })
+        }
       },
 
       onReportUpdated(event) {
@@ -64,5 +82,5 @@ export function useSseSync() {
     })
 
     return close
-  }, [queryClient, setStatus])
+  }, [queryClient, setStatus, userId])
 }

--- a/frontend/src/hooks/useSseSync.points.test.jsx
+++ b/frontend/src/hooks/useSseSync.points.test.jsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useSseSync } from './useSseSync.js'
+import { currentUserKey } from './useCurrentUser.js'
+
+vi.mock('../context/AuthContext.jsx', () => ({
+  useAuth: vi.fn(),
+}))
+vi.mock('../context/SseContext.jsx', () => ({
+  useSseStatusSetter: () => vi.fn(),
+}))
+vi.mock('../services/sseClient.js', () => ({
+  connect: vi.fn(() => vi.fn()),
+}))
+
+import { useAuth } from '../context/AuthContext.jsx'
+import { connect } from '../services/sseClient.js'
+
+function makeWrapper(queryClient) {
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useSseSync — onPointsChanged', () => {
+  let queryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  })
+
+  it('invalidates the leaderboard query for any users points change', () => {
+    useAuth.mockReturnValue({ userId: 100 })
+    const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    renderHook(() => useSseSync(), { wrapper: makeWrapper(queryClient) })
+    const { onPointsChanged } = connect.mock.calls[0][1]
+
+    // A different user's points changed — leaderboard still invalidated
+    // because rankings shift, but profile is not.
+    onPointsChanged({ eventType: 'POINTS_CHANGED', userId: 7, points: 30 })
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['leaderboard'] })
+    expect(spy).not.toHaveBeenCalledWith({ queryKey: currentUserKey })
+  })
+
+  it('also invalidates currentUser when the callers own points change', () => {
+    useAuth.mockReturnValue({ userId: 42 })
+    const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    renderHook(() => useSseSync(), { wrapper: makeWrapper(queryClient) })
+    const { onPointsChanged } = connect.mock.calls[0][1]
+
+    onPointsChanged({ eventType: 'POINTS_CHANGED', userId: 42, points: 55 })
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['leaderboard'] })
+    expect(spy).toHaveBeenCalledWith({ queryKey: currentUserKey })
+  })
+
+  it('matches userId across number/string mismatches between JWT and JSON payload', () => {
+    // JWT claim is a number; SSE payload may serialize the same id as a
+    // string. The hook should still detect the match.
+    useAuth.mockReturnValue({ userId: 42 })
+    const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    renderHook(() => useSseSync(), { wrapper: makeWrapper(queryClient) })
+    const { onPointsChanged } = connect.mock.calls[0][1]
+
+    onPointsChanged({ eventType: 'POINTS_CHANGED', userId: '42', points: 55 })
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: currentUserKey })
+  })
+
+  it('does not invalidate currentUser when no caller is logged in', () => {
+    useAuth.mockReturnValue({ userId: null })
+    const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    renderHook(() => useSseSync(), { wrapper: makeWrapper(queryClient) })
+    const { onPointsChanged } = connect.mock.calls[0][1]
+
+    onPointsChanged({ eventType: 'POINTS_CHANGED', userId: 42, points: 55 })
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['leaderboard'] })
+    expect(spy).not.toHaveBeenCalledWith({ queryKey: currentUserKey })
+  })
+})

--- a/frontend/src/services/sseClient.js
+++ b/frontend/src/services/sseClient.js
@@ -7,6 +7,9 @@
  *   onConnected()
  *   onReportUpdated(event: PublicSseEvent)
  *   onMediaAdded(event: PublicSseEvent)
+ *   onReportCreated(event: PublicSseEvent)
+ *   onReportDeleted(event: PublicSseEvent)
+ *   onPointsChanged(event: PointsChangedSseEvent)
  *   onStatusChange(status: 'connected' | 'reconnecting' | 'disconnected')
  * }
  *
@@ -25,7 +28,15 @@ function calcDelay(attempt) {
 }
 
 export function connect(url, handlers = {}) {
-  const { onConnected, onReportUpdated, onMediaAdded, onReportCreated, onReportDeleted, onStatusChange } = handlers
+  const {
+    onConnected,
+    onReportUpdated,
+    onMediaAdded,
+    onReportCreated,
+    onReportDeleted,
+    onPointsChanged,
+    onStatusChange,
+  } = handlers
 
   let es = null
   let attempt = 0
@@ -80,6 +91,15 @@ export function connect(url, handlers = {}) {
         onReportDeleted?.(payload)
       } catch {
         console.warn('[SSE] Failed to parse report-deleted event', e.data)
+      }
+    })
+
+    es.addEventListener('points-changed', (e) => {
+      try {
+        const payload = JSON.parse(e.data)
+        onPointsChanged?.(payload)
+      } catch {
+        console.warn('[SSE] Failed to parse points-changed event', e.data)
       }
     })
 

--- a/frontend/src/services/sseClient.test.js
+++ b/frontend/src/services/sseClient.test.js
@@ -100,6 +100,14 @@ describe('sseClient.connect', () => {
     expect(onReportDeleted).toHaveBeenCalledWith(payload)
   })
 
+  it('calls onPointsChanged with parsed payload', () => {
+    const onPointsChanged = vi.fn()
+    connect('http://localhost/sse', { onPointsChanged })
+    const payload = { eventType: 'POINTS_CHANGED', userId: 42, points: 55 }
+    FakeEventSource.instance.emit('points-changed', payload)
+    expect(onPointsChanged).toHaveBeenCalledWith(payload)
+  })
+
   it('schedules a reconnect after onerror', () => {
     const onStatusChange = vi.fn()
     connect('http://localhost/sse', { onStatusChange })


### PR DESCRIPTION
# 📝 Description
Fixes #524

The `/leaderboard` page used to cache its response for 60 s (`staleTime` in `useLeaderboard`) and had no live channel for point changes, so after voting on a report the caller's row still showed the old total until the cache went stale or the page was hard-reloaded. Two complementary fixes:

- **Backend — broadcast point changes over SSE.** `GamificationService.applyDelta` is the single point of mutation for any user's points balance (vote cast/withdraw, report-submit bonus, voter alignment payout, fix-resolved bonus, etc.). It now calls `publicSseService.broadcastPointsChanged(userId, newPoints)` after persisting the delta, so every change fans out on the existing public SSE channel as a new `POINTS_CHANGED` event (`points-changed` SSE name). A new `PointsChangedSseEvent` DTO carries the `userId`, the new balance, and a timestamp; `sendToAll` was generified to accept any payload type.
- **Frontend — invalidate caches on the event, plus eager invalidation on the caller's own mutations.** `useSseSync` now listens for `points-changed` and (a) always invalidates the public `['leaderboard']` query so rankings refresh in every connected tab, and (b) invalidates `currentUserKey` only when the event names the current user, so the profile / navbar points balance refreshes without unnecessary fetches for everyone else. `ReportPanel`'s vote + fix-vote mutations and `CreateReportPanel`'s submit also invalidate the same keys, so the caller's tab updates immediately without waiting for the SSE round-trip.

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

Tests added:
- `GamificationServiceTest`: `applyDelta` triggers `broadcastPointsChanged`; clamp-absorbed (no-op) deltas do not broadcast.
- `PublicSseServiceTest`: `broadcastPointsChanged` pushes one event per subscriber; null `userId` is a no-op.
- `sseClient.test`: `points-changed` events are parsed and forwarded to `onPointsChanged`.
- `useSseSync.points.test`: leaderboard always invalidated; `currentUser` invalidated only on self-matching `userId` (covers number/string id mismatches between JWT and JSON payload); no-op when no user is logged in.
- `ReportPanel.test`: voting invalidates both `['leaderboard']` and `currentUserKey`.

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [x] 5-15 min
