### PR TITLE
[Web] Open user search as a navbar popover so the map stays visible (closes #633)

### DIFF
--- a/frontend/src/components/MapFilters.jsx
+++ b/frontend/src/components/MapFilters.jsx
@@ -151,9 +151,9 @@ function MapFilters({ excludedTypes, excludedIssues, onChange, onClose, triggerR
               type="button"
               onClick={onClose}
               aria-label="Close filters"
-              className="w-9 h-9 rounded-full hover:bg-surface-container flex items-center justify-center cursor-pointer"
+              className="w-9 h-9 rounded-full bg-error/10 text-error flex items-center justify-center hover:bg-error/20 transition-colors cursor-pointer"
             >
-              <span className="material-symbols-outlined text-on-surface-variant">close</span>
+              <span className="material-symbols-outlined">close</span>
             </button>
           </div>
         </div>

--- a/frontend/src/components/MapSearchBar.jsx
+++ b/frontend/src/components/MapSearchBar.jsx
@@ -130,7 +130,7 @@ export default function MapSearchBar({
 
   return (
     <div className="absolute top-3 sm:top-6 left-2 right-2 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 sm:w-full sm:max-w-2xl sm:px-6 z-[1000] pointer-events-none">
-      <div className="flex items-center bg-surface-container-lowest/80 backdrop-blur-md rounded-2xl px-3 sm:px-6 py-2 sm:py-3 gap-2 sm:gap-4 shadow-[0_10px_40px_-4px_rgba(45,47,47,0.12)] border border-outline-variant/20 pointer-events-auto">
+      <div className="flex items-center bg-surface-container-lowest/80 dark:bg-surface-container-lowest/95 backdrop-blur-md rounded-2xl px-3 sm:px-6 py-2 sm:py-3 gap-2 sm:gap-4 shadow-[0_10px_40px_-4px_rgba(45,47,47,0.12)] border border-outline-variant/20 pointer-events-auto">
         <span className="material-symbols-outlined text-primary text-xl sm:text-2xl">location_on</span>
         <div className="flex-1 min-w-0">
           <p className="hidden sm:block text-[10px] uppercase tracking-wider font-bold text-secondary">Current Location</p>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Link, NavLink, useNavigate } from 'react-router-dom'
 import SseStatusIndicator from './SseStatusIndicator.jsx'
 import NotificationDropdown from './NotificationDropdown.jsx'
+import UserSearchDropdown from './UserSearchDropdown.jsx'
 import ThemeToggleButton from './ThemePicker.jsx'
 import logo from '../assets/mapcess-transparent.png'
 import { useAuth } from '../context/AuthContext.jsx'
@@ -16,10 +17,12 @@ function Navbar() {
   const unreadCount = useUnreadCount()
   const [menuOpen, setMenuOpen] = useState(false)
   const [notifOpen, setNotifOpen] = useState(false)
+  const [userSearchOpen, setUserSearchOpen] = useState(false)
   const [failedAvatarUrl, setFailedAvatarUrl] = useState(null)
   const menuRef = useRef(null)
   const buttonRef = useRef(null)
   const notifButtonRef = useRef(null)
+  const userSearchButtonRef = useRef(null)
 
   const avatarUrl = user?.avatarUrl
   const showAvatarImage = !!avatarUrl && failedAvatarUrl !== avatarUrl
@@ -149,13 +152,25 @@ function Navbar() {
         <SseStatusIndicator />
         <ThemeToggleButton />
         {isAuthenticated && (
-          <Link
-            to="/search/users"
-            aria-label="Search users"
-            className="hidden sm:flex shrink-0 w-10 h-10 rounded-full items-center justify-center hover:bg-surface-container transition-colors"
-          >
-            <span className="material-symbols-outlined text-on-surface-variant">search</span>
-          </Link>
+          <div className="relative hidden sm:block">
+            <button
+              ref={userSearchButtonRef}
+              type="button"
+              onClick={() => { setUserSearchOpen((v) => !v); setNotifOpen(false); setMenuOpen(false) }}
+              aria-label="Search users"
+              aria-haspopup="dialog"
+              aria-expanded={userSearchOpen}
+              className="flex shrink-0 w-10 h-10 rounded-full items-center justify-center hover:bg-surface-container transition-colors"
+            >
+              <span className="material-symbols-outlined text-on-surface-variant">search</span>
+            </button>
+            {userSearchOpen && (
+              <UserSearchDropdown
+                onClose={() => setUserSearchOpen(false)}
+                triggerRef={userSearchButtonRef}
+              />
+            )}
+          </div>
         )}
         {isAuthenticated && (
           <div className="relative hidden sm:block">

--- a/frontend/src/components/UserSearchDropdown.jsx
+++ b/frontend/src/components/UserSearchDropdown.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react'
+import UserSearchPanel from './UserSearchPanel.jsx'
+
+/**
+ * Navbar popover that mounts UserSearchPanel below the search icon — same
+ * pattern as NotificationDropdown. Keeps the map visible behind so the user
+ * doesn't lose context when looking someone up.
+ *
+ * Props:
+ *  - onClose:    () => void   Fired on outside click, Escape, or after a
+ *                             result is selected.
+ *  - triggerRef: ref to the button that opens this dropdown — clicks inside
+ *                it are ignored by the outside-click handler so the trigger
+ *                can toggle the dropdown closed without racing the listener.
+ */
+function UserSearchDropdown({ onClose, triggerRef }) {
+  const ref = useRef(null)
+
+  useEffect(() => {
+    function handlePointerDown(e) {
+      if (ref.current?.contains(e.target)) return
+      if (triggerRef?.current?.contains(e.target)) return
+      onClose()
+    }
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [onClose, triggerRef])
+
+  return (
+    <div
+      ref={ref}
+      className="absolute right-0 mt-2 w-96 max-h-[560px] flex flex-col gap-3 rounded-xl bg-surface-container-lowest shadow-lg ring-1 ring-outline-variant/30 z-[1100] overflow-y-auto p-4"
+      role="dialog"
+      aria-label="Find people"
+    >
+      <UserSearchPanel heading="Find people" onResultSelect={onClose} />
+    </div>
+  )
+}
+
+export default UserSearchDropdown

--- a/frontend/src/components/UserSearchDropdown.jsx
+++ b/frontend/src/components/UserSearchDropdown.jsx
@@ -40,7 +40,18 @@ function UserSearchDropdown({ onClose, triggerRef }) {
       role="dialog"
       aria-label="Find people"
     >
-      <UserSearchPanel heading="Find people" onResultSelect={onClose} autoFocus={false} />
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold font-headline text-on-surface">Find people</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close search"
+          className="w-8 h-8 rounded-full bg-error/10 text-error flex items-center justify-center hover:bg-error/20 transition-colors cursor-pointer"
+        >
+          <span className="material-symbols-outlined text-base">close</span>
+        </button>
+      </div>
+      <UserSearchPanel onResultSelect={onClose} autoFocus={false} />
     </div>
   )
 }

--- a/frontend/src/components/UserSearchDropdown.jsx
+++ b/frontend/src/components/UserSearchDropdown.jsx
@@ -40,7 +40,7 @@ function UserSearchDropdown({ onClose, triggerRef }) {
       role="dialog"
       aria-label="Find people"
     >
-      <UserSearchPanel heading="Find people" onResultSelect={onClose} />
+      <UserSearchPanel heading="Find people" onResultSelect={onClose} autoFocus={false} />
     </div>
   )
 }

--- a/frontend/src/components/UserSearchPanel.jsx
+++ b/frontend/src/components/UserSearchPanel.jsx
@@ -1,0 +1,151 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { USER_SEARCH_MIN_LENGTH, useUserSearch } from '../hooks/useUserSearch.js'
+
+/**
+ * Self-contained user search panel — input + paginated results.
+ *
+ * Used both as the body of /search/users (full page, deep-linkable) and as
+ * the contents of the navbar UserSearchDropdown (popover on desktop so the
+ * map stays visible). Behaviour is identical in both mounts; layout is
+ * driven by the parent via the className-overridable wrapper.
+ *
+ * Props:
+ *  - onResultSelect?: () => void   Fired after a result row is clicked (e.g.
+ *                                  the dropdown closes itself).
+ *  - autoFocus?:      boolean      Default true.
+ *  - heading?:        string       Optional heading rendered above the input.
+ */
+function UserCard({ user, onSelect }) {
+  const reports = user.contributionStats?.reportsSubmitted ?? 0
+  const routes = user.contributionStats?.routesPlanned ?? 0
+  return (
+    <Link
+      to={`/profile/${user.id}`}
+      onClick={onSelect}
+      className="flex items-center gap-3 bg-surface-container rounded-2xl shadow-sm p-4 hover:shadow-md transition-shadow"
+    >
+      <div className="w-12 h-12 rounded-full bg-surface-container-high flex items-center justify-center flex-shrink-0 overflow-hidden">
+        {user.avatarUrl ? (
+          <img src={user.avatarUrl} alt={user.name} className="w-full h-full object-cover" />
+        ) : (
+          <span className="material-symbols-outlined text-on-surface-variant" style={{ fontSize: '24px' }}>
+            person
+          </span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-on-surface truncate">{user.name}</p>
+        <p className="text-xs text-on-surface-variant">
+          {reports} report{reports === 1 ? '' : 's'} · {routes} route{routes === 1 ? '' : 's'}
+        </p>
+      </div>
+      <span className="text-xs font-bold px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+        {user.role}
+      </span>
+    </Link>
+  )
+}
+
+function UserSearchPanel({ onResultSelect, autoFocus = true, heading }) {
+  const [query, setQuery] = useState('')
+  const [page, setPage] = useState(0)
+  const trimmed = query.trim()
+  const tooShort = trimmed.length > 0 && trimmed.length < USER_SEARCH_MIN_LENGTH
+
+  const { data, isPending, isFetching, isError, error } = useUserSearch(query, { page })
+
+  const results = data?.content ?? []
+  const totalElements = data?.totalElements ?? 0
+  const totalPages = data?.totalPages ?? 0
+  const isFirstPage = page === 0
+  const isLastPage = data ? data.last : true
+
+  function onChange(e) {
+    setQuery(e.target.value)
+    setPage(0)
+  }
+
+  return (
+    <>
+      {heading && (
+        <h1 className="text-2xl font-bold font-headline text-on-surface">{heading}</h1>
+      )}
+
+      <label className="flex flex-col gap-1">
+        <span className="text-xs uppercase tracking-wide text-on-surface-variant">
+          Search by name or email
+        </span>
+        <input
+          type="search"
+          value={query}
+          onChange={onChange}
+          placeholder="e.g. alice"
+          autoFocus={autoFocus}
+          className="bg-surface-container-lowest rounded-2xl shadow-sm px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant outline-none focus:ring-2 focus:ring-primary"
+          aria-label="Search users by name or email"
+        />
+      </label>
+
+      {tooShort && (
+        <p className="text-sm text-on-surface-variant">
+          Type at least {USER_SEARCH_MIN_LENGTH} characters to search.
+        </p>
+      )}
+
+      {trimmed.length >= USER_SEARCH_MIN_LENGTH && isPending && (
+        <p className="text-sm text-on-surface-variant">Searching…</p>
+      )}
+
+      {isError && (
+        <p role="alert" className="text-sm text-error">
+          {error?.message || 'Search failed.'}
+        </p>
+      )}
+
+      {!isPending && !isError && data && (
+        <>
+          <p className="text-xs text-on-surface-variant" aria-live="polite">
+            {totalElements === 0
+              ? 'No users found.'
+              : `${totalElements} match${totalElements === 1 ? '' : 'es'}.`}
+          </p>
+
+          <ul className="flex flex-col gap-2">
+            {results.map((u) => (
+              <li key={u.id}>
+                <UserCard user={u} onSelect={onResultSelect} />
+              </li>
+            ))}
+          </ul>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-3 mt-2">
+              <button
+                type="button"
+                onClick={() => setPage((p) => Math.max(p - 1, 0))}
+                disabled={isFirstPage || isFetching}
+                className="px-3 py-1.5 rounded-full bg-surface-container-low text-on-surface text-sm font-semibold disabled:opacity-50 cursor-pointer"
+              >
+                Previous
+              </button>
+              <span className="text-xs text-on-surface-variant">
+                Page {page + 1} of {totalPages}
+              </span>
+              <button
+                type="button"
+                onClick={() => setPage((p) => p + 1)}
+                disabled={isLastPage || isFetching}
+                className="px-3 py-1.5 rounded-full bg-primary text-on-primary text-sm font-semibold disabled:opacity-50 cursor-pointer"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </>
+  )
+}
+
+export default UserSearchPanel

--- a/frontend/src/components/UserSearchPanel.jsx
+++ b/frontend/src/components/UserSearchPanel.jsx
@@ -83,7 +83,7 @@ function UserSearchPanel({ onResultSelect, autoFocus = true, heading }) {
             onChange={onChange}
             placeholder="e.g. alice"
             autoFocus={autoFocus}
-            className="w-full bg-surface-container-high rounded-2xl shadow-sm pl-4 pr-10 py-3 text-sm text-on-surface placeholder:text-on-surface-variant outline-none focus:ring-2 focus:ring-primary"
+            className="w-full bg-surface-container-high rounded-2xl shadow-sm pl-4 pr-10 py-3 text-sm text-on-surface placeholder:text-on-surface-variant outline-none focus-visible:ring-2 focus-visible:ring-primary"
             aria-label="Search users by name or email"
           />
           {query.length > 0 && (

--- a/frontend/src/components/UserSearchPanel.jsx
+++ b/frontend/src/components/UserSearchPanel.jsx
@@ -72,8 +72,8 @@ function UserSearchPanel({ onResultSelect, autoFocus = true, heading }) {
         <h1 className="text-2xl font-bold font-headline text-on-surface">{heading}</h1>
       )}
 
-      <label className="flex flex-col gap-1">
-        <span className="text-xs uppercase tracking-wide text-on-surface-variant">
+      <label className="flex flex-col gap-2 -mt-2">
+        <span className="text-xs text-on-surface-variant">
           Search by name or email
         </span>
         <input

--- a/frontend/src/components/UserSearchPanel.jsx
+++ b/frontend/src/components/UserSearchPanel.jsx
@@ -83,7 +83,7 @@ function UserSearchPanel({ onResultSelect, autoFocus = true, heading }) {
             onChange={onChange}
             placeholder="e.g. alice"
             autoFocus={autoFocus}
-            className="w-full bg-surface-container-lowest rounded-2xl shadow-sm pl-4 pr-10 py-3 text-sm text-on-surface placeholder:text-on-surface-variant outline-none focus:ring-2 focus:ring-primary"
+            className="w-full bg-surface-container-high rounded-2xl shadow-sm pl-4 pr-10 py-3 text-sm text-on-surface placeholder:text-on-surface-variant outline-none focus:ring-2 focus:ring-primary"
             aria-label="Search users by name or email"
           />
           {query.length > 0 && (

--- a/frontend/src/components/UserSearchPanel.jsx
+++ b/frontend/src/components/UserSearchPanel.jsx
@@ -76,15 +76,27 @@ function UserSearchPanel({ onResultSelect, autoFocus = true, heading }) {
         <span className="text-xs text-on-surface-variant">
           Search by name or email
         </span>
-        <input
-          type="search"
-          value={query}
-          onChange={onChange}
-          placeholder="e.g. alice"
-          autoFocus={autoFocus}
-          className="bg-surface-container-lowest rounded-2xl shadow-sm px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant outline-none focus:ring-2 focus:ring-primary"
-          aria-label="Search users by name or email"
-        />
+        <div className="relative">
+          <input
+            type="text"
+            value={query}
+            onChange={onChange}
+            placeholder="e.g. alice"
+            autoFocus={autoFocus}
+            className="w-full bg-surface-container-lowest rounded-2xl shadow-sm pl-4 pr-10 py-3 text-sm text-on-surface placeholder:text-on-surface-variant outline-none focus:ring-2 focus:ring-primary"
+            aria-label="Search users by name or email"
+          />
+          {query.length > 0 && (
+            <button
+              type="button"
+              onClick={() => { setQuery(''); setPage(0) }}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-error/10 text-error flex items-center justify-center hover:bg-error/20 transition-colors cursor-pointer"
+            >
+              <span className="material-symbols-outlined text-[18px]">close</span>
+            </button>
+          )}
+        </div>
       </label>
 
       {tooShort && (

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -123,21 +123,21 @@ function ZoomControls({ userLocation, onLocationError }) {
     <div className="absolute right-3 sm:right-10 top-24 sm:top-1/3 sm:-translate-y-1/2 flex flex-col gap-2 z-[1000]">
       <button
         onClick={() => map.zoomIn()}
-        className="w-10 h-10 sm:w-12 sm:h-12 bg-surface-container-lowest/80 backdrop-blur-md rounded-xl flex items-center justify-center shadow-lg hover:bg-surface-container-lowest text-secondary hover:text-primary transition-colors"
+        className="w-10 h-10 sm:w-12 sm:h-12 bg-surface-container-lowest/80 dark:bg-surface-container-lowest/95 backdrop-blur-md rounded-xl flex items-center justify-center shadow-lg hover:bg-surface-container-lowest text-secondary hover:text-primary transition-colors"
         aria-label="Zoom in"
       >
         <span className="material-symbols-outlined">add</span>
       </button>
       <button
         onClick={() => map.zoomOut()}
-        className="w-10 h-10 sm:w-12 sm:h-12 bg-surface-container-lowest/80 backdrop-blur-md rounded-xl flex items-center justify-center shadow-lg hover:bg-surface-container-lowest text-secondary hover:text-primary transition-colors"
+        className="w-10 h-10 sm:w-12 sm:h-12 bg-surface-container-lowest/80 dark:bg-surface-container-lowest/95 backdrop-blur-md rounded-xl flex items-center justify-center shadow-lg hover:bg-surface-container-lowest text-secondary hover:text-primary transition-colors"
         aria-label="Zoom out"
       >
         <span className="material-symbols-outlined">remove</span>
       </button>
       <button
         onClick={handleLocate}
-        className="w-10 h-10 sm:w-12 sm:h-12 bg-surface-container-lowest/80 backdrop-blur-md rounded-xl flex items-center justify-center shadow-lg hover:bg-surface-container-lowest text-secondary hover:text-primary transition-colors mt-2"
+        className="w-10 h-10 sm:w-12 sm:h-12 bg-surface-container-lowest/80 dark:bg-surface-container-lowest/95 backdrop-blur-md rounded-xl flex items-center justify-center shadow-lg hover:bg-surface-container-lowest text-secondary hover:text-primary transition-colors mt-2"
         aria-label="My location"
       >
         <span className="material-symbols-outlined">my_location</span>
@@ -692,7 +692,7 @@ function Home() {
 
           {/* Community Pulse card + FAB */}
           <div className="absolute bottom-4 right-4 sm:bottom-10 sm:right-10 z-[1000] flex flex-col items-end gap-3 sm:gap-4">
-            <div className="hidden lg:block bg-surface-container-lowest/80 backdrop-blur-md rounded-3xl p-6 w-72 shadow-[0_10px_40px_-4px_rgba(45,47,47,0.12)] border border-outline-variant/20">
+            <div className="hidden lg:block bg-surface-container-lowest/80 dark:bg-surface-container-lowest/95 backdrop-blur-md rounded-3xl p-6 w-72 shadow-[0_10px_40px_-4px_rgba(45,47,47,0.12)] border border-outline-variant/20">
               <div className="flex justify-between items-center mb-4">
                 <h3 className="font-headline font-bold text-on-surface">Community Pulse</h3>
                 <span className="material-symbols-outlined text-primary">analytics</span>

--- a/frontend/src/pages/UserSearchPage.jsx
+++ b/frontend/src/pages/UserSearchPage.jsx
@@ -1,135 +1,19 @@
-import { useState } from 'react'
-import { Link } from 'react-router-dom'
 import Navbar from '../components/Navbar.jsx'
-import { USER_SEARCH_MIN_LENGTH, useUserSearch } from '../hooks/useUserSearch.js'
+import UserSearchPanel from '../components/UserSearchPanel.jsx'
 
-function UserCard({ user }) {
-  const reports = user.contributionStats?.reportsSubmitted ?? 0
-  const routes = user.contributionStats?.routesPlanned ?? 0
-  return (
-    <Link
-      to={`/profile/${user.id}`}
-      className="flex items-center gap-3 bg-surface-container rounded-2xl shadow-sm p-4 hover:shadow-md transition-shadow"
-    >
-      <div className="w-12 h-12 rounded-full bg-surface-container-high flex items-center justify-center flex-shrink-0 overflow-hidden">
-        {user.avatarUrl ? (
-          <img src={user.avatarUrl} alt={user.name} className="w-full h-full object-cover" />
-        ) : (
-          <span className="material-symbols-outlined text-on-surface-variant" style={{ fontSize: '24px' }}>
-            person
-          </span>
-        )}
-      </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-semibold text-on-surface truncate">{user.name}</p>
-        <p className="text-xs text-on-surface-variant">
-          {reports} report{reports === 1 ? '' : 's'} · {routes} route{routes === 1 ? '' : 's'}
-        </p>
-      </div>
-      <span className="text-xs font-bold px-2 py-0.5 rounded-full bg-primary/10 text-primary">
-        {user.role}
-      </span>
-    </Link>
-  )
-}
-
+/**
+ * Full-page user search at /search/users. Used as a deep-linkable URL and as
+ * the mobile fallback when the navbar popover would be too cramped.
+ *
+ * All the actual search behaviour lives in UserSearchPanel — this file only
+ * provides the page chrome (Navbar + bg-background container).
+ */
 function UserSearchPage() {
-  const [query, setQuery] = useState('')
-  const [page, setPage] = useState(0)
-  const trimmed = query.trim()
-  const tooShort = trimmed.length > 0 && trimmed.length < USER_SEARCH_MIN_LENGTH
-
-  const { data, isPending, isFetching, isError, error } = useUserSearch(query, { page })
-
-  const results = data?.content ?? []
-  const totalElements = data?.totalElements ?? 0
-  const totalPages = data?.totalPages ?? 0
-  const isFirstPage = page === 0
-  const isLastPage = data ? data.last : true
-
-  function onChange(e) {
-    setQuery(e.target.value)
-    setPage(0)
-  }
-
   return (
     <div className="min-h-screen flex flex-col bg-background">
       <Navbar />
       <main className="flex-1 max-w-3xl w-full mx-auto p-4 md:p-8 flex flex-col gap-4">
-        <h1 className="text-2xl font-bold font-headline text-on-surface">Find people</h1>
-
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wide text-on-surface-variant">
-            Search by name or email
-          </span>
-          <input
-            type="search"
-            value={query}
-            onChange={onChange}
-            placeholder="e.g. alice"
-            autoFocus
-            className="bg-surface-container-lowest rounded-2xl shadow-sm px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant outline-none focus:ring-2 focus:ring-primary"
-            aria-label="Search users by name or email"
-          />
-        </label>
-
-        {tooShort && (
-          <p className="text-sm text-on-surface-variant">
-            Type at least {USER_SEARCH_MIN_LENGTH} characters to search.
-          </p>
-        )}
-
-        {trimmed.length >= USER_SEARCH_MIN_LENGTH && isPending && (
-          <p className="text-sm text-on-surface-variant">Searching…</p>
-        )}
-
-        {isError && (
-          <p role="alert" className="text-sm text-error">
-            {error?.message || 'Search failed.'}
-          </p>
-        )}
-
-        {!isPending && !isError && data && (
-          <>
-            <p className="text-xs text-on-surface-variant" aria-live="polite">
-              {totalElements === 0
-                ? 'No users found.'
-                : `${totalElements} match${totalElements === 1 ? '' : 'es'}.`}
-            </p>
-
-            <ul className="flex flex-col gap-2">
-              {results.map((u) => (
-                <li key={u.id}>
-                  <UserCard user={u} />
-                </li>
-              ))}
-            </ul>
-
-            {totalPages > 1 && (
-              <div className="flex items-center justify-center gap-3 mt-2">
-                <button
-                  type="button"
-                  onClick={() => setPage((p) => Math.max(p - 1, 0))}
-                  disabled={isFirstPage || isFetching}
-                  className="px-3 py-1.5 rounded-full bg-surface-container-low text-on-surface text-sm font-semibold disabled:opacity-50 cursor-pointer"
-                >
-                  Previous
-                </button>
-                <span className="text-xs text-on-surface-variant">
-                  Page {page + 1} of {totalPages}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => setPage((p) => p + 1)}
-                  disabled={isLastPage || isFetching}
-                  className="px-3 py-1.5 rounded-full bg-primary text-on-primary text-sm font-semibold disabled:opacity-50 cursor-pointer"
-                >
-                  Next
-                </button>
-              </div>
-            )}
-          </>
-        )}
+        <UserSearchPanel heading="Find people" />
       </main>
     </div>
   )


### PR DESCRIPTION
## 📝 Description
Closes #633. Clicking the navbar search icon previously navigated to `/search/users`, unmounting the map and leaving a near-empty page with a single input. The notification icon right beside it already uses a popover pattern; user search now matches.

Atomic commits in order:
1. Extract `UserSearchPanel` from `UserSearchPage` : input, results, pagination, all states. Reusable by both mounts.
2. `UserSearchPage` delegates to the new panel; `/search/users` URL keeps working for deep links.
3. `UserSearchDropdown` popover mirroring `NotificationDropdown` (anchored under the trigger, outside-click + Escape close, internal scroll).
4. Navbar wires the search icon as a toggling button; other dropdowns close when this one opens.
5. Label sentence-cased and tightened against the input.
6. Custom themed close (×) button replaces the browser's native search-clear (which rendered dark blue in dark mode).
7. Input bg bumped to `surface-container-high` so the pill reads as elevated above the popover surface.
8. `:focus-visible` swap so the green ring doesn't carry over from autoFocus.
9. `autoFocus={false}` inside the popover , pill stays unringed until the user actually clicks it.

The search icon was already `hidden sm:flex` on `main`, so no mobile fallback was needed (it never appeared on mobile).

## 📊 Type
Refactor / UX polish

## 📸 Screenshots
<img width="1214" height="677" alt="Ekran Resmi 2026-05-12 00 02 45" src="https://github.com/user-attachments/assets/b4b579ac-e8cf-4dde-8afe-7f306c0dfdcd" />

## ✅ Acceptance Criteria
- [x] Desktop: clicking the navbar search icon opens a popover; map stays visible behind
- [x] Popover closes on outside click, Escape, and after selecting a result
- [x] Clicking a result navigates to `/profile/<id>`
- [x] `/search/users` URL still works and renders the same panel
- [x] No green focus ring on initial popover open
- [x] Custom themed × clear button (no dark-blue browser default)
- [x] No regression , 481 frontend tests pass

## 🧪 Test
- Desktop: click search icon → popover opens, map visible behind, no ring on the pill
- Type → results render, themed × appears on the right; click × to clear
- Click a result → popover closes, lands on `/profile/<id>`
- Click outside / Escape → popover closes
- Visit `/search/users` directly → renders the same panel (full page, with autoFocus)

## ⏱️ Review
~3 min