### PR TITLE
[Web][Backend] Reverse-geocode + persist locationLabel on reports (closes #621, #622)

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportResponse.java
@@ -117,6 +117,13 @@ public class ReportResponse {
             nullable = true)
     private Badge authorTopBadge;
 
+    @Schema(description = "Human-readable place name reverse-geocoded once at create time " +
+            "(e.g. \"Bebek Yolu Sokağı, Rumelihisarı Mahallesi\"). Null when the geocoder was " +
+            "unreachable at create time or the report predates this column — clients should fall " +
+            "back to displaying `geometry` / scalar coordinates.",
+            example = "Bebek Yolu Sokağı, Rumelihisarı Mahallesi", nullable = true)
+    private String locationLabel;
+
     public static ReportResponse fromEntity(Report report) {
         return fromEntity(report, null, Collections.emptyList(), null);
     }
@@ -167,6 +174,7 @@ public class ReportResponse {
         if (report.getLastEditedBy() != null) {
             r.setLastEditedByUserId(report.getLastEditedBy().getId());
         }
+        r.setLocationLabel(report.getLocationLabel());
         return r;
     }
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/model/Report.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/Report.java
@@ -78,6 +78,12 @@ public class Report {
     @Column(name = "edit_history", columnDefinition = "TEXT")
     private String editHistory;
 
+    // Human-readable place name reverse-geocoded once at create time.
+    // Nullable: an outage during create leaves this blank and the frontend
+    // falls back to the rounded coordinates.
+    @Column(name = "location_label", length = 200)
+    private String locationLabel;
+
     @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/NominatimReverseGeocoder.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/NominatimReverseGeocoder.java
@@ -1,9 +1,10 @@
 package com.bounswe2026group1.backend.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -28,6 +29,7 @@ import java.time.Duration;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class NominatimReverseGeocoder {
 
     private static final String BASE = "https://nominatim.openstreetmap.org/reverse";
@@ -37,7 +39,7 @@ public class NominatimReverseGeocoder {
     private final HttpClient http = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(2))
             .build();
-    private final ObjectMapper json = new ObjectMapper();
+    private final ObjectMapper json;
 
     /**
      * Reverse-geocode (latitude, longitude) to a short label. Never throws —

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/NominatimReverseGeocoder.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/NominatimReverseGeocoder.java
@@ -1,0 +1,81 @@
+package com.bounswe2026group1.backend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+/**
+ * Tiny reverse-geocoding wrapper over OSM Nominatim. Used at report-create time
+ * to persist a human-readable label on the row so every downstream surface
+ * (Feed cards, ReportPanel, mobile, admin tables) can display it without each
+ * client geocoding independently.
+ *
+ * Returns the first two comma-separated parts of {@code display_name} (e.g.
+ * "Bebek Yolu Sokağı, Rumelihisarı Mahallesi") capped to 200 chars to fit the
+ * DB column. Returns {@code null} on any failure — callers must treat the
+ * result as best-effort and never roll back the surrounding write on a null.
+ *
+ * Nominatim's usage policy (https://operations.osmfoundation.org/policies/nominatim/)
+ * requires a descriptive User-Agent and is throttled to 1 req/s; report creation
+ * is well below that ceiling so no client-side rate-limiter is needed.
+ */
+@Slf4j
+@Service
+public class NominatimReverseGeocoder {
+
+    private static final String BASE = "https://nominatim.openstreetmap.org/reverse";
+    private static final String USER_AGENT = "mapcess-backend/1.0 (https://mapcess.live)";
+    private static final int MAX_LABEL_CHARS = 200;
+
+    private final HttpClient http = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(2))
+            .build();
+    private final ObjectMapper json = new ObjectMapper();
+
+    /**
+     * Reverse-geocode (latitude, longitude) to a short label. Never throws —
+     * any IO / parse / timeout error returns null and logs a warning.
+     */
+    public String reverseLabel(double latitude, double longitude) {
+        try {
+            URI uri = URI.create(String.format(
+                    java.util.Locale.ROOT,
+                    "%s?lat=%f&lon=%f&format=json&zoom=17&addressdetails=0",
+                    BASE, latitude, longitude));
+            HttpRequest req = HttpRequest.newBuilder(uri)
+                    .timeout(Duration.ofSeconds(3))
+                    .header("User-Agent", USER_AGENT)
+                    .header("Accept", "application/json")
+                    .GET()
+                    .build();
+            HttpResponse<String> res = http.send(req, HttpResponse.BodyHandlers.ofString());
+            if (res.statusCode() / 100 != 2) {
+                log.warn("Nominatim returned {} for ({}, {})", res.statusCode(), latitude, longitude);
+                return null;
+            }
+            JsonNode root = json.readTree(res.body());
+            String displayName = root.path("display_name").asText("");
+            if (displayName.isBlank()) return null;
+            // First two comma-separated parts — matches the frontend's existing
+            // reverseGeocode() helper so labels stay visually consistent
+            // between the create-time banner and the persisted value.
+            String[] parts = displayName.split(",");
+            String label = parts.length >= 2
+                    ? (parts[0].trim() + ", " + parts[1].trim())
+                    : parts[0].trim();
+            return label.length() > MAX_LABEL_CHARS
+                    ? label.substring(0, MAX_LABEL_CHARS)
+                    : label;
+        } catch (Exception e) {
+            log.warn("Nominatim reverse-geocode failed for ({}, {}): {}", latitude, longitude, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -48,6 +48,7 @@ public class ReportService {
     private final S3MediaService s3MediaService;
     private final MeasurementValidator measurementValidator;
     private final OverpassService overpassService;
+    private final NominatimReverseGeocoder reverseGeocoder;
 
     @Value("${app.report.verification.threshold:5}")
     private int verificationThreshold;
@@ -176,6 +177,13 @@ public class ReportService {
         Point reportLocation = GeoUtils.point4326(lat, lon);
         Report report = new Report(user, reportLocation, request.getDescription(),
                 request.getReportType(), request.getEnvironment());
+
+        // Reverse-geocode once at create time and persist on the row so every
+        // downstream consumer (Feed, ReportPanel, mobile, admin) shows a place
+        // name without each client geocoding independently. Best-effort: a
+        // Nominatim outage leaves the field null and the frontend falls back
+        // to displaying the coordinates.
+        report.setLocationLabel(reverseGeocoder.reverseLabel(lat, lon));
 
         List<ReportObjectRequest> objectRequests = request.getObjects() != null
                 ? request.getObjects() : List.of();

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -47,6 +47,7 @@ class ReportServiceTest {
     @Mock private S3MediaService s3MediaService;
     @Mock private MeasurementValidator measurementValidator;
     @Mock private OverpassService overpassService;
+    @Mock private NominatimReverseGeocoder reverseGeocoder;
     @Mock private NotificationService notificationService;
     @Mock private GamificationService gamificationService;
     @Mock private UserBadgeRepository userBadgeRepository;

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -207,7 +207,9 @@ export function mapReport(r) {
         })
       : 'Unknown date',
     fixedAt: r.fixedAt || null,
-    location: formatReportLocation(r.latitude, r.longitude),
+    // Prefer the backend-provided label (reverse-geocoded once at create time);
+    // fall back to rounded coordinates for older rows where the column is null.
+    location: r.locationLabel || formatReportLocation(r.latitude, r.longitude),
     reportedBy: `User #${r.userId}`,
     ownerId: r.userId,
     agrees: r.agrees,


### PR DESCRIPTION
## 📝 Description
Closes the location-label issue pair. Reports now carry a human-readable place name reverse-geocoded once at create time, so every surface (Feed cards, ReportPanel, mobile, admin tables) displays "Bebek Yolu Sokağı, Rumelihisarı Mahallesi" instead of `41.0683, 29.0505`.

**Backend**
- `location_label` column on `Report` (nullable VARCHAR(200))
- `NominatimReverseGeocoder` : Tiny `HttpClient` wrapper with 3s timeout, descriptive `User-Agent` per Nominatim ToS. Best-effort: any IO/parse/timeout returns null and logs a warning, never throws
- `ReportService.createReport` persists the label after constructing the entity. A Nominatim outage leaves the column null but the report still creates successfully
- `ReportResponse.locationLabel` surfaced on every report endpoint (`/api/reports`, `/api/reports/feed`, `/api/reports/{id}`, etc.) via the shared `fromEntity` factory

**Web**
- `mapReport` reads `r.locationLabel` and falls back to `formatReportLocation(latitude, longitude)` for legacy rows
- One-line change; no new helper, no client-side geocoding loop

## 📊 Type
New feature

## 📸 Screenshots
<img width="448" height="285" alt="Ekran Resmi 2026-05-11 23 07 39" src="https://github.com/user-attachments/assets/cab1242f-6362-4202-8fc3-32963c442623" />



## ✅ Acceptance Criteria
- [x] New reports show a place name on Feed cards and in ReportPanel
- [x] Old reports without a label still show the rounded coordinate fallback
- [x] Nominatim outage during create returns 201 with `locationLabel: null` (logged warning, report still creates)
- [x] `User-Agent` header set per Nominatim ToS
- [x] 481 frontend tests pass

## 🧪 How to Test
1. `docker compose -f docker-compose.local.yml --env-file backend/.env up -d --build`
2. Create a report on the map → response body has `locationLabel`
3. Open the Feed → that report's card shows the place name, not coords
4. Stop external network / point Nominatim base URL at an invalid host → create still returns 201 with `locationLabel: null`; Feed card shows the coord fallback

## ⏱️ Review
~5 min