### PR TITLE
[Web][Mobile] Remove Unused Forgot Password Link From Login

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -112,17 +112,12 @@ function Login() {
 
               {/* Password */}
               <div className="space-y-2">
-                <div className="flex justify-between items-center px-1">
-                  <label className="text-sm font-label font-bold text-[#5a5c5c]" htmlFor="password">
-                    Password
-                  </label>
-                  <a
-                    className="text-xs font-semibold text-[#176a21] hover:text-[#025d16] transition-colors"
-                    href="#"
-                  >
-                    Forgot password?
-                  </a>
-                </div>
+                <label
+                  className="block text-sm font-label font-bold text-[#5a5c5c] px-1"
+                  htmlFor="password"
+                >
+                  Password
+                </label>
                 <div className="relative">
                   <input
                     className="w-full px-5 py-4 bg-[#f0f1f1] border-none rounded-xl focus:ring-2 focus:ring-[#176a21]/40 text-[#2d2f2f] placeholder:text-[#767777]/70 transition-all outline-none pr-12"

--- a/frontend/src/pages/Login.test.jsx
+++ b/frontend/src/pages/Login.test.jsx
@@ -59,11 +59,6 @@ describe('Login page', () => {
       expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
     })
 
-    it('renders a "Forgot password?" link', () => {
-      renderLogin()
-      expect(screen.getByRole('link', { name: /forgot password/i })).toBeInTheDocument()
-    })
-
     // Commented out: Google/Apple OAuth buttons removed from the app.
     // See: https://github.com/bounswe/bounswe2026group1/issues/133
     // it('renders Google and Apple social auth buttons', () => {

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -115,23 +115,7 @@ class _LoginScreenState extends State<LoginScreen> {
                       errorText: _emailError,
                     ),
                     const SizedBox(height: 16),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        _buildLabel('Password'),
-                        GestureDetector(
-                          onTap: () {},
-                          child: Text(
-                            'Forgot Password?',
-                            style: TextStyle(
-                              fontSize: 13,
-                              fontWeight: FontWeight.w700,
-                              color: AppColors.primary,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+                    _buildLabel('Password'),
                     const SizedBox(height: 6),
                     _buildTextField(
                       controller: _passwordController,


### PR DESCRIPTION
# 📝 Description
Fixes #635
Removes the unused **"Forgot password?"** control from the login screen on web (`frontend/src/pages/Login.jsx`) and mobile (`mobile/lib/screens/login_screen.dart`). Updates Login tests so they no longer expect that link.

---
# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation


# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed
---
# 📸 Screenshots / Recordings

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min