### PR TITLE
[Web] Dark-mode polish : About edit boxes + Create-custom-preset modal panel (closes #624)

### DIFF
--- a/frontend/src/components/CustomPresetEditorModal.jsx
+++ b/frontend/src/components/CustomPresetEditorModal.jsx
@@ -152,7 +152,7 @@ function CustomPresetEditorModal({
       onClick={handleBackdropClick}
       className="fixed inset-0 z-[1500] flex items-center justify-center bg-black/50 p-4"
     >
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+      <div className="bg-surface-container-lowest rounded-2xl shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
         <div className="flex items-center justify-between p-5 border-b border-outline-variant">
           <h2 className="text-xl font-bold font-headline text-on-surface">
             {isEdit ? 'Edit custom preset' : 'New custom preset'}

--- a/frontend/src/components/CustomPresetEditorModal.jsx
+++ b/frontend/src/components/CustomPresetEditorModal.jsx
@@ -180,7 +180,7 @@ function CustomPresetEditorModal({
               onChange={(e) => setName(e.target.value)}
               maxLength={NAME_MAX}
               placeholder="e.g. Work commute"
-              className="w-full px-4 py-2.5 bg-surface-container border-none rounded-xl focus:ring-2 focus:ring-primary/40"
+              className="w-full px-4 py-2.5 bg-surface-container text-on-surface placeholder:text-on-surface-variant border-none rounded-xl focus:ring-2 focus:ring-primary/40 outline-none"
             />
             <p className={`text-xs text-right ${nameInvalid ? 'text-error' : 'text-on-surface-variant'}`}>
               {trimmedName.length === 0
@@ -200,8 +200,9 @@ function CustomPresetEditorModal({
                     value={tm.value}
                     checked={travelMode === tm.value}
                     onChange={() => setTravelMode(tm.value)}
+                    className="w-4 h-4 accent-primary cursor-pointer"
                   />
-                  <span className="text-sm">{tm.label}</span>
+                  <span className="text-sm text-on-surface">{tm.label}</span>
                 </label>
               ))}
             </div>

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -176,7 +176,7 @@ function ProfilePage() {
                   <button
                     type="button"
                     onClick={handleStartEdit}
-                    className="px-3 py-1.5 rounded-lg bg-surface-container text-on-surface font-semibold text-sm cursor-pointer"
+                    className="px-3 py-1.5 rounded-lg bg-surface-container-high text-on-surface font-semibold text-sm cursor-pointer"
                   >
                     Edit
                   </button>
@@ -198,7 +198,7 @@ function ProfilePage() {
                       value={name}
                       onChange={(e) => setName(e.target.value)}
                       maxLength={NAME_MAX}
-                      className="w-full px-5 py-3 bg-surface-container border-none rounded-xl text-on-surface focus:ring-2 focus:ring-primary/40 outline-none"
+                      className="w-full px-5 py-3 bg-surface-container-high border-none rounded-xl text-on-surface focus:ring-2 focus:ring-primary/40 outline-none"
                     />
                     <p className={`text-xs text-right ${nameInvalid ? 'text-error' : 'text-on-surface-variant'}`}>
                       {trimmedName.length < NAME_MIN
@@ -216,7 +216,7 @@ function ProfilePage() {
                       value={bio}
                       onChange={(e) => setBio(e.target.value)}
                       rows={4}
-                      className="w-full px-5 py-3 bg-surface-container border-none rounded-xl text-on-surface focus:ring-2 focus:ring-primary/40 outline-none"
+                      className="w-full px-5 py-3 bg-surface-container-high border-none rounded-xl text-on-surface focus:ring-2 focus:ring-primary/40 outline-none"
                     />
                     <p className={`text-xs text-right ${bioInvalid ? 'text-error' : 'text-on-surface-variant'}`}>
                       {bio.length}/{BIO_MAX}
@@ -242,7 +242,7 @@ function ProfilePage() {
                       type="button"
                       onClick={handleCancel}
                       disabled={updateProfileMutation.isPending}
-                      className="px-4 py-2 rounded-lg bg-surface-container text-on-surface font-semibold cursor-pointer"
+                      className="px-4 py-2 rounded-lg bg-surface-container-high text-on-surface font-semibold cursor-pointer"
                     >
                       Cancel
                     </button>


### PR DESCRIPTION
## 📝 Description
Closes #624.

1. **About edit controls** -> Display name input, Bio textarea, Edit, and Cancel buttons all used `bg-surface-container` after #612 bumped their parent section to the same token, so they vanished into the section. Bumped to `bg-surface-container-high` (one step above the section) in both themes. Keeps the borderless aesthetic.
2. **CustomPresetEditorModal panel** -> was hardcoded `bg-white`, rendering as a white rectangle in dark mode with mismatched theme-aware controls inside. Swapped to `bg-surface-container-lowest` to match the rest of the modal pattern (NotificationDropdown, MyReportDetailModal).

## 📊 Type
Bug / polish

## 📸 Screenshots
<img width="1277" height="713" alt="Ekran Resmi 2026-05-11 23 29 43" src="https://github.com/user-attachments/assets/e78e41e3-43dc-4bef-a67c-b12cc5eeac44" />



## ✅ AC
- [x] Display name / Bio / Edit / Cancel visibly elevated above the About section in both themes
- [x] Custom preset modal panel adapts to theme; no white-on-dark
- [x] Light mode: visually unchanged on every touched control
- [x] 481 frontend tests pass

## ⏱️ Review
~1 min