### PR TITLE
[Web] Dark-mode polish : elevate cards, fix medal chips, rank banner, feed chips (closes #612)

### DIFF
--- a/frontend/src/components/MyReportsSection.jsx
+++ b/frontend/src/components/MyReportsSection.jsx
@@ -29,7 +29,7 @@ function MyReportsSection({ userId, isOwnProfile = true }) {
   const selected = reports?.find((r) => r.id === selectedId) ?? null
 
   return (
-    <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6">
+    <section className="bg-surface-container-low rounded-2xl shadow-sm p-6">
       <h2 className="text-xl font-bold font-headline text-on-surface mb-4">
         {isOwnProfile ? 'My Reports' : 'Reports'}{reports ? ` (${reports.length})` : ''}
       </h2>

--- a/frontend/src/components/MyReportsSection.jsx
+++ b/frontend/src/components/MyReportsSection.jsx
@@ -29,7 +29,7 @@ function MyReportsSection({ userId, isOwnProfile = true }) {
   const selected = reports?.find((r) => r.id === selectedId) ?? null
 
   return (
-    <section className="bg-surface-container-low rounded-2xl shadow-sm p-6">
+    <section className="bg-surface-container rounded-2xl shadow-sm p-6">
       <h2 className="text-xl font-bold font-headline text-on-surface mb-4">
         {isOwnProfile ? 'My Reports' : 'Reports'}{reports ? ` (${reports.length})` : ''}
       </h2>

--- a/frontend/src/components/RoutingPreferencesSection.jsx
+++ b/frontend/src/components/RoutingPreferencesSection.jsx
@@ -60,7 +60,7 @@ function PresetCard({
       className={`relative text-left p-4 rounded-2xl border-2 transition-colors flex flex-col gap-2 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary/40 ${
         active
           ? 'border-primary bg-primary/5'
-          : 'border-outline-variant bg-surface-container-lowest hover:border-primary/40'
+          : 'border-outline-variant bg-surface-container hover:border-primary/40'
       } ${disabled ? 'opacity-60 cursor-wait' : ''}`}
     >
       {active && (
@@ -127,7 +127,7 @@ function RoutingPreferencesSection() {
 
   if (isPending) {
     return (
-      <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6">
+      <section className="bg-surface-container-low rounded-2xl shadow-sm p-6">
         <p className="text-sm text-on-surface-variant">Loading routing preferences…</p>
       </section>
     )
@@ -135,7 +135,7 @@ function RoutingPreferencesSection() {
 
   if (isError) {
     return (
-      <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-2">
+      <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-2">
         <p role="alert" className="text-sm text-error">
           Failed to load routing preferences{error?.message ? `: ${error.message}` : '.'}
         </p>
@@ -244,7 +244,7 @@ function RoutingPreferencesSection() {
     createCustom.isPending || updateCustom.isPending || deleteCustom.isPending
 
   return (
-    <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+    <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-4">
       <div className="flex items-baseline justify-between gap-2 flex-wrap">
         <h2 className="text-xl font-bold font-headline text-on-surface">Routing preferences</h2>
         <span className="text-xs text-on-surface-variant">

--- a/frontend/src/components/RoutingPreferencesSection.jsx
+++ b/frontend/src/components/RoutingPreferencesSection.jsx
@@ -60,7 +60,7 @@ function PresetCard({
       className={`relative text-left p-4 rounded-2xl border-2 transition-colors flex flex-col gap-2 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary/40 ${
         active
           ? 'border-primary bg-primary/5'
-          : 'border-outline-variant bg-surface-container hover:border-primary/40'
+          : 'border-outline-variant bg-surface-container-high hover:border-primary/40'
       } ${disabled ? 'opacity-60 cursor-wait' : ''}`}
     >
       {active && (
@@ -127,7 +127,7 @@ function RoutingPreferencesSection() {
 
   if (isPending) {
     return (
-      <section className="bg-surface-container-low rounded-2xl shadow-sm p-6">
+      <section className="bg-surface-container rounded-2xl shadow-sm p-6">
         <p className="text-sm text-on-surface-variant">Loading routing preferences…</p>
       </section>
     )
@@ -135,7 +135,7 @@ function RoutingPreferencesSection() {
 
   if (isError) {
     return (
-      <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-2">
+      <section className="bg-surface-container rounded-2xl shadow-sm p-6 flex flex-col gap-2">
         <p role="alert" className="text-sm text-error">
           Failed to load routing preferences{error?.message ? `: ${error.message}` : '.'}
         </p>
@@ -244,7 +244,7 @@ function RoutingPreferencesSection() {
     createCustom.isPending || updateCustom.isPending || deleteCustom.isPending
 
   return (
-    <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+    <section className="bg-surface-container rounded-2xl shadow-sm p-6 flex flex-col gap-4">
       <div className="flex items-baseline justify-between gap-2 flex-wrap">
         <h2 className="text-xl font-bold font-headline text-on-surface">Routing preferences</h2>
         <span className="text-xs text-on-surface-variant">

--- a/frontend/src/pages/Feed.jsx
+++ b/frontend/src/pages/Feed.jsx
@@ -239,7 +239,7 @@ export default function Feed() {
           </h1>
         </header>
 
-        <section className="rounded-2xl border border-outline-variant/20 bg-white dark:bg-surface-container-lowest shadow-sm p-6 md:p-8 flex flex-col gap-6">
+        <section className="rounded-2xl border border-outline-variant/20 bg-surface-container-low shadow-sm p-6 md:p-8 flex flex-col gap-6">
           {/* Filters + radius: one row, aligned */}
           <div className="flex flex-wrap items-end gap-x-6 gap-y-4 justify-between">
             <div className="flex flex-wrap items-end gap-x-8 gap-y-4 flex-1 min-w-0">
@@ -367,7 +367,7 @@ export default function Feed() {
               <li key={report.id} className="min-w-0">
                 <Link
                   to={`/?report=${report.id}&from=feed`}
-                  className="flex flex-col h-full rounded-xl border border-outline-variant/20 bg-white dark:bg-surface-container-lowest shadow-sm p-3 hover:shadow-md transition-shadow group"
+                  className="flex flex-col h-full rounded-xl border border-outline-variant/20 bg-surface-container-low shadow-sm p-3 hover:shadow-md transition-shadow group"
                 >
                   <div className="relative aspect-[5/3] max-h-[140px] w-full rounded-lg overflow-hidden bg-surface-container-high mb-2">
                     {report.image ? (
@@ -410,7 +410,7 @@ export default function Feed() {
                       </span>
                     )}
                     {env && (
-                      <span className="text-[10px] font-bold px-2 py-0.5 rounded-full border border-outline-variant/35 bg-surface-container-lowest text-on-surface-variant">
+                      <span className="text-[10px] font-bold px-2 py-0.5 rounded-full border border-outline-variant/35 bg-surface-container text-on-surface-variant">
                         {env}
                       </span>
                     )}

--- a/frontend/src/pages/Feed.jsx
+++ b/frontend/src/pages/Feed.jsx
@@ -315,7 +315,7 @@ export default function Feed() {
             <button
               type="button"
               onClick={() => setPickerOpen(true)}
-              className={`${feedFilterChipClass(false)} gap-2 dark:text-on-surface`}
+              className={`${feedFilterChipClass(false)} gap-2`}
             >
               <span className="material-symbols-outlined text-lg" aria-hidden>
                 map
@@ -325,7 +325,7 @@ export default function Feed() {
             <button
               type="button"
               onClick={handleUseCurrentLocation}
-              className={`${feedFilterChipClass(false)} gap-2 dark:text-on-surface`}
+              className={`${feedFilterChipClass(false)} gap-2`}
             >
               <span className="material-symbols-outlined text-lg" aria-hidden>
                 my_location

--- a/frontend/src/pages/Feed.jsx
+++ b/frontend/src/pages/Feed.jsx
@@ -315,7 +315,7 @@ export default function Feed() {
             <button
               type="button"
               onClick={() => setPickerOpen(true)}
-              className={`${feedFilterChipClass(false)} gap-2`}
+              className={`${feedFilterChipClass(false)} gap-2 dark:text-on-surface`}
             >
               <span className="material-symbols-outlined text-lg" aria-hidden>
                 map
@@ -325,7 +325,7 @@ export default function Feed() {
             <button
               type="button"
               onClick={handleUseCurrentLocation}
-              className={`${feedFilterChipClass(false)} gap-2`}
+              className={`${feedFilterChipClass(false)} gap-2 dark:text-on-surface`}
             >
               <span className="material-symbols-outlined text-lg" aria-hidden>
                 my_location

--- a/frontend/src/pages/Feed.jsx
+++ b/frontend/src/pages/Feed.jsx
@@ -410,7 +410,7 @@ export default function Feed() {
                       </span>
                     )}
                     {env && (
-                      <span className="text-[10px] font-bold px-2 py-0.5 rounded-full border border-outline-variant/35 bg-surface-container text-on-surface-variant">
+                      <span className="text-[10px] font-bold px-2 py-0.5 rounded-full border border-outline-variant/35 bg-surface-container-high text-on-surface-variant">
                         {env}
                       </span>
                     )}

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -26,13 +26,16 @@ function RankCell({ rank }) {
   // Top 3 get a colored chip; the rest stay neutral. Tie-aware values are
   // already produced by the backend (olympic-style rank assignment), so we
   // never need to display "T-1" — the rank itself does the talking.
+  // Top 3 chips use tinted palette colors with `dark:` variants so gold /
+  // silver / bronze stay recognizable in both themes without rendering as
+  // bright pale blocks on a near-black page.
   const tone =
     rank === 1
-      ? 'bg-[#fde68a] text-[#92400e]' // gold
+      ? 'bg-amber-400/20 text-amber-700 dark:bg-amber-300/15 dark:text-amber-300' // gold
       : rank === 2
-        ? 'bg-[#e5e7eb] text-[#374151]' // silver
+        ? 'bg-slate-300/40 text-slate-700 dark:bg-slate-300/15 dark:text-slate-200' // silver
         : rank === 3
-          ? 'bg-[#fed7aa] text-[#9a3412]' // bronze
+          ? 'bg-orange-300/25 text-orange-800 dark:bg-orange-300/15 dark:text-orange-300' // bronze
           : 'bg-surface-container text-on-surface-variant'
   return (
     <div className={`w-12 h-10 rounded-lg flex items-center justify-center font-bold text-sm tabular-nums ${tone}`}>
@@ -43,7 +46,7 @@ function RankCell({ rank }) {
 
 function YourRankBanner({ rank, points }) {
   return (
-    <div className="bg-primary/5 border border-primary/20 rounded-2xl p-4 flex items-center justify-between gap-4">
+    <div className="bg-primary/10 border border-primary/30 rounded-2xl p-4 flex items-center justify-between gap-4">
       <div className="flex items-center gap-3">
         <span className="material-symbols-outlined text-primary" style={{ fontSize: '24px' }}>
           person_pin
@@ -110,7 +113,7 @@ function Leaderboard() {
                 {data.entries.map((entry) => (
                   <li
                     key={entry.userId}
-                    className="bg-surface-container-lowest rounded-2xl shadow-sm p-3 flex items-center gap-3"
+                    className="bg-surface-container-low rounded-2xl shadow-sm p-3 flex items-center gap-3"
                   >
                     <RankCell rank={entry.rank} />
                     <Avatar url={entry.avatarUrl} name={entry.name} />

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -113,7 +113,7 @@ function Leaderboard() {
                 {data.entries.map((entry) => (
                   <li
                     key={entry.userId}
-                    className="bg-surface-container-low rounded-2xl shadow-sm p-3 flex items-center gap-3"
+                    className="bg-surface-container rounded-2xl shadow-sm p-3 flex items-center gap-3"
                   >
                     <RankCell rank={entry.rank} />
                     <Avatar url={entry.avatarUrl} name={entry.name} />

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -109,7 +109,7 @@ function ProfilePage() {
 
         {!isPending && !isError && user && (
           <>
-            <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+            <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-4">
               <div className="flex items-start gap-4 flex-wrap">
                 <div className="flex-1 min-w-0">
                   <h1 className="text-2xl font-bold font-headline text-on-surface break-words">
@@ -142,13 +142,13 @@ function ProfilePage() {
             </section>
 
             {user.badges && user.badges.length > 0 && (
-              <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+              <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-3">
                 <h2 className="text-xl font-bold font-headline text-on-surface">Badges</h2>
                 <BadgeList badges={user.badges} />
               </section>
             )}
 
-            <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+            <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-3">
               <h2 className="text-xl font-bold font-headline text-on-surface">Leaderboard</h2>
               <label className="flex items-center gap-3 cursor-pointer">
                 <input
@@ -168,7 +168,7 @@ function ProfilePage() {
               </p>
             </section>
 
-            <section className="bg-surface-container-lowest rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+            <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-4">
               <div className="flex items-center justify-between">
                 <h2 className="text-xl font-bold font-headline text-on-surface">About</h2>
                 {!isEditing && (

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -109,7 +109,7 @@ function ProfilePage() {
 
         {!isPending && !isError && user && (
           <>
-            <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+            <section className="bg-surface-container rounded-2xl shadow-sm p-6 flex flex-col gap-4">
               <div className="flex items-start gap-4 flex-wrap">
                 <div className="flex-1 min-w-0">
                   <h1 className="text-2xl font-bold font-headline text-on-surface break-words">
@@ -142,13 +142,13 @@ function ProfilePage() {
             </section>
 
             {user.badges && user.badges.length > 0 && (
-              <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+              <section className="bg-surface-container rounded-2xl shadow-sm p-6 flex flex-col gap-3">
                 <h2 className="text-xl font-bold font-headline text-on-surface">Badges</h2>
                 <BadgeList badges={user.badges} />
               </section>
             )}
 
-            <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+            <section className="bg-surface-container rounded-2xl shadow-sm p-6 flex flex-col gap-3">
               <h2 className="text-xl font-bold font-headline text-on-surface">Leaderboard</h2>
               <label className="flex items-center gap-3 cursor-pointer">
                 <input
@@ -168,7 +168,7 @@ function ProfilePage() {
               </p>
             </section>
 
-            <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+            <section className="bg-surface-container rounded-2xl shadow-sm p-6 flex flex-col gap-4">
               <div className="flex items-center justify-between">
                 <h2 className="text-xl font-bold font-headline text-on-surface">About</h2>
                 {!isEditing && (

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -41,7 +41,7 @@ function UserProfilePage() {
 
         {!isPending && !isError && user && (
           <>
-            <section className="bg-white rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+            <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-4">
               <div className="flex items-start gap-4 flex-wrap">
                 <div className="w-16 h-16 rounded-full bg-surface-container-high flex items-center justify-center flex-shrink-0 overflow-hidden">
                   {user.avatarUrl ? (
@@ -79,13 +79,13 @@ function UserProfilePage() {
             </section>
 
             {user.badges && user.badges.length > 0 && (
-              <section className="bg-white rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+              <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-3">
                 <h2 className="text-xl font-bold font-headline text-on-surface">Badges</h2>
                 <BadgeList badges={user.badges} />
               </section>
             )}
 
-            <section className="bg-white rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+            <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-4">
               <h2 className="text-xl font-bold font-headline text-on-surface">About</h2>
               <p className="text-sm text-on-surface whitespace-pre-wrap break-words">
                 {user.bio || <em className="text-on-surface-variant">No bio yet.</em>}

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -41,7 +41,7 @@ function UserProfilePage() {
 
         {!isPending && !isError && user && (
           <>
-            <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+            <section className="bg-surface-container rounded-2xl shadow-sm p-6 flex flex-col gap-4">
               <div className="flex items-start gap-4 flex-wrap">
                 <div className="w-16 h-16 rounded-full bg-surface-container-high flex items-center justify-center flex-shrink-0 overflow-hidden">
                   {user.avatarUrl ? (
@@ -79,13 +79,13 @@ function UserProfilePage() {
             </section>
 
             {user.badges && user.badges.length > 0 && (
-              <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-3">
+              <section className="bg-surface-container rounded-2xl shadow-sm p-6 flex flex-col gap-3">
                 <h2 className="text-xl font-bold font-headline text-on-surface">Badges</h2>
                 <BadgeList badges={user.badges} />
               </section>
             )}
 
-            <section className="bg-surface-container-low rounded-2xl shadow-sm p-6 flex flex-col gap-4">
+            <section className="bg-surface-container rounded-2xl shadow-sm p-6 flex flex-col gap-4">
               <h2 className="text-xl font-bold font-headline text-on-surface">About</h2>
               <p className="text-sm text-on-surface whitespace-pre-wrap break-words">
                 {user.bio || <em className="text-on-surface-variant">No bio yet.</em>}

--- a/frontend/src/pages/UserSearchPage.jsx
+++ b/frontend/src/pages/UserSearchPage.jsx
@@ -9,7 +9,7 @@ function UserCard({ user }) {
   return (
     <Link
       to={`/profile/${user.id}`}
-      className="flex items-center gap-3 bg-surface-container-lowest rounded-2xl shadow-sm p-4 hover:shadow-md transition-shadow"
+      className="flex items-center gap-3 bg-surface-container-low rounded-2xl shadow-sm p-4 hover:shadow-md transition-shadow"
     >
       <div className="w-12 h-12 rounded-full bg-surface-container-high flex items-center justify-center flex-shrink-0 overflow-hidden">
         {user.avatarUrl ? (

--- a/frontend/src/pages/UserSearchPage.jsx
+++ b/frontend/src/pages/UserSearchPage.jsx
@@ -9,7 +9,7 @@ function UserCard({ user }) {
   return (
     <Link
       to={`/profile/${user.id}`}
-      className="flex items-center gap-3 bg-surface-container-low rounded-2xl shadow-sm p-4 hover:shadow-md transition-shadow"
+      className="flex items-center gap-3 bg-surface-container rounded-2xl shadow-sm p-4 hover:shadow-md transition-shadow"
     >
       <div className="w-12 h-12 rounded-full bg-surface-container-high flex items-center justify-center flex-shrink-0 overflow-hidden">
         {user.avatarUrl ? (

--- a/frontend/src/utils/feedFilterChip.js
+++ b/frontend/src/utils/feedFilterChip.js
@@ -4,7 +4,7 @@ export function feedFilterChipClass(active) {
     'inline-flex items-center justify-center px-4 py-2 rounded-2xl text-sm font-semibold border transition-colors',
     'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
     active
-      ? 'bg-primary text-on-primary border-primary shadow-sm'
-      : 'bg-surface-container-highest text-primary dark:text-on-surface border-primary/30 hover:bg-primary/10 hover:border-primary/45',
+      ? 'bg-primary text-on-primary border-transparent shadow-sm'
+      : 'bg-surface-container-highest text-primary dark:text-on-surface border-transparent hover:bg-primary/10',
   ].join(' ')
 }

--- a/frontend/src/utils/feedFilterChip.js
+++ b/frontend/src/utils/feedFilterChip.js
@@ -5,6 +5,6 @@ export function feedFilterChipClass(active) {
     'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
     active
       ? 'bg-primary text-on-primary border-primary shadow-sm'
-      : 'bg-surface-container-highest text-primary border-primary/30 hover:bg-primary/10 hover:border-primary/45',
+      : 'bg-surface-container-highest text-primary dark:text-on-surface border-primary/30 hover:bg-primary/10 hover:border-primary/45',
   ].join(' ')
 }


### PR DESCRIPTION
## 📝 Description
Closes #612. Single-issue PR addressing the three visual inconsistencies the issue flagged, plus a few related polish items uncovered while testing.

**Card elevation.** Surfaces meant to read as elevated cards were using `bg-surface-container-lowest` (#0e0e0e), which is *darker* than `--color-background` (#121212) in dark mode , so cards punched into the page instead of lifting above it. Swapped to `bg-surface-container-low` on:
- Leaderboard rows
- ProfilePage sections (×4)
- UserProfilePage sections (×3, also drops a lingering `bg-white`)
- UserSearchPage result cards
- RoutingPreferencesSection outer wrappers (×3)
- MyReportsSection outer wrapper
- Feed filter section + each feed card

Inner-card-on-card surfaces bumped one step higher than the new parent:
- Inactive `PresetCard` → `bg-surface-container`
- Feed environment chip → `bg-surface-container`

**Rank banner.** `bg-primary/5 border-primary/20` → `bg-primary/10 border-primary/30`. Subtle in light, finally visible in dark.

**Medal chips.** Hardcoded light hexes replaced with alpha-tinted Tailwind palettes plus `dark:` variants : gold / silver / bronze stay recognizable in both themes without bright pale blocks.

**Feed filter chips.** Inactive text uses `dark:text-on-surface` (≈ white) so labels read clearly in dark mode. Green borders dropped — chips now read as soft pills, active stays solid primary, inactive stays surface-container-highest.

Token `surface-container-lowest` itself stays untouched , only callers changed. It remains reserved for genuinely subtle backdrop use (navbar overlay, floating search bar).

## 📊 Type
Bug / polish

## ✅ Acceptance Criteria
- [x] Dark mode: Leaderboard rows visually sit above the page background
- [x] Dark mode: Profile, UserProfile, UserSearch, Feed cards sit above the page background
- [x] Dark mode: YourRankBanner is clearly distinguishable without being loud
- [x] Dark mode: gold / silver / bronze chips are recognizable but muted
- [x] Dark mode: feed filter pill text is readable (on-surface)
- [x] Light mode: every touched surface renders effectively unchanged
- [x] 474 frontend tests pass
- [ ] 
## 📸 Screenshots
<img width="1271" height="680" alt="Ekran Resmi 2026-05-11 20 47 21" src="https://github.com/user-attachments/assets/69a0c087-c8a0-46a5-8c95-062cee5710ca" />
<img width="1281" height="724" alt="Ekran Resmi 2026-05-11 20 47 04" src="https://github.com/user-attachments/assets/9aabc7ab-dd45-460d-ab09-1729796a847c" />

## 🧪 Test
- Toggle theme on `/leaderboard`, `/profile`, `/profile/<other>`, `/search/users`, `/feed`
  - cards properly elevated in dark, unchanged in light
- Top-3 chips on Leaderboard in both modes , recognizable, not loud
- Feed → all filter pills + location action buttons → text legible, no green borders

## ⏱️ Review Time
~5 min