### PR TITLE
[Mobile] Live Leaderboard And Profile Refresh On Points Change

### DIFF
--- a/mobile/lib/models/sse_event.dart
+++ b/mobile/lib/models/sse_event.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
-/// Typed representation of the backend PublicSseEvent.
-/// eventType is one of: 'REPORT_CREATED', 'REPORT_UPDATED', 'REPORT_DELETED', 'MEDIA_ADDED'.
+/// Typed representation of the backend public SSE payloads.
+/// eventType is one of: 'REPORT_CREATED', 'REPORT_UPDATED', 'REPORT_DELETED',
+/// 'MEDIA_ADDED', 'POINTS_CHANGED'. POINTS_CHANGED carries [userId] and
+/// [points] instead of a reportId; reportId stays 0 for those events.
 class SseEvent {
   final String eventType;
   final int reportId;
@@ -12,6 +14,9 @@ class SseEvent {
   final String? mediaId;
   final String? mediaUrl;
   final String? timestamp;
+  // Populated only for POINTS_CHANGED.
+  final int? userId;
+  final int? points;
 
   const SseEvent({
     required this.eventType,
@@ -23,6 +28,8 @@ class SseEvent {
     this.mediaId,
     this.mediaUrl,
     this.timestamp,
+    this.userId,
+    this.points,
   });
 
   factory SseEvent.fromJson(Map<String, dynamic> json) {
@@ -36,6 +43,8 @@ class SseEvent {
       mediaId: json['mediaId']?.toString(),
       mediaUrl: json['mediaUrl'] as String?,
       timestamp: json['timestamp'] as String?,
+      userId: (json['userId'] as num?)?.toInt(),
+      points: (json['points'] as num?)?.toInt(),
     );
   }
 
@@ -51,6 +60,10 @@ class SseEvent {
   }
 
   @override
-  String toString() =>
-      'SseEvent(type: $eventType, reportId: $reportId, agrees: $agrees, disagrees: $disagrees)';
+  String toString() {
+    if (eventType == 'POINTS_CHANGED') {
+      return 'SseEvent(type: $eventType, userId: $userId, points: $points)';
+    }
+    return 'SseEvent(type: $eventType, reportId: $reportId, agrees: $agrees, disagrees: $disagrees)';
+  }
 }

--- a/mobile/lib/screens/leaderboard_screen.dart
+++ b/mobile/lib/screens/leaderboard_screen.dart
@@ -52,16 +52,29 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
     if (event.eventType != 'POINTS_CHANGED') return;
     _refetchDebounce?.cancel();
     _refetchDebounce = Timer(const Duration(milliseconds: 250), () {
-      if (mounted) _load();
+      if (mounted) _silentRefresh();
     });
   }
 
   Future<void> _load() async {
-    final api = context.read<AuthService>().api;
     setState(() {
       _loading = true;
       _error = null;
     });
+    await _fetchAndApply(showErrorOnFailure: true);
+  }
+
+  /// SSE-triggered refetch. Reconciles new points/ranks into existing state
+  /// without flashing the loading spinner or replacing the error banner —
+  /// the list and YourRank banner just rebuild with the new values, which
+  /// `AnimatedSwitcher` then cross-fades. A failed background refresh is
+  /// silent: the next event (or pull-to-refresh) will retry.
+  Future<void> _silentRefresh() async {
+    await _fetchAndApply(showErrorOnFailure: false);
+  }
+
+  Future<void> _fetchAndApply({required bool showErrorOnFailure}) async {
+    final api = context.read<AuthService>().api;
     try {
       final payload = await api.getLeaderboard();
       if (!mounted) return;
@@ -73,13 +86,16 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
             .toList();
         _callerRank = rawCaller != null ? RankInfo.fromJson(rawCaller) : null;
         _loading = false;
+        _error = null;
       });
     } catch (e) {
       if (!mounted) return;
-      setState(() {
-        _error = e is ApiException ? e.userMessage : e.toString();
-        _loading = false;
-      });
+      if (showErrorOnFailure) {
+        setState(() {
+          _error = e is ApiException ? e.userMessage : e.toString();
+          _loading = false;
+        });
+      }
     }
   }
 
