### PR TITLE
[Web] Onboarding bullets : Wrap in elevated card to match diagram column (closes #628)

### DIFF
--- a/frontend/src/components/OnboardingTutorial.jsx
+++ b/frontend/src/components/OnboardingTutorial.jsx
@@ -426,7 +426,7 @@ export default function OnboardingTutorial({ onClose }) {
 
           <div className="w-[320px] flex-shrink-0 flex flex-col gap-3 overflow-y-auto">
             {slide.bullets && (
-              <ul className="list-none p-0 m-0 text-left text-[13.5px] leading-snug text-on-surface flex flex-col gap-1.5">
+              <ul className="bg-surface-container-low border border-surface-container-high rounded-xl px-4 py-3 list-none m-0 text-left text-[13.5px] leading-snug text-on-surface flex flex-col gap-1.5">
                 {slide.bullets.map((bullet, i) => (
                   <li key={i} className="flex items-start gap-2.5 py-1">
                     <span

--- a/frontend/src/components/OnboardingTutorial.jsx
+++ b/frontend/src/components/OnboardingTutorial.jsx
@@ -424,7 +424,7 @@ export default function OnboardingTutorial({ onClose }) {
             </div>
           )}
 
-          <div className="w-[320px] flex-shrink-0 flex flex-col gap-3 overflow-y-auto">
+          <div className="w-[320px] flex-shrink-0 flex flex-col gap-3 overflow-y-auto pr-2">
             {slide.bullets && (
               <ul className="bg-surface-container-low border border-surface-container-high rounded-xl px-4 py-3 list-none m-0 text-left text-[13.5px] leading-snug text-on-surface flex flex-col gap-1.5">
                 {slide.bullets.map((bullet, i) => (


### PR DESCRIPTION
## 📝 Description
Closes #628. The bullets `<ul>` on every onboarding slide had no background or border, so it floated as bare text on the near-black modal panel while the diagram beside it sat in a clearly elevated card. Added the same `bg-surface-container-low border border-surface-container-high rounded-xl px-4 py-3` treatment.

## 📊 Type
Bug / polish

## ✅ AC
- [x] Bullets column matches the diagram card in both themes
- [x] Slides without bullets unaffected (the `<ul>` doesn't render)
- [x] Light mode regression check
- [x] 481 frontend tests pass

## ⏱️ Review
~1 min