@@ -151,7 +167,11 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
   }
 
   Widget _buildRow(LeaderboardEntry entry) {
+    // Keyed by userId so an SSE-driven reorder reuses the same Element for
+    // a given user — the row's content cross-fades to the new rank/points
+    // instead of the whole tile remounting.
     return Padding(
+      key: ValueKey('lb-${entry.userId}'),
       padding: const EdgeInsets.only(bottom: 8),
       child: InkWell(
         onTap: () {
@@ -202,8 +222,8 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
                       color: AppColors.onSurfaceVariant,
                     ),
                   ),
-                  Text(
-                    '${entry.points}',
+                  _AnimatedPoints(
+                    points: entry.points,
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w700,
@@ -215,6 +235,34 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// A points label that cross-fades when its value changes, so SSE-driven
+/// updates feel like a tally rolling rather than a hard re-render.
+class _AnimatedPoints extends StatelessWidget {
+  final int points;
+  final TextStyle style;
+  final String prefix;
+
+  const _AnimatedPoints({
+    required this.points,
+    required this.style,
+    this.prefix = '',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 220),
+      transitionBuilder: (child, animation) =>
+          FadeTransition(opacity: animation, child: child),
+      child: Text(
+        '$prefix$points',
+        key: ValueKey<int>(points),
+        style: style,
       ),
     );
   }
@@ -238,7 +286,8 @@ class _RankCell extends StatelessWidget {
           AppColors.onSurfaceVariant
         ),
     };
-    return Container(
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 220),
       width: 44,
       height: 36,
       decoration: BoxDecoration(
@@ -246,12 +295,18 @@ class _RankCell extends StatelessWidget {
         borderRadius: BorderRadius.circular(10),
       ),
       alignment: Alignment.center,
-      child: Text(
-        '#$rank',
-        style: TextStyle(
-          fontWeight: FontWeight.w700,
-          fontSize: 13,
-          color: fg,
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 220),
+        transitionBuilder: (child, animation) =>
+            FadeTransition(opacity: animation, child: child),
+        child: Text(
+          '#$rank',
+          key: ValueKey<int>(rank),
+          style: TextStyle(
+            fontWeight: FontWeight.w700,
+            fontSize: 13,
+            color: fg,
+          ),
         ),
       ),
     );
@@ -312,13 +367,16 @@ class _YourRankBanner extends StatelessWidget {
                     color: AppColors.onSurfaceVariant,
                   ),
                 ),
-                Text(
-                  '#${info.rank}',
+                _AnimatedPoints(
+                  points: info.rank,
+                  // Prefix the rank with '#' via a wrapper so AnimatedSwitcher
+                  // still keys on the integer.
                   style: TextStyle(
                     fontSize: 22,
                     fontWeight: FontWeight.w800,
                     color: AppColors.onSurface,
                   ),
+                  prefix: '#',
                 ),
               ],
             ),
@@ -335,8 +393,8 @@ class _YourRankBanner extends StatelessWidget {
                   color: AppColors.onSurfaceVariant,
                 ),
               ),
-              Text(
-                '${info.points}',
+              _AnimatedPoints(
+                points: info.points,
                 style: TextStyle(
                   fontSize: 22,
                   fontWeight: FontWeight.w800,

--- a/mobile/lib/screens/leaderboard_screen.dart
+++ b/mobile/lib/screens/leaderboard_screen.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../models/leaderboard_entry.dart';
+import '../models/sse_event.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
+import '../services/sse_service.dart';
 import '../theme/app_colors.dart';
 import 'user_profile_screen.dart';
 
@@ -24,10 +28,32 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
   bool _loading = true;
   String? _error;
 
+  StreamSubscription<SseEvent>? _sseSub;
+  // A single report transition can pay out points to many users in quick
+  // succession (author bonus + voter alignment). Coalesce those bursts into
+  // one refetch so we don't hammer /api/leaderboard.
+  Timer? _refetchDebounce;
+
   @override
   void initState() {
     super.initState();
     _load();
+    _sseSub = context.read<SseService>().events.listen(_onSseEvent);
+  }
+
+  @override
+  void dispose() {
+    _sseSub?.cancel();
+    _refetchDebounce?.cancel();
+    super.dispose();
+  }
+
+  void _onSseEvent(SseEvent event) {
+    if (event.eventType != 'POINTS_CHANGED') return;
+    _refetchDebounce?.cancel();
+    _refetchDebounce = Timer(const Duration(milliseconds: 250), () {
+      if (mounted) _load();
+    });
   }
 
   Future<void> _load() async {

--- a/mobile/lib/screens/profile_screen.dart
+++ b/mobile/lib/screens/profile_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -6,7 +7,9 @@ import 'package:provider/provider.dart';
 import '../theme/app_colors.dart';
 import '../services/auth_service.dart';
 import '../services/api_service.dart';
+import '../services/sse_service.dart';
 import '../models/report_model.dart';
+import '../models/sse_event.dart';
 import '../widgets/badge_chip.dart';
 import '../main.dart' show AuthShell;
 import 'avatar_crop_screen.dart';
@@ -37,17 +40,39 @@ class _ProfileScreenState extends State<ProfileScreen> {
   final _formKey = GlobalKey<FormState>();
   File? _pickedAvatar;
 
+  // ── SSE refresh ────────────────────────────────────────────────────────────
+  StreamSubscription<SseEvent>? _sseSub;
+  // Coalesce bursts (e.g. a report verify pays out multiple users at once,
+  // some of which may be us via voter-alignment payouts) into one refetch.
+  Timer? _refetchDebounce;
+
   @override
   void initState() {
     super.initState();
     _loadData();
+    _sseSub = context.read<SseService>().events.listen(_onSseEvent);
   }
 
   @override
   void dispose() {
+    _sseSub?.cancel();
+    _refetchDebounce?.cancel();
     _nameController.dispose();
     _bioController.dispose();
     super.dispose();
+  }
+
+  void _onSseEvent(SseEvent event) {
+    if (event.eventType != 'POINTS_CHANGED') return;
+    final myId = context.read<AuthService>().userId;
+    // Only the current user's balance is shown on this screen, so ignore
+    // events for other users. Stays in sync with the leaderboard screen,
+    // which listens to every POINTS_CHANGED.
+    if (event.userId == null || event.userId != myId) return;
+    _refetchDebounce?.cancel();
+    _refetchDebounce = Timer(const Duration(milliseconds: 250), () {
+      if (mounted && !_editMode) _loadData();
+    });
   }
 
   Future<void> _loadData() async {

--- a/mobile/test/sse_event_test.dart
+++ b/mobile/test/sse_event_test.dart
@@ -70,6 +70,28 @@ void main() {
       expect(event.mediaUrl, isNull);
     });
 
+    test('parses POINTS_CHANGED event with userId and points', () {
+      const json = '''
+{
+  "eventType": "POINTS_CHANGED",
+  "userId": 42,
+  "points": 55,
+  "timestamp": "2026-05-11T13:22:11Z"
+}''';
+
+      final event = SseEvent.tryParse(json);
+
+      expect(event, isNotNull);
+      expect(event!.eventType, 'POINTS_CHANGED');
+      expect(event.userId, 42);
+      expect(event.points, 55);
+      // POINTS_CHANGED carries no reportId — falls back to the default 0.
+      expect(event.reportId, 0);
+      expect(event.agrees, isNull);
+      expect(event.toString(), contains('userId: 42'));
+      expect(event.toString(), contains('points: 55'));
+    });
+
     test('parses REPORT_DELETED event', () {
       const json = '''
 {


### PR DESCRIPTION
# 📝 Description


Mobile counterpart of the leaderboard / profile points refresh flow. Depends on the backend PR landing first, since the broadcast that triggers these listeners (`POINTS_CHANGED` on the public SSE stream) comes from `GamificationService.applyDelta` — without it, the listeners attached here will simply never fire.

Changes:
- **Model — extend `SseEvent` for `POINTS_CHANGED`.** Added nullable `userId` and `points` fields and a dedicated `toString` branch. `reportId` stays a non-nullable `int` (defaults to `0` for events without one) so existing `REPORT_*` callers don't need to handle a new nullable type.
- **Leaderboard screen — refresh on any points change.** `LeaderboardScreen` now subscribes to `SseService.events` in `initState` and re-runs `_load()` on every `POINTS_CHANGED` event. A 250 ms debounce coalesces bursts — a single report transition (e.g. PENDING → VERIFIED at 5 agrees) pays out multiple users in quick succession (author bonus + voter-alignment payouts) and would otherwise trigger one fetch per affected user.
- **Profile screen — refresh only on the caller's own changes.** `ProfileScreen` subscribes the same way but filters `event.userId == AuthService.userId` so other users' point movements don't churn the screen. The reload is also suppressed while the user is mid-edit, so an inbound event can't overwrite unsaved form state.

Both subscriptions are cancelled in `dispose`. App-lifecycle pause/resume of the SSE stream is already handled by `SseService` itself.

# 📊 Type of Change
- [x] New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

Test added:
- `sse_event_test`: parser populates `userId` and `points` for a `POINTS_CHANGED` payload, the missing `reportId` falls back to `0`, and `toString` switches to the points-flavoured format.

The existing report-flavoured parser tests still pass unchanged, confirming the new optional fields don't perturb the existing payloads.

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [x] < 5 min
