### PR TITLE
[Backend][Frontend] Add Advanced Filters and Sort to Report Feed

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportController.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/controller/ReportController.java
@@ -44,22 +44,18 @@ public class ReportController {
     @GetMapping("/feed")
     @Operation(
             summary = "Paginated, filterable report feed",
-            description = "Like `GET /api/reports`, but paginated and filterable by reportType / " +
-                    "environment / proximity. When `latitude` and `longitude` are supplied, results " +
-                    "are ordered by PostGIS distance from that point."
+            description = "Paginated feed with filters for reportType, environment, status, authorId, " +
+                    "publish date range, free-text description (`q`, case-insensitive), vote thresholds " +
+                    "(`minAgrees`, `minDisagrees`, `minNetScore`), attached objectType / issueType, and " +
+                    "proximity. When `latitude` and `longitude` are supplied, results default to " +
+                    "PostGIS distance ordering; an explicit `sort` parameter overrides this " +
+                    "(`NEWEST`, `OLDEST`, `MOST_AGREED`, `MOST_CONTROVERSIAL`, `DISTANCE`)."
     )
     public Page<ReportResponse> feed(
             @ParameterObject ReportFeedQuery query,
             @ParameterObject @PageableDefault(size = 20) Pageable pageable,
             @AuthenticationPrincipal String email) {
-        return reportService.feed(
-                query.getReportType(),
-                query.getEnvironment(),
-                query.getLatitude(),
-                query.getLongitude(),
-                query.getRadiusInKm(),
-                pageable,
-                email);
+        return reportService.feed(query, pageable, email);
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/FeedSort.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/FeedSort.java
@@ -1,0 +1,13 @@
+package com.bounswe2026group1.backend.dto;
+
+/**
+ * Explicit sort selection for the report feed. When omitted, the service defaults to
+ * {@link #DISTANCE} if coordinates are supplied and {@link #NEWEST} otherwise.
+ */
+public enum FeedSort {
+    NEWEST,
+    OLDEST,
+    MOST_AGREED,
+    MOST_CONTROVERSIAL,
+    DISTANCE
+}

--- a/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportFeedQuery.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/dto/ReportFeedQuery.java
@@ -1,9 +1,15 @@
 package com.bounswe2026group1.backend.dto;
 
+import com.bounswe2026group1.backend.model.IssueType;
+import com.bounswe2026group1.backend.model.ObjectType;
 import com.bounswe2026group1.backend.model.ReportEnvironment;
+import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.ReportType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
 
 /**
  * Query parameters for {@code GET /api/reports/feed}. Optional {@code latitude}/{@code longitude}
@@ -20,8 +26,49 @@ public class ReportFeedQuery {
     @Schema(description = "Filter by environment.", example = "OUTDOOR")
     private ReportEnvironment environment;
 
+    @Schema(description = "Filter by report status. Repeatable; matches any of the supplied values.",
+            example = "VERIFIED")
+    private List<ReportStatus> status;
+
+    @Schema(description = "Filter by report author user id.", example = "42")
+    private Long authorId;
+
+    @Schema(description = "Only include reports published at or after this ISO-8601 instant.",
+            example = "2026-01-01T00:00:00Z")
+    private Instant publishedAfter;
+
+    @Schema(description = "Only include reports published at or before this ISO-8601 instant.",
+            example = "2026-12-31T23:59:59Z")
+    private Instant publishedBefore;
+
+    @Schema(description = "Case-insensitive substring search over the report description.",
+            example = "elevator")
+    private String q;
+
+    @Schema(description = "Only include reports with at least this many agree votes.", example = "5")
+    private Integer minAgrees;
+
+    @Schema(description = "Only include reports with at least this many disagree votes.", example = "2")
+    private Integer minDisagrees;
+
+    @Schema(description = "Only include reports whose (agrees - disagrees) is at least this value.",
+            example = "1")
+    private Integer minNetScore;
+
+    @Schema(description = "Filter by attached object type. Repeatable; matches reports that have at least one matching object.",
+            example = "RAMP")
+    private List<ObjectType> objectType;
+
+    @Schema(description = "Filter by attached object issue type. Repeatable; matches reports that have at least one object with a matching issue.",
+            example = "TOO_STEEP")
+    private List<IssueType> issueType;
+
+    @Schema(description = "Sort selection. Defaults to DISTANCE when coordinates are given, else NEWEST.",
+            example = "NEWEST")
+    private FeedSort sort;
+
     @Schema(description = "WGS84 latitude of the user's location. " +
-            "When set together with `longitude`, results are ordered by distance from this point.",
+            "When set together with `longitude`, results may be ordered by distance from this point.",
             example = "41.085", minimum = "-90", maximum = "90", nullable = true)
     private Double latitude;
 

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryCustom.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryCustom.java
@@ -1,30 +1,23 @@
 package com.bounswe2026group1.backend.repository;
 
+import com.bounswe2026group1.backend.dto.ReportFeedQuery;
 import com.bounswe2026group1.backend.model.Report;
-import com.bounswe2026group1.backend.model.ReportEnvironment;
-import com.bounswe2026group1.backend.model.ReportType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ReportRepositoryCustom {
 
     /**
-     * PostGIS geography distance: filters within {@code radiusInKm} (converted to meters for {@code ST_DWithin})
-     * and sorts strictly by ascending {@code ST_Distance} (closest first). Pagination applies after this order.
+     * PostGIS geography distance: filters within {@code filter.radiusInKm} (converted to meters
+     * for {@code ST_DWithin}) plus any other supplied filters. Sort order is dictated by
+     * {@code filter.sort}; defaults to ascending {@code ST_Distance} (closest first) when null.
+     * Requires {@code filter.latitude} and {@code filter.longitude} to be non-null.
      */
-    Page<Report> findFeedWithinRadius(
-            ReportType reportType,
-            ReportEnvironment environment,
-            double latitude,
-            double longitude,
-            double radiusInKm,
-            Pageable pageable);
+    Page<Report> findFeedWithinRadius(ReportFeedQuery filter, Pageable pageable);
 
     /**
-     * Default feed ordering: newest first by {@link com.bounswe2026group1.backend.model.Report#getPublishDate()}.
+     * Non-proximity feed. Applies all supplied filters and orders by {@code filter.sort}
+     * (default: publish date descending — newest first).
      */
-    Page<Report> findFeedRecent(
-            ReportType reportType,
-            ReportEnvironment environment,
-            Pageable pageable);
+    Page<Report> findFeedRecent(ReportFeedQuery filter, Pageable pageable);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryImpl.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/ReportRepositoryImpl.java
@@ -1,7 +1,12 @@
 package com.bounswe2026group1.backend.repository;
 
+import com.bounswe2026group1.backend.dto.FeedSort;
+import com.bounswe2026group1.backend.dto.ReportFeedQuery;
+import com.bounswe2026group1.backend.model.IssueType;
+import com.bounswe2026group1.backend.model.ObjectType;
 import com.bounswe2026group1.backend.model.Report;
 import com.bounswe2026group1.backend.model.ReportEnvironment;
+import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.ReportType;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -11,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,13 +27,7 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
     private EntityManager entityManager;
 
     @Override
-    public Page<Report> findFeedWithinRadius(
-            ReportType reportType,
-            ReportEnvironment environment,
-            double latitude,
-            double longitude,
-            double radiusInKm,
-            Pageable pageable) {
+    public Page<Report> findFeedWithinRadius(ReportFeedQuery filter, Pageable pageable) {
 
         // Single ST_MakePoint via CTE so :feedLon/:feedLat appear only once. Some JDBC/Hibernate
         // stacks mishandle duplicate native named parameters; that surfaced as 500 when combining
@@ -48,14 +48,14 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
                 """);
 
         Map<String, Object> params = new HashMap<>();
-        params.put("feedLat", latitude);
-        params.put("feedLon", longitude);
-        params.put("feedRadiusMeters", radiusInKm * 1000.0);
+        params.put("feedLat", filter.getLatitude());
+        params.put("feedLon", filter.getLongitude());
+        params.put("feedRadiusMeters",
+                (filter.getRadiusInKm() != null ? filter.getRadiusInKm() : 1.0) * 1000.0);
 
-        appendNativeReportTypeFilter(fromWhere, params, reportType);
-        appendNativeEnvironmentFilter(fromWhere, params, environment);
+        appendNativeFilters(fromWhere, params, filter);
 
-        String orderBy = " ORDER BY ST_Distance(r.location::geography, ref.g) ASC";
+        String orderBy = nativeOrderBy(resolveSort(filter, /*hasCoords=*/ true));
 
         String countSql = withClause + "SELECT count(*) " + fromWhere;
         Query countQuery = entityManager.createNativeQuery(countSql);
@@ -75,22 +75,18 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
     }
 
     @Override
-    public Page<Report> findFeedRecent(
-            ReportType reportType,
-            ReportEnvironment environment,
-            Pageable pageable) {
+    public Page<Report> findFeedRecent(ReportFeedQuery filter, Pageable pageable) {
 
         StringBuilder base = new StringBuilder("FROM Report r WHERE 1=1");
         Map<String, Object> params = new HashMap<>();
-        appendJpqlReportTypeFilter(base, params, reportType);
-        appendJpqlEnvironmentFilter(base, params, environment);
+        appendJpqlFilters(base, params, filter);
 
         String countHql = "SELECT count(r) " + base;
         TypedQuery<Long> countQuery = entityManager.createQuery(countHql, Long.class);
         bindAllTyped(countQuery, params);
         long total = countQuery.getSingleResult();
 
-        String dataHql = "SELECT r " + base + " ORDER BY r.publishDate DESC";
+        String dataHql = "SELECT r " + base + jpqlOrderBy(resolveSort(filter, /*hasCoords=*/ false));
         TypedQuery<Report> dataQuery = entityManager.createQuery(dataHql, Report.class);
         bindAllTyped(dataQuery, params);
         dataQuery.setFirstResult((int) pageable.getOffset());
@@ -100,36 +96,186 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
         return new PageImpl<>(content, pageable, total);
     }
 
-    private static void appendNativeReportTypeFilter(StringBuilder sql, Map<String, Object> params, ReportType reportType) {
-        if (reportType == null) {
-            return;
+    // ----- shared filter assembly --------------------------------------------------------------
+
+    private static void appendNativeFilters(StringBuilder sql, Map<String, Object> params,
+                                            ReportFeedQuery filter) {
+        ReportType reportType = filter.getReportType();
+        if (reportType != null) {
+            sql.append(" AND r.report_type = :feedReportType");
+            params.put("feedReportType", reportType.name());
         }
-        sql.append(" AND r.report_type = :feedReportType");
-        params.put("feedReportType", reportType.name());
+        ReportEnvironment environment = filter.getEnvironment();
+        if (environment != null) {
+            sql.append(" AND r.environment = :feedEnvironment");
+            params.put("feedEnvironment", environment.name());
+        }
+        List<ReportStatus> statuses = nonEmpty(filter.getStatus());
+        if (statuses != null) {
+            sql.append(" AND r.status IN (:feedStatuses)");
+            params.put("feedStatuses", statuses.stream().map(Enum::name).toList());
+        }
+        if (filter.getAuthorId() != null) {
+            sql.append(" AND r.user_id = :feedAuthorId");
+            params.put("feedAuthorId", filter.getAuthorId());
+        }
+        if (filter.getPublishedAfter() != null) {
+            sql.append(" AND r.publish_date >= :feedPublishedAfter");
+            params.put("feedPublishedAfter", filter.getPublishedAfter());
+        }
+        if (filter.getPublishedBefore() != null) {
+            sql.append(" AND r.publish_date <= :feedPublishedBefore");
+            params.put("feedPublishedBefore", filter.getPublishedBefore());
+        }
+        String q = normalizeQ(filter.getQ());
+        if (q != null) {
+            sql.append(" AND r.description ILIKE :feedQ");
+            params.put("feedQ", "%" + q + "%");
+        }
+        if (filter.getMinAgrees() != null) {
+            sql.append(" AND r.agrees >= :feedMinAgrees");
+            params.put("feedMinAgrees", filter.getMinAgrees());
+        }
+        if (filter.getMinDisagrees() != null) {
+            sql.append(" AND r.disagrees >= :feedMinDisagrees");
+            params.put("feedMinDisagrees", filter.getMinDisagrees());
+        }
+        if (filter.getMinNetScore() != null) {
+            sql.append(" AND (r.agrees - r.disagrees) >= :feedMinNetScore");
+            params.put("feedMinNetScore", filter.getMinNetScore());
+        }
+        List<ObjectType> objectTypes = nonEmpty(filter.getObjectType());
+        if (objectTypes != null) {
+            sql.append(" AND EXISTS (SELECT 1 FROM report_objects ro")
+                    .append(" WHERE ro.report_id = r.report_id")
+                    .append(" AND ro.object_type IN (:feedObjectTypes))");
+            params.put("feedObjectTypes", objectTypes.stream().map(Enum::name).toList());
+        }
+        List<IssueType> issueTypes = nonEmpty(filter.getIssueType());
+        if (issueTypes != null) {
+            sql.append(" AND EXISTS (SELECT 1 FROM report_objects ro2")
+                    .append(" JOIN report_object_issues roi ON roi.report_object_id = ro2.id")
+                    .append(" WHERE ro2.report_id = r.report_id")
+                    .append(" AND roi.issue_type IN (:feedIssueTypes))");
+            params.put("feedIssueTypes", issueTypes.stream().map(Enum::name).toList());
+        }
     }
 
-    private static void appendNativeEnvironmentFilter(StringBuilder sql, Map<String, Object> params, ReportEnvironment environment) {
-        if (environment == null) {
-            return;
+    private static void appendJpqlFilters(StringBuilder jpql, Map<String, Object> params,
+                                          ReportFeedQuery filter) {
+        ReportType reportType = filter.getReportType();
+        if (reportType != null) {
+            jpql.append(" AND r.reportType = :reportType");
+            params.put("reportType", reportType);
         }
-        sql.append(" AND r.environment = :feedEnvironment");
-        params.put("feedEnvironment", environment.name());
+        ReportEnvironment environment = filter.getEnvironment();
+        if (environment != null) {
+            jpql.append(" AND r.environment = :feedEnv");
+            params.put("feedEnv", environment);
+        }
+        List<ReportStatus> statuses = nonEmpty(filter.getStatus());
+        if (statuses != null) {
+            jpql.append(" AND r.status IN :feedStatuses");
+            params.put("feedStatuses", statuses);
+        }
+        if (filter.getAuthorId() != null) {
+            jpql.append(" AND r.createdBy.id = :feedAuthorId");
+            params.put("feedAuthorId", filter.getAuthorId());
+        }
+        if (filter.getPublishedAfter() != null) {
+            jpql.append(" AND r.publishDate >= :feedPublishedAfter");
+            params.put("feedPublishedAfter", filter.getPublishedAfter());
+        }
+        if (filter.getPublishedBefore() != null) {
+            jpql.append(" AND r.publishDate <= :feedPublishedBefore");
+            params.put("feedPublishedBefore", filter.getPublishedBefore());
+        }
+        String q = normalizeQ(filter.getQ());
+        if (q != null) {
+            jpql.append(" AND LOWER(r.description) LIKE LOWER(:feedQ)");
+            params.put("feedQ", "%" + q + "%");
+        }
+        if (filter.getMinAgrees() != null) {
+            jpql.append(" AND r.agrees >= :feedMinAgrees");
+            params.put("feedMinAgrees", filter.getMinAgrees());
+        }
+        if (filter.getMinDisagrees() != null) {
+            jpql.append(" AND r.disagrees >= :feedMinDisagrees");
+            params.put("feedMinDisagrees", filter.getMinDisagrees());
+        }
+        if (filter.getMinNetScore() != null) {
+            jpql.append(" AND (r.agrees - r.disagrees) >= :feedMinNetScore");
+            params.put("feedMinNetScore", filter.getMinNetScore());
+        }
+        List<ObjectType> objectTypes = nonEmpty(filter.getObjectType());
+        if (objectTypes != null) {
+            jpql.append(" AND EXISTS (SELECT 1 FROM ReportObject ro")
+                    .append(" WHERE ro.report = r AND ro.objectType IN :feedObjectTypes)");
+            params.put("feedObjectTypes", objectTypes);
+        }
+        List<IssueType> issueTypes = nonEmpty(filter.getIssueType());
+        if (issueTypes != null) {
+            jpql.append(" AND EXISTS (SELECT 1 FROM ReportObject ro2 JOIN ro2.issues i")
+                    .append(" WHERE ro2.report = r AND i IN :feedIssueTypes)");
+            params.put("feedIssueTypes", issueTypes);
+        }
     }
 
-    private static void appendJpqlReportTypeFilter(StringBuilder jpql, Map<String, Object> params, ReportType reportType) {
-        if (reportType == null) {
-            return;
+    // ----- ordering ----------------------------------------------------------------------------
+
+    private static FeedSort resolveSort(ReportFeedQuery filter, boolean hasCoords) {
+        FeedSort sort = filter.getSort();
+        if (sort != null) {
+            return sort;
         }
-        jpql.append(" AND r.reportType = :reportType");
-        params.put("reportType", reportType);
+        return hasCoords ? FeedSort.DISTANCE : FeedSort.NEWEST;
     }
 
-    private static void appendJpqlEnvironmentFilter(StringBuilder jpql, Map<String, Object> params, ReportEnvironment environment) {
-        if (environment == null) {
-            return;
+    private static String nativeOrderBy(FeedSort sort) {
+        return switch (sort) {
+            case DISTANCE -> " ORDER BY ST_Distance(r.location::geography, ref.g) ASC";
+            case OLDEST -> " ORDER BY r.publish_date ASC";
+            case MOST_AGREED -> " ORDER BY r.agrees DESC, r.publish_date DESC";
+            case MOST_CONTROVERSIAL -> " ORDER BY (r.agrees + r.disagrees) DESC, r.publish_date DESC";
+            case NEWEST -> " ORDER BY r.publish_date DESC";
+        };
+    }
+
+    private static String jpqlOrderBy(FeedSort sort) {
+        return switch (sort) {
+            case OLDEST -> " ORDER BY r.publishDate ASC";
+            case MOST_AGREED -> " ORDER BY r.agrees DESC, r.publishDate DESC";
+            case MOST_CONTROVERSIAL -> " ORDER BY (r.agrees + r.disagrees) DESC, r.publishDate DESC";
+            // DISTANCE only makes sense in the proximity branch; fall through to NEWEST as a guard.
+            case DISTANCE, NEWEST -> " ORDER BY r.publishDate DESC";
+        };
+    }
+
+    // ----- helpers -----------------------------------------------------------------------------
+
+    private static <T> List<T> nonEmpty(List<T> list) {
+        if (list == null || list.isEmpty()) {
+            return null;
         }
-        jpql.append(" AND r.environment = :feedEnv");
-        params.put("feedEnv", environment);
+        List<T> filtered = new ArrayList<>(list.size());
+        for (T item : list) {
+            if (item != null) {
+                filtered.add(item);
+            }
+        }
+        return filtered.isEmpty() ? null : filtered;
+    }
+
+    private static String normalizeQ(String q) {
+        if (q == null) {
+            return null;
+        }
+        String trimmed = q.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        // Cap input length so we don't ship arbitrarily long LIKE patterns to the DB.
+        return trimmed.length() > 100 ? trimmed.substring(0, 100) : trimmed;
     }
 
     private static void bindAll(Query query, Map<String, Object> params) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -101,37 +101,41 @@ public class ReportService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ReportResponse> feed(
-            ReportType reportType,
-            ReportEnvironment environment,
-            Double latitude,
-            Double longitude,
-            Double radiusInKm,
-            Pageable pageable,
-            String email) {
+    public Page<ReportResponse> feed(ReportFeedQuery query, Pageable pageable, String email) {
+
+        if (query == null) {
+            query = new ReportFeedQuery();
+        }
+
+        Double latitude = query.getLatitude();
+        Double longitude = query.getLongitude();
+        boolean hasCoords = latitude != null && longitude != null;
 
         if (latitude != null ^ longitude != null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                     "latitude and longitude must both be provided for proximity feed");
         }
+        if (query.getPublishedAfter() != null && query.getPublishedBefore() != null
+                && query.getPublishedAfter().isAfter(query.getPublishedBefore())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "publishedAfter must not be after publishedBefore");
+        }
+        if (query.getSort() == FeedSort.DISTANCE && !hasCoords) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "sort=DISTANCE requires latitude and longitude");
+        }
 
         int pageNumber = Math.max(0, pageable.getPageNumber());
         int pageSize = Math.min(100, Math.max(1, pageable.getPageSize()));
-        Pageable paged = latitude != null
+        Pageable paged = hasCoords
                 ? PageRequest.of(pageNumber, pageSize, Sort.unsorted())
                 : PageRequest.of(pageNumber, pageSize);
 
         Long userId = resolveUserId(email);
 
-        Page<Report> page = latitude != null
-                ? reportRepository.findFeedWithinRadius(
-                        reportType,
-                        environment,
-                        latitude,
-                        longitude,
-                        radiusInKm != null ? radiusInKm : 1.0,
-                        paged)
-                : reportRepository.findFeedRecent(reportType, environment, paged);
+        Page<Report> page = hasCoords
+                ? reportRepository.findFeedWithinRadius(query, paged)
+                : reportRepository.findFeedRecent(query, paged);
 
         Map<Long, VoteType> votesByReportId = resolveUserVotes(userId, page.getContent());
         Map<Long, FixRequestResponse> activeFixByReportId = resolveActiveFixRequests(userId, page.getContent());

--- a/backend/src/main/resources/db/migration/V6__report_feed_indexes.sql
+++ b/backend/src/main/resources/db/migration/V6__report_feed_indexes.sql
@@ -1,0 +1,22 @@
+-- Indexes supporting filterable / sortable report feed (see ReportRepositoryImpl).
+-- Each filter or ORDER BY column gets a single-column index. PostgreSQL can
+-- combine these via bitmap index scans when filters are mixed, so per-combination
+-- composite indexes aren't necessary at current data sizes.
+
+CREATE INDEX IF NOT EXISTS idx_reports_status
+    ON reports(status);
+
+CREATE INDEX IF NOT EXISTS idx_reports_user_id
+    ON reports(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_reports_publish_date_desc
+    ON reports(publish_date DESC);
+
+CREATE INDEX IF NOT EXISTS idx_reports_agrees_desc
+    ON reports(agrees DESC);
+
+CREATE INDEX IF NOT EXISTS idx_report_objects_object_type
+    ON report_objects(object_type);
+
+CREATE INDEX IF NOT EXISTS idx_report_object_issues_issue_type
+    ON report_object_issues(issue_type);

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/ReportControllerTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/ReportControllerTest.java
@@ -41,7 +41,7 @@ class ReportControllerTest {
     private ReportController controller;
 
     @Test
-    void feed_passesQueryFieldsPageableAndEmailToService() {
+    void feed_passesQueryPageableAndEmailToService() {
         ReportFeedQuery query = new ReportFeedQuery();
         query.setReportType(ReportType.OBSTACLE);
         query.setEnvironment(ReportEnvironment.INDOOR);
@@ -51,26 +51,12 @@ class ReportControllerTest {
 
         Pageable pageable = PageRequest.of(1, 15);
         Page<ReportResponse> expected = new PageImpl<>(List.of());
-        when(reportService.feed(
-                ReportType.OBSTACLE,
-                ReportEnvironment.INDOOR,
-                41.02,
-                29.01,
-                4.5,
-                pageable,
-                "user@example.com")).thenReturn(expected);
+        when(reportService.feed(query, pageable, "user@example.com")).thenReturn(expected);
 
         Page<ReportResponse> result = controller.feed(query, pageable, "user@example.com");
 
         assertEquals(expected, result);
-        verify(reportService).feed(
-                ReportType.OBSTACLE,
-                ReportEnvironment.INDOOR,
-                41.02,
-                29.01,
-                4.5,
-                pageable,
-                "user@example.com");
+        verify(reportService).feed(query, pageable, "user@example.com");
     }
 
     @Test
@@ -78,19 +64,12 @@ class ReportControllerTest {
         ReportFeedQuery query = new ReportFeedQuery();
         Pageable pageable = PageRequest.of(0, 20);
         Page<ReportResponse> expected = new PageImpl<>(List.of());
-        when(reportService.feed(
-                isNull(),
-                isNull(),
-                isNull(),
-                isNull(),
-                isNull(),
-                eq(pageable),
-                isNull())).thenReturn(expected);
+        when(reportService.feed(eq(query), eq(pageable), isNull())).thenReturn(expected);
 
         Page<ReportResponse> result = controller.feed(query, pageable, null);
 
         assertEquals(expected, result);
-        verify(reportService).feed(null, null, null, null, null, pageable, null);
+        verify(reportService).feed(query, pageable, null);
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/ReportFeedWebMvcTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/ReportFeedWebMvcTest.java
@@ -1,12 +1,15 @@
 package com.bounswe2026group1.backend.controller;
 
+import com.bounswe2026group1.backend.dto.ReportFeedQuery;
 import com.bounswe2026group1.backend.dto.ReportResponse;
 import com.bounswe2026group1.backend.model.ReportEnvironment;
+import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.ReportType;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.service.ReportService;
 import com.bounswe2026group1.backend.util.JwtUtil;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -20,8 +23,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,14 +53,7 @@ class ReportFeedWebMvcTest {
 
     @Test
     void feed_get_returnsPagedJson_forAnonymousGlobalFeed() throws Exception {
-        when(reportService.feed(
-                isNull(),
-                isNull(),
-                isNull(),
-                isNull(),
-                isNull(),
-                any(Pageable.class),
-                isNull()))
+        when(reportService.feed(any(ReportFeedQuery.class), any(Pageable.class), isNull()))
                 .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
 
         mockMvc.perform(get("/api/reports/feed")
@@ -69,28 +66,20 @@ class ReportFeedWebMvcTest {
                 .andExpect(jsonPath("$.number").value(0))
                 .andExpect(jsonPath("$.size").value(20));
 
-        verify(reportService).feed(
-                isNull(),
-                isNull(),
-                isNull(),
-                isNull(),
-                isNull(),
-                any(Pageable.class),
-                isNull());
+        ArgumentCaptor<ReportFeedQuery> captor = ArgumentCaptor.forClass(ReportFeedQuery.class);
+        verify(reportService).feed(captor.capture(), any(Pageable.class), isNull());
+        ReportFeedQuery captured = captor.getValue();
+        assertNull(captured.getReportType());
+        assertNull(captured.getEnvironment());
+        assertNull(captured.getLatitude());
+        assertNull(captured.getLongitude());
     }
 
     @Test
     void feed_get_passesFiltersAndProximityParamsToService() throws Exception {
         ReportResponse row = new ReportResponse();
         row.setReportId(7L);
-        when(reportService.feed(
-                eq(ReportType.OBSTACLE),
-                eq(ReportEnvironment.OUTDOOR),
-                eq(41.02),
-                eq(29.01),
-                eq(3.5),
-                any(Pageable.class),
-                isNull()))
+        when(reportService.feed(any(ReportFeedQuery.class), any(Pageable.class), isNull()))
                 .thenReturn(new PageImpl<>(List.of(row), PageRequest.of(1, 15), 1));
 
         mockMvc.perform(get("/api/reports/feed")
@@ -98,6 +87,12 @@ class ReportFeedWebMvcTest {
                         .param("size", "15")
                         .param("reportType", "OBSTACLE")
                         .param("environment", "OUTDOOR")
+                        .param("status", "VERIFIED", "PENDING")
+                        .param("authorId", "42")
+                        .param("q", "ramp")
+                        .param("minAgrees", "3")
+                        .param("minNetScore", "1")
+                        .param("sort", "MOST_AGREED")
                         .param("latitude", "41.02")
                         .param("longitude", "29.01")
                         .param("radiusInKm", "3.5")
@@ -106,26 +101,24 @@ class ReportFeedWebMvcTest {
                 .andExpect(jsonPath("$.content.length()").value(1))
                 .andExpect(jsonPath("$.content[0].reportId").value(7));
 
-        verify(reportService).feed(
-                eq(ReportType.OBSTACLE),
-                eq(ReportEnvironment.OUTDOOR),
-                eq(41.02),
-                eq(29.01),
-                eq(3.5),
-                any(Pageable.class),
-                isNull());
+        ArgumentCaptor<ReportFeedQuery> captor = ArgumentCaptor.forClass(ReportFeedQuery.class);
+        verify(reportService).feed(captor.capture(), any(Pageable.class), isNull());
+        ReportFeedQuery captured = captor.getValue();
+        assertEquals(ReportType.OBSTACLE, captured.getReportType());
+        assertEquals(ReportEnvironment.OUTDOOR, captured.getEnvironment());
+        assertEquals(List.of(ReportStatus.VERIFIED, ReportStatus.PENDING), captured.getStatus());
+        assertEquals(42L, captured.getAuthorId());
+        assertEquals("ramp", captured.getQ());
+        assertEquals(3, captured.getMinAgrees());
+        assertEquals(1, captured.getMinNetScore());
+        assertEquals(41.02, captured.getLatitude());
+        assertEquals(29.01, captured.getLongitude());
+        assertEquals(3.5, captured.getRadiusInKm());
     }
 
     @Test
     void feed_get_returnsBadRequestWhenServiceRejectsPartialCoordinates() throws Exception {
-        when(reportService.feed(
-                isNull(),
-                isNull(),
-                eq(41.0),
-                isNull(),
-                isNull(),
-                any(Pageable.class),
-                isNull()))
+        when(reportService.feed(any(ReportFeedQuery.class), any(Pageable.class), isNull()))
                 .thenThrow(new ResponseStatusException(
                         HttpStatus.BAD_REQUEST,
                         "latitude and longitude must both be provided for proximity feed"));

--- a/backend/src/test/java/com/bounswe2026group1/backend/repository/ReportRepositoryImplTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/repository/ReportRepositoryImplTest.java
@@ -1,8 +1,14 @@
 package com.bounswe2026group1.backend.repository;
 
+import com.bounswe2026group1.backend.dto.FeedSort;
+import com.bounswe2026group1.backend.dto.ReportFeedQuery;
+import com.bounswe2026group1.backend.model.IssueType;
+import com.bounswe2026group1.backend.model.ObjectType;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.model.Report;
 import com.bounswe2026group1.backend.model.ReportEnvironment;
+import com.bounswe2026group1.backend.model.ReportObject;
+import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.ReportType;
 import com.bounswe2026group1.backend.model.UserRole;
 import com.bounswe2026group1.backend.support.AbstractPostgisIntegrationTest;
@@ -15,7 +21,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,6 +42,8 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
     @Autowired
     private RegisteredUserRepository userRepository;
 
+    // ───── proximity branch ────────────────────────────────────────────────────────
+
     @Test
     void findFeedWithinRadius_returnsOnlyReportsInsideRadius_orderedByDistance() {
         RegisteredUser user = persistUser("ada-feed@test.com");
@@ -49,7 +59,7 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
                 ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
 
         Page<Report> page = reportRepository.findFeedWithinRadius(
-                null, null, REF_LAT, REF_LON, 1.0, PageRequest.of(0, 10));
+                proximity(REF_LAT, REF_LON, 1.0), PageRequest.of(0, 10));
 
         List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
         assertTrue(ids.contains(near.getReportId()));
@@ -67,8 +77,9 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
         Report feature = persistReport(user, REF_LAT, REF_LON + 0.0004,
                 ReportType.FEATURE, ReportEnvironment.OUTDOOR);
 
-        Page<Report> obstacles = reportRepository.findFeedWithinRadius(
-                ReportType.OBSTACLE, null, REF_LAT, REF_LON, 1.0, PageRequest.of(0, 10));
+        ReportFeedQuery q = proximity(REF_LAT, REF_LON, 1.0);
+        q.setReportType(ReportType.OBSTACLE);
+        Page<Report> obstacles = reportRepository.findFeedWithinRadius(q, PageRequest.of(0, 10));
 
         List<Long> ids = obstacles.getContent().stream().map(Report::getReportId).toList();
         assertTrue(ids.contains(obstacle.getReportId()));
@@ -84,8 +95,9 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
         Report outdoor = persistReport(user, REF_LAT, REF_LON + 0.0004,
                 ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
 
-        Page<Report> indoorPage = reportRepository.findFeedWithinRadius(
-                null, ReportEnvironment.INDOOR, REF_LAT, REF_LON, 1.0, PageRequest.of(0, 10));
+        ReportFeedQuery q = proximity(REF_LAT, REF_LON, 1.0);
+        q.setEnvironment(ReportEnvironment.INDOOR);
+        Page<Report> indoorPage = reportRepository.findFeedWithinRadius(q, PageRequest.of(0, 10));
 
         List<Long> ids = indoorPage.getContent().stream().map(Report::getReportId).toList();
         assertTrue(ids.contains(indoor.getReportId()));
@@ -103,9 +115,10 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
         Report wrongEnv = persistReport(user, REF_LAT, REF_LON + 0.0005,
                 ReportType.FEATURE, ReportEnvironment.OUTDOOR);
 
-        Page<Report> page = reportRepository.findFeedWithinRadius(
-                ReportType.FEATURE, ReportEnvironment.INDOOR,
-                REF_LAT, REF_LON, 1.0, PageRequest.of(0, 10));
+        ReportFeedQuery q = proximity(REF_LAT, REF_LON, 1.0);
+        q.setReportType(ReportType.FEATURE);
+        q.setEnvironment(ReportEnvironment.INDOOR);
+        Page<Report> page = reportRepository.findFeedWithinRadius(q, PageRequest.of(0, 10));
 
         List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
         assertTrue(ids.contains(match.getReportId()));
@@ -117,7 +130,6 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
     @Test
     void findFeedWithinRadius_paginatesWithCorrectTotal() {
         RegisteredUser user = persistUser("page-radius@test.com");
-        // Persist 3 reports at increasing distances
         Report r1 = persistReport(user, REF_LAT, REF_LON + 0.0001,
                 ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
         Report r2 = persistReport(user, REF_LAT, REF_LON + 0.0002,
@@ -127,19 +139,20 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
 
         Pageable pageable = PageRequest.of(0, 2);
         Page<Report> first = reportRepository.findFeedWithinRadius(
-                null, null, REF_LAT, REF_LON, 1.0, pageable);
+                proximity(REF_LAT, REF_LON, 1.0), pageable);
 
         assertEquals(2, first.getContent().size());
         assertEquals(3L, first.getTotalElements(), "total must reflect full match set, not page size");
-        // ordered by distance ASC
         assertEquals(r1.getReportId(), first.getContent().get(0).getReportId());
         assertEquals(r2.getReportId(), first.getContent().get(1).getReportId());
 
         Page<Report> second = reportRepository.findFeedWithinRadius(
-                null, null, REF_LAT, REF_LON, 1.0, PageRequest.of(1, 2));
+                proximity(REF_LAT, REF_LON, 1.0), PageRequest.of(1, 2));
         assertEquals(1, second.getContent().size());
         assertEquals(r3.getReportId(), second.getContent().get(0).getReportId());
     }
+
+    // ───── recent branch — legacy coverage ────────────────────────────────────────
 
     @Test
     void findFeedRecent_returnsAllReports_orderedByPublishDateDesc() {
@@ -151,7 +164,7 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
                 ReportType.OBSTACLE, ReportEnvironment.OUTDOOR,
                 Instant.now());
 
-        Page<Report> page = reportRepository.findFeedRecent(null, null, PageRequest.of(0, 10));
+        Page<Report> page = reportRepository.findFeedRecent(new ReportFeedQuery(), PageRequest.of(0, 10));
 
         List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
         assertEquals(newer.getReportId(), ids.get(0), "newer report should come first");
@@ -166,8 +179,9 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
         Report feature = persistReport(user, REF_LAT, REF_LON,
                 ReportType.FEATURE, ReportEnvironment.OUTDOOR);
 
-        Page<Report> page = reportRepository.findFeedRecent(
-                ReportType.FEATURE, null, PageRequest.of(0, 10));
+        ReportFeedQuery q = new ReportFeedQuery();
+        q.setReportType(ReportType.FEATURE);
+        Page<Report> page = reportRepository.findFeedRecent(q, PageRequest.of(0, 10));
 
         List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
         assertTrue(ids.contains(feature.getReportId()));
@@ -183,8 +197,9 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
         Report outdoor = persistReport(user, REF_LAT, REF_LON,
                 ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
 
-        Page<Report> page = reportRepository.findFeedRecent(
-                null, ReportEnvironment.OUTDOOR, PageRequest.of(0, 10));
+        ReportFeedQuery q = new ReportFeedQuery();
+        q.setEnvironment(ReportEnvironment.OUTDOOR);
+        Page<Report> page = reportRepository.findFeedRecent(q, PageRequest.of(0, 10));
 
         List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
         assertTrue(ids.contains(outdoor.getReportId()));
@@ -201,12 +216,218 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
                     Instant.now().minusSeconds(i * 60L));
         }
 
-        Page<Report> first = reportRepository.findFeedRecent(null, null, PageRequest.of(0, 2));
+        Page<Report> first = reportRepository.findFeedRecent(new ReportFeedQuery(), PageRequest.of(0, 2));
         assertEquals(2, first.getContent().size());
         assertEquals(3L, first.getTotalElements());
 
-        Page<Report> second = reportRepository.findFeedRecent(null, null, PageRequest.of(1, 2));
+        Page<Report> second = reportRepository.findFeedRecent(new ReportFeedQuery(), PageRequest.of(1, 2));
         assertEquals(1, second.getContent().size());
+    }
+
+    // ───── new filters ────────────────────────────────────────────────────────────
+
+    @Test
+    void findFeedRecent_filtersByStatus_multipleValues() {
+        RegisteredUser user = persistUser("status-filter@test.com");
+        Report pending = persistReport(user, REF_LAT, REF_LON,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        Report verified = persistReport(user, REF_LAT, REF_LON,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        verified.setStatus(ReportStatus.VERIFIED);
+        verified = reportRepository.save(verified);
+        Report fixed = persistReport(user, REF_LAT, REF_LON,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        fixed.setStatus(ReportStatus.FIXED);
+        reportRepository.save(fixed);
+
+        ReportFeedQuery q = new ReportFeedQuery();
+        q.setStatus(List.of(ReportStatus.PENDING, ReportStatus.VERIFIED));
+        Page<Report> page = reportRepository.findFeedRecent(q, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(ids.contains(pending.getReportId()));
+        assertTrue(ids.contains(verified.getReportId()));
+        assertEquals(2L, page.getTotalElements());
+    }
+
+    @Test
+    void findFeedRecent_filtersByAuthorId() {
+        RegisteredUser alice = persistUser("author-a@test.com");
+        RegisteredUser bob = persistUser("author-b@test.com");
+        Report aliceReport = persistReport(alice, REF_LAT, REF_LON,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        Report bobReport = persistReport(bob, REF_LAT, REF_LON,
+                ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+
+        ReportFeedQuery q = new ReportFeedQuery();
+        q.setAuthorId(alice.getId());
+        Page<Report> page = reportRepository.findFeedRecent(q, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(ids.contains(aliceReport.getReportId()));
+        assertFalse(ids.contains(bobReport.getReportId()));
+        assertEquals(1L, page.getTotalElements());
+    }
+
+    @Test
+    void findFeedRecent_filtersByPublishedDateRange() {
+        RegisteredUser user = persistUser("date-range@test.com");
+        Report old = persistReportWithPublishDate(user, ReportType.OBSTACLE,
+                ReportEnvironment.OUTDOOR, Instant.parse("2026-01-01T00:00:00Z"));
+        Report mid = persistReportWithPublishDate(user, ReportType.OBSTACLE,
+                ReportEnvironment.OUTDOOR, Instant.parse("2026-03-15T00:00:00Z"));
+        Report fresh = persistReportWithPublishDate(user, ReportType.OBSTACLE,
+                ReportEnvironment.OUTDOOR, Instant.parse("2026-05-01T00:00:00Z"));
+
+        ReportFeedQuery q = new ReportFeedQuery();
+        q.setPublishedAfter(Instant.parse("2026-02-01T00:00:00Z"));
+        q.setPublishedBefore(Instant.parse("2026-04-01T00:00:00Z"));
+        Page<Report> page = reportRepository.findFeedRecent(q, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertFalse(ids.contains(old.getReportId()));
+        assertTrue(ids.contains(mid.getReportId()));
+        assertFalse(ids.contains(fresh.getReportId()));
+        assertEquals(1L, page.getTotalElements());
+    }
+
+    @Test
+    void findFeedRecent_freeTextSearchIsCaseInsensitive() {
+        RegisteredUser user = persistUser("q-filter@test.com");
+        Report hit = persistReportWithDescription(user, "Broken ELEVATOR on floor 2");
+        Report miss = persistReportWithDescription(user, "Cracked sidewalk");
+
+        ReportFeedQuery q = new ReportFeedQuery();
+        q.setQ("elevator");
+        Page<Report> page = reportRepository.findFeedRecent(q, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(ids.contains(hit.getReportId()));
+        assertFalse(ids.contains(miss.getReportId()));
+        assertEquals(1L, page.getTotalElements());
+    }
+
+    @Test
+    void findFeedRecent_filtersByVoteThresholds() {
+        RegisteredUser user = persistUser("votes-filter@test.com");
+        Report low = persistReportWithVotes(user, 1, 0);
+        Report high = persistReportWithVotes(user, 8, 1);
+        Report controversial = persistReportWithVotes(user, 5, 5);
+
+        ReportFeedQuery q = new ReportFeedQuery();
+        q.setMinAgrees(5);
+        q.setMinNetScore(3);
+        Page<Report> page = reportRepository.findFeedRecent(q, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertFalse(ids.contains(low.getReportId()));
+        assertTrue(ids.contains(high.getReportId()));
+        assertFalse(ids.contains(controversial.getReportId()),
+                "5-5 fails minNetScore=3 even though it passes minAgrees=5");
+        assertEquals(1L, page.getTotalElements());
+    }
+
+    @Test
+    void findFeedRecent_filtersByObjectTypeAndIssueType() {
+        RegisteredUser user = persistUser("object-filter@test.com");
+        Report rampReport = persistReportWithObject(user, ObjectType.RAMP,
+                EnumSet.of(IssueType.TOO_STEEP));
+        Report doorReport = persistReportWithObject(user, ObjectType.DOOR,
+                EnumSet.of(IssueType.HEAVY_DOOR));
+        Report rampWrongIssue = persistReportWithObject(user, ObjectType.RAMP,
+                EnumSet.of(IssueType.MISSING_HANDRAIL));
+
+        ReportFeedQuery byObject = new ReportFeedQuery();
+        byObject.setObjectType(List.of(ObjectType.RAMP));
+        Page<Report> rampPage = reportRepository.findFeedRecent(byObject, PageRequest.of(0, 10));
+        List<Long> rampIds = rampPage.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(rampIds.contains(rampReport.getReportId()));
+        assertTrue(rampIds.contains(rampWrongIssue.getReportId()));
+        assertFalse(rampIds.contains(doorReport.getReportId()));
+        assertEquals(2L, rampPage.getTotalElements());
+
+        ReportFeedQuery byIssue = new ReportFeedQuery();
+        byIssue.setIssueType(List.of(IssueType.TOO_STEEP));
+        Page<Report> steepPage = reportRepository.findFeedRecent(byIssue, PageRequest.of(0, 10));
+        List<Long> steepIds = steepPage.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(steepIds.contains(rampReport.getReportId()));
+        assertFalse(steepIds.contains(rampWrongIssue.getReportId()));
+        assertFalse(steepIds.contains(doorReport.getReportId()));
+        assertEquals(1L, steepPage.getTotalElements());
+    }
+
+    @Test
+    void findFeedRecent_sortMostAgreed_ordersByAgreesDesc() {
+        RegisteredUser user = persistUser("sort-agreed@test.com");
+        Report mid = persistReportWithVotes(user, 5, 0);
+        Report top = persistReportWithVotes(user, 12, 3);
+        Report low = persistReportWithVotes(user, 1, 0);
+
+        ReportFeedQuery q = new ReportFeedQuery();
+        q.setSort(FeedSort.MOST_AGREED);
+        Page<Report> page = reportRepository.findFeedRecent(q, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertEquals(top.getReportId(), ids.get(0));
+        assertEquals(mid.getReportId(), ids.get(1));
+        assertEquals(low.getReportId(), ids.get(2));
+    }
+
+    @Test
+    void findFeedRecent_sortOldest_reversesPublishDateOrder() {
+        RegisteredUser user = persistUser("sort-oldest@test.com");
+        Report older = persistReportWithPublishDate(user, ReportType.OBSTACLE,
+                ReportEnvironment.OUTDOOR, Instant.now().minusSeconds(3600));
+        Report newer = persistReportWithPublishDate(user, ReportType.OBSTACLE,
+                ReportEnvironment.OUTDOOR, Instant.now());
+
+        ReportFeedQuery q = new ReportFeedQuery();
+        q.setSort(FeedSort.OLDEST);
+        Page<Report> page = reportRepository.findFeedRecent(q, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertEquals(older.getReportId(), ids.get(0));
+        assertEquals(newer.getReportId(), ids.get(1));
+    }
+
+    @Test
+    void findFeedWithinRadius_combinesProximityWithStatusAndQ() {
+        RegisteredUser user = persistUser("combo-radius@test.com");
+        Report matches = persistReportWithDescription(user, "Wide RAMP needs handrail");
+        matches.setStatus(ReportStatus.VERIFIED);
+        matches.setLocation(GeoUtils.point4326(REF_LAT, REF_LON + 0.0003));
+        reportRepository.save(matches);
+
+        Report wrongStatus = persistReportWithDescription(user, "Wide ramp needs handrail");
+        wrongStatus.setLocation(GeoUtils.point4326(REF_LAT, REF_LON + 0.0004));
+        reportRepository.save(wrongStatus);
+        // wrongStatus stays PENDING
+
+        Report wrongText = persistReportWithDescription(user, "Cracked sidewalk");
+        wrongText.setStatus(ReportStatus.VERIFIED);
+        wrongText.setLocation(GeoUtils.point4326(REF_LAT, REF_LON + 0.0005));
+        reportRepository.save(wrongText);
+
+        ReportFeedQuery q = proximity(REF_LAT, REF_LON, 1.0);
+        q.setStatus(List.of(ReportStatus.VERIFIED));
+        q.setQ("ramp");
+        Page<Report> page = reportRepository.findFeedWithinRadius(q, PageRequest.of(0, 10));
+
+        List<Long> ids = page.getContent().stream().map(Report::getReportId).toList();
+        assertTrue(ids.contains(matches.getReportId()));
+        assertFalse(ids.contains(wrongStatus.getReportId()));
+        assertFalse(ids.contains(wrongText.getReportId()));
+        assertEquals(1L, page.getTotalElements());
+    }
+
+    // ───── helpers ─────────────────────────────────────────────────────────────────
+
+    private static ReportFeedQuery proximity(double lat, double lon, double radiusKm) {
+        ReportFeedQuery q = new ReportFeedQuery();
+        q.setLatitude(lat);
+        q.setLongitude(lon);
+        q.setRadiusInKm(radiusKm);
+        return q;
     }
 
     private RegisteredUser persistUser(String email) {
@@ -231,6 +452,28 @@ class ReportRepositoryImplTest extends AbstractPostgisIntegrationTest {
         Report r = new Report(user, GeoUtils.point4326(REF_LAT, REF_LON),
                 "test report", type, env);
         r.setPublishDate(publishDate);
+        return reportRepository.save(r);
+    }
+
+    private Report persistReportWithDescription(RegisteredUser user, String description) {
+        Report r = new Report(user, GeoUtils.point4326(REF_LAT, REF_LON),
+                description, ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        return reportRepository.save(r);
+    }
+
+    private Report persistReportWithVotes(RegisteredUser user, int agrees, int disagrees) {
+        Report r = new Report(user, GeoUtils.point4326(REF_LAT, REF_LON),
+                "test report", ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        for (int i = 0; i < agrees; i++) r.incrementAgrees();
+        for (int i = 0; i < disagrees; i++) r.incrementDisagrees();
+        return reportRepository.save(r);
+    }
+
+    private Report persistReportWithObject(RegisteredUser user, ObjectType type, Set<IssueType> issues) {
+        Report r = new Report(user, GeoUtils.point4326(REF_LAT, REF_LON),
+                "test report", ReportType.OBSTACLE, ReportEnvironment.OUTDOOR);
+        ReportObject obj = new ReportObject(r, type, issues, null);
+        r.getObjects().add(obj);
         return reportRepository.save(r);
     }
 }

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -1,6 +1,8 @@
 package com.bounswe2026group1.backend.service;
 
 import com.bounswe2026group1.backend.dto.CreateReportRequest;
+import com.bounswe2026group1.backend.dto.FeedSort;
+import com.bounswe2026group1.backend.dto.ReportFeedQuery;
 import com.bounswe2026group1.backend.dto.ReportObjectRequest;
 import com.bounswe2026group1.backend.dto.ReportResponse;
 import com.bounswe2026group1.backend.dto.UpdateReportRequest;
@@ -28,10 +30,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -897,83 +897,96 @@ class ReportServiceTest {
     void feed_withoutCoordinates_callsFindFeedRecent() {
         ReflectionTestUtils.setField(testReport, "reportId", 10L);
         Page<Report> repoPage = new PageImpl<>(List.of(testReport));
-        when(reportRepository.findFeedRecent(isNull(), isNull(), any(Pageable.class))).thenReturn(repoPage);
+        when(reportRepository.findFeedRecent(any(ReportFeedQuery.class), any(Pageable.class))).thenReturn(repoPage);
         when(fixRequestRepository.findOpenFixRequestIdsByReportIds(anyList())).thenReturn(List.of());
 
-        Page<ReportResponse> result = reportService.feed(
-                null, null, null, null, null,
-                PageRequest.of(0, 20),
-                null);
+        ReportFeedQuery query = new ReportFeedQuery();
+        Page<ReportResponse> result = reportService.feed(query, PageRequest.of(0, 20), null);
 
         assertEquals(1, result.getContent().size());
         assertEquals("Broken ramp", result.getContent().get(0).getDescription());
-        verify(reportRepository).findFeedRecent(null, null, PageRequest.of(0, 20));
-        verify(reportRepository, never()).findFeedWithinRadius(
-                any(), any(), anyDouble(), anyDouble(), anyDouble(), any(Pageable.class));
+        verify(reportRepository).findFeedRecent(query, PageRequest.of(0, 20));
+        verify(reportRepository, never()).findFeedWithinRadius(any(), any(Pageable.class));
     }
 
     @Test
-    void feed_withCoordinates_callsFindFeedWithinRadius_withDefaultRadiusKmWhenNull() {
+    void feed_withCoordinates_callsFindFeedWithinRadius() {
         ReflectionTestUtils.setField(testReport, "reportId", 11L);
         Page<Report> repoPage = new PageImpl<>(List.of(testReport));
         Pageable expectedPaging = PageRequest.of(0, 20, Sort.unsorted());
-        when(reportRepository.findFeedWithinRadius(
-                isNull(),
-                isNull(),
-                eq(41.0),
-                eq(29.0),
-                eq(1.0),
-                eq(expectedPaging))).thenReturn(repoPage);
+        when(reportRepository.findFeedWithinRadius(any(ReportFeedQuery.class), eq(expectedPaging)))
+                .thenReturn(repoPage);
         when(fixRequestRepository.findOpenFixRequestIdsByReportIds(anyList())).thenReturn(List.of());
 
-        Page<ReportResponse> result = reportService.feed(
-                null, null, 41.0, 29.0, null,
-                PageRequest.of(0, 20),
-                null);
+        ReportFeedQuery query = new ReportFeedQuery();
+        query.setLatitude(41.0);
+        query.setLongitude(29.0);
+        Page<ReportResponse> result = reportService.feed(query, PageRequest.of(0, 20), null);
 
         assertEquals(1, result.getTotalElements());
-        verify(reportRepository).findFeedWithinRadius(
-                null, null, 41.0, 29.0, 1.0, PageRequest.of(0, 20, Sort.unsorted()));
-        verify(reportRepository, never()).findFeedRecent(any(), any(), any(Pageable.class));
+        verify(reportRepository).findFeedWithinRadius(query, PageRequest.of(0, 20, Sort.unsorted()));
+        verify(reportRepository, never()).findFeedRecent(any(), any(Pageable.class));
     }
 
     @Test
-    void feed_withCoordinatesAndFilters_passesReportTypeEnvironmentAndRadiusToProximityRepository() {
+    void feed_withCoordinatesAndFilters_passesQueryToProximityRepository() {
         ReflectionTestUtils.setField(testReport, "reportId", 12L);
         Page<Report> repoPage = new PageImpl<>(List.of(testReport));
         Pageable expectedPaging = PageRequest.of(0, 10, Sort.unsorted());
-        when(reportRepository.findFeedWithinRadius(
-                eq(ReportType.OBSTACLE),
-                eq(ReportEnvironment.INDOOR),
-                eq(41.5),
-                eq(29.5),
-                eq(3.0),
-                eq(expectedPaging))).thenReturn(repoPage);
+        when(reportRepository.findFeedWithinRadius(any(ReportFeedQuery.class), eq(expectedPaging)))
+                .thenReturn(repoPage);
         when(fixRequestRepository.findOpenFixRequestIdsByReportIds(anyList())).thenReturn(List.of());
 
-        reportService.feed(
-                ReportType.OBSTACLE,
-                ReportEnvironment.INDOOR,
-                41.5,
-                29.5,
-                3.0,
-                PageRequest.of(0, 10),
-                null);
+        ReportFeedQuery query = new ReportFeedQuery();
+        query.setReportType(ReportType.OBSTACLE);
+        query.setEnvironment(ReportEnvironment.INDOOR);
+        query.setLatitude(41.5);
+        query.setLongitude(29.5);
+        query.setRadiusInKm(3.0);
+        reportService.feed(query, PageRequest.of(0, 10), null);
 
-        verify(reportRepository).findFeedWithinRadius(
-                ReportType.OBSTACLE,
-                ReportEnvironment.INDOOR,
-                41.5,
-                29.5,
-                3.0,
-                PageRequest.of(0, 10, Sort.unsorted()));
+        verify(reportRepository).findFeedWithinRadius(query, PageRequest.of(0, 10, Sort.unsorted()));
     }
 
     @Test
     void feed_latitudeWithoutLongitude_throwsBadRequest() {
+        ReportFeedQuery query = new ReportFeedQuery();
+        query.setLatitude(41.0);
         ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-                () -> reportService.feed(null, null, 41.0, null, null, PageRequest.of(0, 20), null));
+                () -> reportService.feed(query, PageRequest.of(0, 20), null));
         assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+    }
+
+    @Test
+    void feed_publishedAfterAfterPublishedBefore_throwsBadRequest() {
+        ReportFeedQuery query = new ReportFeedQuery();
+        query.setPublishedAfter(java.time.Instant.parse("2026-12-01T00:00:00Z"));
+        query.setPublishedBefore(java.time.Instant.parse("2026-01-01T00:00:00Z"));
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> reportService.feed(query, PageRequest.of(0, 20), null));
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+    }
+
+    @Test
+    void feed_distanceSortWithoutCoordinates_throwsBadRequest() {
+        ReportFeedQuery query = new ReportFeedQuery();
+        query.setSort(FeedSort.DISTANCE);
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> reportService.feed(query, PageRequest.of(0, 20), null));
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+    }
+
+    @Test
+    void feed_nullQuery_treatedAsEmptyQuery_callsFindFeedRecent() {
+        ReflectionTestUtils.setField(testReport, "reportId", 13L);
+        when(reportRepository.findFeedRecent(any(ReportFeedQuery.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(testReport)));
+        when(fixRequestRepository.findOpenFixRequestIdsByReportIds(anyList())).thenReturn(List.of());
+
+        Page<ReportResponse> result = reportService.feed(null, PageRequest.of(0, 20), null);
+
+        assertEquals(1, result.getTotalElements());
+        verify(reportRepository).findFeedRecent(any(ReportFeedQuery.class), eq(PageRequest.of(0, 20)));
     }
 
     // ───── addMediaToReport authorization paths ────────────────────────────

--- a/frontend/src/pages/Feed.jsx
+++ b/frontend/src/pages/Feed.jsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query'
 import Navbar from '../components/Navbar.jsx'
 import FeedLocationPickerModal from '../components/FeedLocationPickerModal.jsx'
 import { useTheme } from '../context/ThemeContext.jsx'
 import { useAuth } from '../context/AuthContext.jsx'
 import { getReportFeed, mapReport } from '../services/reportService.js'
 import { feedFilterChipClass } from '../utils/feedFilterChip.js'
+import { STATUS_OPTIONS, SORT_OPTIONS } from '../utils/feedFilterOptions.js'
+import { OBJECT_TYPES } from '../utils/objectTypeConfig.js'
+import { useUserSearch, USER_SEARCH_MIN_LENGTH } from '../hooks/useUserSearch.js'
 
 const MAPTILER_KEY = import.meta.env.VITE_MAPTILER_KEY
 const TILE_LIGHT = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
@@ -80,12 +83,71 @@ function typeLabel(t) {
   return null
 }
 
+/** Converts a `<input type="datetime-local">` value to an ISO-8601 instant. Empty → null. */
+function localDatetimeToIso(v) {
+  if (!v) return null
+  const d = new Date(v)
+  return Number.isNaN(d.getTime()) ? null : d.toISOString()
+}
+
+function parseNonNegativeInt(v) {
+  if (v === '' || v == null) return null
+  const n = Number(v)
+  return Number.isInteger(n) && n >= 0 ? n : null
+}
+
+function toggleInArray(arr, value) {
+  return arr.includes(value) ? arr.filter((v) => v !== value) : [...arr, value]
+}
+
+const OBJECT_CHIP_BASE =
+  'inline-flex items-center gap-2 px-4 py-2 rounded-2xl text-sm font-semibold border transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary'
+
+function objectTypeChipClass(selected) {
+  return selected ? OBJECT_CHIP_BASE : `${OBJECT_CHIP_BASE} bg-surface-container-highest`
+}
+
+function objectTypeChipStyle(color, selected) {
+  return selected
+    ? { backgroundColor: color, borderColor: color, color: '#ffffff' }
+    : { borderColor: 'transparent', borderLeft: `4px solid ${color}` }
+}
+
+/**
+ * Issue groups for the advanced filter, keyed by object type. Order follows the user's click
+ * order in `selectedObjectTypes` so issue groups appear in the same order the user picked
+ * their object types — visually matching the colored chips above.
+ */
+function buildIssueGroups(selectedObjectTypes) {
+  if (selectedObjectTypes.length === 0) return []
+  return selectedObjectTypes
+    .map((type) => OBJECT_TYPES.find((t) => t.type === type))
+    .filter(Boolean)
+    .map((t) => ({
+      type: t.type,
+      label: t.label,
+      color: t.markerColor,
+      issues: t.issues,
+    }))
+}
+
+/** All issue keys valid for the given object types (used to prune orphan selections). */
+function validIssueKeysFor(selectedObjectTypes) {
+  const keys = new Set()
+  for (const t of OBJECT_TYPES) {
+    if (selectedObjectTypes.includes(t.type)) {
+      for (const i of t.issues) keys.add(i.key)
+    }
+  }
+  return keys
+}
+
 export default function Feed() {
   const { resolved: themeResolved } = useTheme()
   const isDark = themeResolved === 'dark'
   const tileUrl = isDark ? TILE_DARK : TILE_LIGHT
   const tileAttr = isDark ? TILE_ATTR_DARK : TILE_ATTR_LIGHT
-  const { token } = useAuth()
+  const { token, isAuthenticated } = useAuth()
 
   const [pickerOpen, setPickerOpen] = useState(false)
   const [feedCenterDraft, setFeedCenterDraft] = useState(null)
@@ -94,6 +156,41 @@ export default function Feed() {
 
   const [reportTypeFilter, setReportTypeFilter] = useState('ALL')
   const [environmentFilter, setEnvironmentFilter] = useState('ALL')
+  const [statusFilter, setStatusFilter] = useState(/** @type {string[]} */ ([]))
+  const [sortFilter, setSortFilter] = useState('NEWEST')
+
+  // Free-text search: draft updates immediately, applied is debounced (300ms) to avoid hammering the API.
+  const [qDraft, setQDraft] = useState('')
+  const [qApplied, setQApplied] = useState('')
+  useEffect(() => {
+    const t = setTimeout(() => setQApplied(qDraft.trim()), 300)
+    return () => clearTimeout(t)
+  }, [qDraft])
+
+  // Advanced filters live behind a toggle to keep the default bar uncluttered.
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+  const [objectTypeFilter, setObjectTypeFilter] = useState(/** @type {string[]} */ ([]))
+  const [issueTypeFilter, setIssueTypeFilter] = useState(/** @type {string[]} */ ([]))
+  // Drop orphan issues whenever the user narrows or clears their object selection — an
+  // unrelated issue chip silently filtering the feed is confusing.
+  useEffect(() => {
+    if (objectTypeFilter.length === 0) {
+      setIssueTypeFilter((prev) => (prev.length === 0 ? prev : []))
+      return
+    }
+    const valid = validIssueKeysFor(objectTypeFilter)
+    setIssueTypeFilter((prev) => {
+      const filtered = prev.filter((k) => valid.has(k))
+      return filtered.length === prev.length ? prev : filtered
+    })
+  }, [objectTypeFilter])
+  /** @type {[null | {id:number,name:string}, Function]} */
+  const [selectedAuthor, setSelectedAuthor] = useState(null)
+  const [authorQuery, setAuthorQuery] = useState('')
+  const [publishedAfterInput, setPublishedAfterInput] = useState('')
+  const [publishedBeforeInput, setPublishedBeforeInput] = useState('')
+  const [minAgreesInput, setMinAgreesInput] = useState('')
+  const [minDisagreesInput, setMinDisagreesInput] = useState('')
 
   const [locateHint, setLocateHint] = useState(null)
 
@@ -112,10 +209,73 @@ export default function Feed() {
       ? Number(feedCenterDraft.lng)
       : null
 
-  const feedQueryKey = useMemo(
-    () => ['reportFeed', reportTypeFilter, environmentFilter, feedLat, feedLng, radiusKm, token ?? ''],
-    [reportTypeFilter, environmentFilter, feedLat, feedLng, radiusKm, token]
+  // Resolved author id comes from autocomplete selection — typing a name without picking from
+  // the dropdown does not filter the feed (avoids ambiguous matches across duplicate names).
+  const authorIdNum = selectedAuthor?.id ?? null
+
+  const publishedAfterIso = useMemo(
+    () => localDatetimeToIso(publishedAfterInput),
+    [publishedAfterInput]
   )
+  const publishedBeforeIso = useMemo(
+    () => localDatetimeToIso(publishedBeforeInput),
+    [publishedBeforeInput]
+  )
+
+  const minAgreesNum = parseNonNegativeInt(minAgreesInput)
+  const minDisagreesNum = parseNonNegativeInt(minDisagreesInput)
+
+  // Serialize set-like filters into stable strings so the queryKey is referentially stable.
+  const statusKey = statusFilter.join(',')
+  const objectTypeKey = objectTypeFilter.join(',')
+  const issueTypeKey = issueTypeFilter.join(',')
+
+  const feedQueryKey = useMemo(
+    () => [
+      'reportFeed',
+      reportTypeFilter,
+      environmentFilter,
+      statusKey,
+      sortFilter,
+      qApplied,
+      authorIdNum,
+      publishedAfterIso,
+      publishedBeforeIso,
+      minAgreesNum,
+      minDisagreesNum,
+      objectTypeKey,
+      issueTypeKey,
+      feedLat,
+      feedLng,
+      radiusKm,
+      token ?? '',
+    ],
+    [
+      reportTypeFilter,
+      environmentFilter,
+      statusKey,
+      sortFilter,
+      qApplied,
+      authorIdNum,
+      publishedAfterIso,
+      publishedBeforeIso,
+      minAgreesNum,
+      minDisagreesNum,
+      objectTypeKey,
+      issueTypeKey,
+      feedLat,
+      feedLng,
+      radiusKm,
+      token,
+    ]
+  )
+
+  // Block the request entirely when the selected sort needs data we don't have — surfacing
+  // a clear UI hint is much better than a 400 round-trip + generic "couldn't load" error.
+  const feedBlockedReason =
+    sortFilter === 'DISTANCE' && (feedLat == null || feedLng == null)
+      ? 'Pick a reference point to sort by distance.'
+      : null
 
   const {
     data,
@@ -123,24 +283,37 @@ export default function Feed() {
     hasNextPage,
     isFetchingNextPage,
     isPending,
+    isFetching,
+    isPlaceholderData,
     isError,
     error,
   } = useInfiniteQuery({
     queryKey: feedQueryKey,
-    // Build the request from `queryKey` so filters always match the cache entry (avoids stale
-    // closures when combining location + report type / environment).
-    queryFn: ({ pageParam, signal, queryKey }) => {
-      const [, rt, env, lat, lng, rKm] = queryKey
-      const hasLocation = lat != null && lng != null
+    enabled: feedBlockedReason == null,
+    // Keeps the previous page list visible while a filter change refetches — without it the
+    // list flashes empty, the page collapses, and the scroll position jumps to the top.
+    placeholderData: keepPreviousData,
+    queryFn: ({ pageParam, signal }) => {
+      const hasLocation = feedLat != null && feedLng != null
       return getReportFeed(
         {
           page: pageParam,
           size: 20,
-          reportType: rt,
-          environment: env,
-          latitude: hasLocation ? lat : undefined,
-          longitude: hasLocation ? lng : undefined,
-          radiusInKm: hasLocation ? rKm : undefined,
+          reportType: reportTypeFilter,
+          environment: environmentFilter,
+          status: statusFilter.length ? statusFilter : undefined,
+          authorId: authorIdNum ?? undefined,
+          publishedAfter: publishedAfterIso ?? undefined,
+          publishedBefore: publishedBeforeIso ?? undefined,
+          q: qApplied || undefined,
+          minAgrees: minAgreesNum ?? undefined,
+          minDisagrees: minDisagreesNum ?? undefined,
+          objectType: objectTypeFilter.length ? objectTypeFilter : undefined,
+          issueType: issueTypeFilter.length ? issueTypeFilter : undefined,
+          sort: sortFilter,
+          latitude: hasLocation ? feedLat : undefined,
+          longitude: hasLocation ? feedLng : undefined,
+          radiusInKm: hasLocation ? radiusKm : undefined,
         },
         token,
         { signal }
@@ -167,9 +340,13 @@ export default function Feed() {
   const modalCenter = feedCenterDraft ?? DEFAULT_CENTER
   const referenceForDistance = feedCenterDraft
 
+  // Client-side distance re-sort is a safety net for the DISTANCE case where the backend
+  // already orders by ST_Distance. Any other explicit sort (NEWEST, MOST_AGREED, …) must
+  // be left in the order the backend returned it.
   const reportsSorted = useMemo(() => {
     const ref = referenceForDistance
-    if (!ref) return reportsMatchingFilters
+    const useDistance = ref && sortFilter === 'DISTANCE'
+    if (!useDistance) return reportsMatchingFilters
     return [...reportsMatchingFilters].sort((a, b) => {
       const da = haversineKm(ref.lat, ref.lng, Number(a.latitude), Number(a.longitude))
       const db = haversineKm(ref.lat, ref.lng, Number(b.latitude), Number(b.longitude))
@@ -177,7 +354,7 @@ export default function Feed() {
       const fb = Number.isFinite(db) ? db : Number.POSITIVE_INFINITY
       return fa - fb
     })
-  }, [reportsMatchingFilters, referenceForDistance])
+  }, [reportsMatchingFilters, referenceForDistance, sortFilter])
 
   const loadMoreRef = useRef(null)
   const onIntersect = useCallback(
@@ -199,14 +376,70 @@ export default function Feed() {
   }, [onIntersect])
 
   const hasActiveFilter =
-    reportTypeFilter !== 'ALL' || environmentFilter !== 'ALL'
+    reportTypeFilter !== 'ALL' ||
+    environmentFilter !== 'ALL' ||
+    statusFilter.length > 0 ||
+    qApplied.length > 0 ||
+    authorIdNum != null ||
+    publishedAfterIso != null ||
+    publishedBeforeIso != null ||
+    minAgreesNum != null ||
+    minDisagreesNum != null ||
+    objectTypeFilter.length > 0 ||
+    issueTypeFilter.length > 0
 
+  function resetAdvancedFilters() {
+    setStatusFilter([])
+    setSortFilter('NEWEST')
+    setQDraft('')
+    setQApplied('')
+    setObjectTypeFilter([])
+    setIssueTypeFilter([])
+    setSelectedAuthor(null)
+    setAuthorQuery('')
+    setPublishedAfterInput('')
+    setPublishedBeforeInput('')
+    setMinAgreesInput('')
+    setMinDisagreesInput('')
+  }
+
+  // Suppress the empty / loading message while a filter-change refetch is in flight and we're
+  // still showing placeholder (i.e. previous) data — otherwise it would briefly overlay the list.
+  const isRefreshingWithPlaceholder = isFetching && isPlaceholderData
   const emptyMessage = useMemo(() => {
+    if (feedBlockedReason) return null
     if (reportsSorted.length > 0 || isPending || isError) return null
+    if (isRefreshingWithPlaceholder) return null
     if (hasActiveFilter) return 'No reports match your filters.'
     if (feedCenterDraft != null) return 'No reports within this search radius.'
     return 'No reports yet.'
-  }, [reportsSorted.length, isPending, isError, hasActiveFilter, feedCenterDraft])
+  }, [
+    feedBlockedReason,
+    reportsSorted.length,
+    isPending,
+    isError,
+    isRefreshingWithPlaceholder,
+    hasActiveFilter,
+    feedCenterDraft,
+  ])
+
+  // Hide the dropdown once a user is selected so the previous result list doesn't linger.
+  const authorSearchActive = !selectedAuthor && authorQuery.trim().length >= USER_SEARCH_MIN_LENGTH
+  const { data: authorSearchPage, isFetching: authorSearchFetching } = useUserSearch(
+    authorSearchActive ? authorQuery : '',
+    { page: 0, size: 8 }
+  )
+  const authorOptions = authorSearchActive ? authorSearchPage?.content ?? [] : []
+
+  function clearSelectedAuthor() {
+    setSelectedAuthor(null)
+    setAuthorQuery('')
+  }
+
+  function pickAuthor(option) {
+    setSelectedAuthor({ id: option.id, name: option.name })
+    setAuthorQuery(option.name)
+  }
 
   function handleUseCurrentLocation() {
     if (!navigator.geolocation) {
@@ -311,6 +544,71 @@ export default function Feed() {
             </div>
           </div>
 
+          {/* Status (multi) + sort + search row */}
+          <div className="flex flex-wrap items-end gap-x-6 gap-y-4">
+            <div className="flex flex-col gap-2 min-w-0">
+              <span className="text-xs font-bold uppercase tracking-wide text-on-surface-variant">
+                Status
+              </span>
+              <div className="flex flex-wrap gap-2">
+                {STATUS_OPTIONS.map(({ id, label }) => {
+                  const selected = statusFilter.includes(id)
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      aria-pressed={selected}
+                      aria-label={`Status: ${label}`}
+                      className={feedFilterChipClass(selected)}
+                      onClick={() => setStatusFilter((prev) => toggleInArray(prev, id))}
+                    >
+                      {label}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2 min-w-0">
+              <label
+                htmlFor="feed-sort"
+                className="text-xs font-bold uppercase tracking-wide text-on-surface-variant"
+              >
+                Sort
+              </label>
+              <select
+                id="feed-sort"
+                value={sortFilter}
+                onChange={(e) => setSortFilter(e.target.value)}
+                className="rounded-2xl border border-outline-variant bg-surface-container-highest px-3 py-2 text-sm font-semibold text-on-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              >
+                {SORT_OPTIONS.map(({ id, label }) => (
+                  <option key={id} value={id}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2 flex-1 min-w-[14rem]">
+              <label
+                htmlFor="feed-q"
+                className="text-xs font-bold uppercase tracking-wide text-on-surface-variant"
+              >
+                Search description
+              </label>
+              <input
+                id="feed-q"
+                type="search"
+                inputMode="search"
+                placeholder="e.g. elevator, ramp, sidewalk"
+                value={qDraft}
+                onChange={(e) => setQDraft(e.target.value)}
+                className="rounded-2xl border border-outline-variant bg-background px-4 py-2 text-sm text-on-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              />
+            </div>
+          </div>
+
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
@@ -332,12 +630,243 @@ export default function Feed() {
               </span>
               Use current location
             </button>
+            <button
+              type="button"
+              onClick={() => setAdvancedOpen((v) => !v)}
+              aria-expanded={advancedOpen}
+              aria-controls="feed-advanced-filters"
+              className={`${feedFilterChipClass(advancedOpen)} gap-2`}
+            >
+              <span className="material-symbols-outlined text-lg" aria-hidden>
+                tune
+              </span>
+              Advanced filters
+            </button>
+            {hasActiveFilter && (
+              <button
+                type="button"
+                onClick={resetAdvancedFilters}
+                className="text-sm font-semibold text-primary hover:bg-primary/10 px-3 py-2 rounded-2xl cursor-pointer"
+              >
+                Clear all
+              </button>
+            )}
           </div>
 
           {feedCenterDraft != null && (
             <p className="text-sm text-on-surface-variant">
               Reference point: {feedCenterDraft.lat.toFixed(4)}, {feedCenterDraft.lng.toFixed(4)}
             </p>
+          )}
+
+          {advancedOpen && (
+            <div
+              id="feed-advanced-filters"
+              className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4 border-t border-outline-variant/20"
+            >
+              <div className="flex flex-col gap-2">
+                <span className="text-xs font-bold uppercase tracking-wide text-on-surface-variant">
+                  Object type
+                </span>
+                <div className="flex flex-wrap gap-2">
+                  {OBJECT_TYPES.map((t) => {
+                    const selected = objectTypeFilter.includes(t.type)
+                    return (
+                      <button
+                        key={t.type}
+                        type="button"
+                        aria-pressed={selected}
+                        aria-label={`Object type: ${t.label}`}
+                        onClick={() => setObjectTypeFilter((prev) => toggleInArray(prev, t.type))}
+                        className={objectTypeChipClass(selected)}
+                        style={objectTypeChipStyle(t.markerColor, selected)}
+                      >
+                        <span
+                          aria-hidden
+                          className="inline-block w-2 h-2 rounded-full shrink-0"
+                          style={{ backgroundColor: selected ? '#ffffff' : t.markerColor }}
+                        />
+                        <span>{t.label}</span>
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <span className="text-xs font-bold uppercase tracking-wide text-on-surface-variant">
+                  Issue type
+                </span>
+                {objectTypeFilter.length === 0 ? (
+                  <p className="text-xs text-on-surface-variant italic">
+                    Pick at least one object type to choose issue types.
+                  </p>
+                ) : (
+                  <div className="flex flex-col gap-3 max-h-60 overflow-y-auto pr-1">
+                    {buildIssueGroups(objectTypeFilter).map((group) => (
+                      <div key={group.type} className="flex flex-col gap-1.5">
+                        <div className="flex items-center gap-2">
+                          <span
+                            aria-hidden
+                            className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                            style={{ backgroundColor: group.color }}
+                          />
+                          <span className="text-[11px] font-bold uppercase tracking-wide text-on-surface">
+                            {group.label}
+                          </span>
+                        </div>
+                        <div className="flex flex-wrap gap-1.5 pl-4">
+                          {group.issues.map((i) => {
+                            const selected = issueTypeFilter.includes(i.key)
+                            return (
+                              <button
+                                key={`${group.type}:${i.key}`}
+                                type="button"
+                                aria-pressed={selected}
+                                aria-label={`${group.label} issue: ${i.label}`}
+                                onClick={() =>
+                                  setIssueTypeFilter((prev) => toggleInArray(prev, i.key))
+                                }
+                                className={`${feedFilterChipClass(selected)} text-xs px-3 py-1.5`}
+                                style={
+                                  selected
+                                    ? undefined
+                                    : { borderLeft: `4px solid ${group.color}` }
+                                }
+                              >
+                                {i.label}
+                              </button>
+                            )
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-1 relative">
+                <label
+                  htmlFor="feed-author-name"
+                  className="text-xs font-bold uppercase tracking-wide text-on-surface-variant"
+                >
+                  Author
+                </label>
+                {selectedAuthor ? (
+                  <div className="flex items-center gap-2 rounded-xl border border-primary/30 bg-primary/10 px-3 py-2 text-sm text-on-surface">
+                    <span className="material-symbols-outlined text-base text-primary" aria-hidden>
+                      person
+                    </span>
+                    <span className="truncate font-medium">{selectedAuthor.name}</span>
+                    <button
+                      type="button"
+                      onClick={clearSelectedAuthor}
+                      aria-label="Clear author filter"
+                      className="ml-auto w-6 h-6 rounded-full hover:bg-primary/20 flex items-center justify-center cursor-pointer"
+                    >
+                      <span className="material-symbols-outlined text-base">close</span>
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    <input
+                      id="feed-author-name"
+                      type="search"
+                      autoComplete="off"
+                      placeholder={
+                        isAuthenticated
+                          ? 'Type at least 2 letters of a name'
+                          : 'Sign in to filter by author'
+                      }
+                      value={authorQuery}
+                      disabled={!isAuthenticated}
+                      onChange={(e) => setAuthorQuery(e.target.value)}
+                      className="rounded-xl border border-outline-variant bg-background px-3 py-2 text-sm text-on-surface disabled:bg-surface-container disabled:cursor-not-allowed"
+                    />
+                    {authorSearchActive && (
+                      <div
+                        role="listbox"
+                        aria-label="Author search results"
+                        className="absolute left-0 right-0 top-full mt-1 z-20 max-h-56 overflow-y-auto rounded-xl border border-outline-variant bg-surface-container-lowest shadow-md"
+                      >
+                        {authorSearchFetching && authorOptions.length === 0 && (
+                          <p className="px-3 py-2 text-xs text-on-surface-variant">Searching…</p>
+                        )}
+                        {!authorSearchFetching && authorOptions.length === 0 && (
+                          <p className="px-3 py-2 text-xs text-on-surface-variant">No users found.</p>
+                        )}
+                        {authorOptions.map((u) => (
+                          <button
+                            key={u.id}
+                            type="button"
+                            role="option"
+                            aria-selected={false}
+                            onClick={() => pickAuthor(u)}
+                            className="block w-full text-left px-3 py-2 text-sm text-on-surface hover:bg-primary/10 cursor-pointer"
+                          >
+                            {u.name}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-bold uppercase tracking-wide text-on-surface-variant">
+                    Published after
+                  </span>
+                  <input
+                    type="datetime-local"
+                    value={publishedAfterInput}
+                    onChange={(e) => setPublishedAfterInput(e.target.value)}
+                    className="rounded-xl border border-outline-variant bg-background px-3 py-2 text-sm text-on-surface"
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-bold uppercase tracking-wide text-on-surface-variant">
+                    Published before
+                  </span>
+                  <input
+                    type="datetime-local"
+                    value={publishedBeforeInput}
+                    onChange={(e) => setPublishedBeforeInput(e.target.value)}
+                    className="rounded-xl border border-outline-variant bg-background px-3 py-2 text-sm text-on-surface"
+                  />
+                </label>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 md:col-span-2">
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-bold uppercase tracking-wide text-on-surface-variant">
+                    Min agrees
+                  </span>
+                  <input
+                    type="number"
+                    min={0}
+                    step={1}
+                    value={minAgreesInput}
+                    onChange={(e) => setMinAgreesInput(e.target.value)}
+                    className="rounded-xl border border-outline-variant bg-background px-3 py-2 text-sm text-on-surface"
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-bold uppercase tracking-wide text-on-surface-variant">
+                    Min disagrees
+                  </span>
+                  <input
+                    type="number"
+                    min={0}
+                    step={1}
+                    value={minDisagreesInput}
+                    onChange={(e) => setMinDisagreesInput(e.target.value)}
+                    className="rounded-xl border border-outline-variant bg-background px-3 py-2 text-sm text-on-surface"
+                  />
+                </label>
+              </div>
+            </div>
           )}
         </section>
 
@@ -347,13 +876,43 @@ export default function Feed() {
           </p>
         )}
 
-        {isError && (
+        {feedBlockedReason && (
+          <div
+            role="status"
+            className="flex flex-wrap items-center gap-3 rounded-2xl border border-amber-300 bg-amber-50 dark:border-amber-700/50 dark:bg-amber-950/40 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+          >
+            <span className="material-symbols-outlined text-base shrink-0" aria-hidden>
+              location_searching
+            </span>
+            <span className="flex-1">{feedBlockedReason}</span>
+            <button
+              type="button"
+              onClick={handleUseCurrentLocation}
+              className="text-sm font-semibold underline underline-offset-2 hover:text-amber-700 dark:hover:text-amber-50"
+            >
+              Use current location
+            </button>
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              className="text-sm font-semibold underline underline-offset-2 hover:text-amber-700 dark:hover:text-amber-50"
+            >
+              Choose on map
+            </button>
+          </div>
+        )}
+
+        {isError && !feedBlockedReason && (
           <p role="alert" className="text-sm text-error font-medium">
             {error?.message || 'Could not load the feed.'}
           </p>
         )}
 
-        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4 list-none p-0 m-0">
+        <ul
+          aria-busy={isRefreshingWithPlaceholder ? 'true' : 'false'}
+          hidden={feedBlockedReason != null}
+          className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4 list-none p-0 m-0 transition-opacity duration-150 ${isRefreshingWithPlaceholder ? 'opacity-60' : 'opacity-100'}`}
+        >
           {reportsSorted.map((report) => {
             const distLabel = formatDistanceKm(
               referenceForDistance,
@@ -488,7 +1047,7 @@ export default function Feed() {
           <p className="text-center text-lg text-on-surface-variant py-16">{emptyMessage}</p>
         )}
 
-        {isPending && (
+        {isPending && !feedBlockedReason && (
           <p className="text-center text-lg text-on-surface-variant py-12">Loading feed…</p>
         )}
 

--- a/frontend/src/pages/Feed.test.jsx
+++ b/frontend/src/pages/Feed.test.jsx
@@ -247,4 +247,89 @@ describe('Feed page', () => {
       expect(screen.getByRole('alert')).toHaveTextContent(/service unavailable/i)
     })
   })
+
+  it('passes selected status filters as an array to getReportFeed', async () => {
+    const user = userEvent.setup()
+    renderFeed()
+    await waitFor(() => expect(getReportFeedMock).toHaveBeenCalled())
+
+    await user.click(screen.getByRole('button', { name: /status: validated/i }))
+
+    await waitFor(() => {
+      const withStatus = getReportFeedMock.mock.calls.filter((call) =>
+        Array.isArray(call[0]?.status) && call[0].status.includes('VERIFIED')
+      )
+      expect(withStatus.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('passes the selected sort option to getReportFeed', async () => {
+    const user = userEvent.setup()
+    renderFeed()
+    await waitFor(() => expect(getReportFeedMock).toHaveBeenCalled())
+
+    await user.selectOptions(screen.getByLabelText(/^sort$/i), 'MOST_AGREED')
+
+    await waitFor(() => {
+      const withSort = getReportFeedMock.mock.calls.filter(
+        (call) => call[0]?.sort === 'MOST_AGREED'
+      )
+      expect(withSort.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('passes the debounced description search to getReportFeed', async () => {
+    const user = userEvent.setup()
+    renderFeed()
+    await waitFor(() => expect(getReportFeedMock).toHaveBeenCalled())
+
+    await user.type(screen.getByLabelText(/search description/i), 'elevator')
+
+    await waitFor(
+      () => {
+        const withQ = getReportFeedMock.mock.calls.filter((call) => call[0]?.q === 'elevator')
+        expect(withQ.length).toBeGreaterThan(0)
+      },
+      { timeout: 1500 }
+    )
+  })
+
+  it('blocks the feed request and shows a warning when Nearest is picked without a location', async () => {
+    const user = userEvent.setup()
+    renderFeed()
+    await waitFor(() => expect(getReportFeedMock).toHaveBeenCalled())
+    getReportFeedMock.mockClear()
+
+    await user.selectOptions(screen.getByLabelText(/^sort$/i), 'DISTANCE')
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/pick a reference point to sort by distance/i)
+      ).toBeInTheDocument()
+    })
+    // No new feed request should have fired while the sort needs data we don't have.
+    expect(getReportFeedMock).not.toHaveBeenCalled()
+  })
+
+  it('reveals advanced filters when toggled and clears all on demand', async () => {
+    const user = userEvent.setup()
+    renderFeed()
+    await waitFor(() => expect(getReportFeedMock).toHaveBeenCalled())
+
+    // Advanced panel is hidden initially.
+    expect(screen.queryByLabelText(/published after/i)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /advanced filters/i }))
+    expect(screen.getByLabelText(/published after/i)).toBeInTheDocument()
+
+    // Activate a filter so "Clear all" shows up, then reset.
+    await user.click(screen.getByRole('button', { name: /status: pending/i }))
+    const clearBtn = await screen.findByRole('button', { name: /clear all/i })
+    await user.click(clearBtn)
+
+    await waitFor(() => {
+      const lastCall = getReportFeedMock.mock.calls.at(-1)
+      expect(lastCall?.[0]?.status).toBeUndefined()
+    })
+  })
 })

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -257,7 +257,14 @@ export async function getReportsByUserId(userId) {
 /**
  * Paginated community feed.
  * GET /api/reports/feed
- * With coordinates + radiusInKm: proximity ordering. Without coordinates: global newest-first feed.
+ *
+ * Filters mirror the backend `ReportFeedQuery`:
+ *  - `reportType`, `environment` (single value; 'ALL' is treated as unset)
+ *  - `status`, `objectType`, `issueType` (arrays; each value becomes a repeated query param)
+ *  - `authorId`, `publishedAfter`, `publishedBefore`, `q`
+ *  - `minAgrees`, `minDisagrees`
+ *  - `sort` (omitted when falsy; backend defaults to distance with coords, newest otherwise)
+ *  - `latitude` + `longitude` (+ optional `radiusInKm`)
  */
 export async function getReportFeed(
   {
@@ -265,6 +272,16 @@ export async function getReportFeed(
     size = 20,
     reportType,
     environment,
+    status,
+    authorId,
+    publishedAfter,
+    publishedBefore,
+    q,
+    minAgrees,
+    minDisagrees,
+    objectType,
+    issueType,
+    sort,
     latitude,
     longitude,
     radiusInKm,
@@ -277,6 +294,19 @@ export async function getReportFeed(
   params.set('size', String(size))
   if (reportType && reportType !== 'ALL') params.set('reportType', reportType)
   if (environment && environment !== 'ALL') params.set('environment', environment)
+  appendMulti(params, 'status', status)
+  if (authorId != null && Number.isFinite(Number(authorId))) {
+    params.set('authorId', String(authorId))
+  }
+  if (publishedAfter) params.set('publishedAfter', String(publishedAfter))
+  if (publishedBefore) params.set('publishedBefore', String(publishedBefore))
+  const qTrimmed = typeof q === 'string' ? q.trim() : ''
+  if (qTrimmed) params.set('q', qTrimmed)
+  appendNonNegativeInt(params, 'minAgrees', minAgrees)
+  appendNonNegativeInt(params, 'minDisagrees', minDisagrees)
+  appendMulti(params, 'objectType', objectType)
+  appendMulti(params, 'issueType', issueType)
+  if (sort) params.set('sort', sort)
   const latN = latitude != null ? Number(latitude) : NaN
   const lonN = longitude != null ? Number(longitude) : NaN
   if (Number.isFinite(latN) && Number.isFinite(lonN)) {
@@ -289,6 +319,19 @@ export async function getReportFeed(
   const headers = {}
   if (token) headers.Authorization = `Bearer ${token}`
   return apiFetch(`/api/reports/feed?${params.toString()}`, { headers, ...fetchOpts })
+}
+
+function appendMulti(params, key, values) {
+  if (!Array.isArray(values)) return
+  for (const v of values) {
+    if (v != null && v !== '') params.append(key, String(v))
+  }
+}
+
+function appendNonNegativeInt(params, key, value) {
+  if (value == null) return
+  const n = Number(value)
+  if (Number.isInteger(n) && n >= 0) params.set(key, String(n))
 }
 
 export async function updateReport(id, body, token) {

--- a/frontend/src/services/reportService.js
+++ b/frontend/src/services/reportService.js
@@ -329,7 +329,7 @@ function appendMulti(params, key, values) {
 }
 
 function appendNonNegativeInt(params, key, value) {
-  if (value == null) return
+  if (value == null || value === '') return
   const n = Number(value)
   if (Number.isInteger(n) && n >= 0) params.set(key, String(n))
 }

--- a/frontend/src/services/reportService.test.js
+++ b/frontend/src/services/reportService.test.js
@@ -191,6 +191,92 @@ describe('reportService — fix request helpers', () => {
         signal: ac.signal,
       })
     })
+
+    it('serializes multi-value enum filters as repeated query params', async () => {
+      apiFetch.mockResolvedValue({ content: [] })
+
+      await getReportFeed(
+        {
+          page: 0,
+          size: 20,
+          status: ['VERIFIED', 'PENDING'],
+          objectType: ['RAMP'],
+          issueType: ['TOO_STEEP', 'MISSING'],
+        },
+        null
+      )
+
+      const qs = apiFetch.mock.calls[0][0].split('?')[1]
+      const sp = new URLSearchParams(qs)
+      expect(sp.getAll('status')).toEqual(['VERIFIED', 'PENDING'])
+      expect(sp.getAll('objectType')).toEqual(['RAMP'])
+      expect(sp.getAll('issueType')).toEqual(['TOO_STEEP', 'MISSING'])
+    })
+
+    it('passes authorId, date range, q, and vote thresholds', async () => {
+      apiFetch.mockResolvedValue({ content: [] })
+
+      await getReportFeed(
+        {
+          page: 0,
+          size: 20,
+          authorId: 42,
+          publishedAfter: '2026-01-01T00:00:00Z',
+          publishedBefore: '2026-06-01T00:00:00Z',
+          q: '  elevator  ',
+          minAgrees: 3,
+          minDisagrees: 0,
+        },
+        null
+      )
+
+      const qs = apiFetch.mock.calls[0][0].split('?')[1]
+      const sp = new URLSearchParams(qs)
+      expect(sp.get('authorId')).toBe('42')
+      expect(sp.get('publishedAfter')).toBe('2026-01-01T00:00:00Z')
+      expect(sp.get('publishedBefore')).toBe('2026-06-01T00:00:00Z')
+      expect(sp.get('q')).toBe('elevator') // trimmed
+      expect(sp.get('minAgrees')).toBe('3')
+      expect(sp.get('minDisagrees')).toBe('0')
+    })
+
+    it('sends sort when explicit; omits sort when falsy', async () => {
+      apiFetch.mockResolvedValue({ content: [] })
+
+      await getReportFeed({ page: 0, size: 20, sort: 'MOST_AGREED' }, null)
+      let qs = apiFetch.mock.calls[0][0].split('?')[1]
+      expect(new URLSearchParams(qs).get('sort')).toBe('MOST_AGREED')
+
+      apiFetch.mockClear()
+      await getReportFeed({ page: 0, size: 20, sort: undefined }, null)
+      qs = apiFetch.mock.calls[0][0].split('?')[1]
+      expect(new URLSearchParams(qs).has('sort')).toBe(false)
+    })
+
+    it('drops empty arrays, whitespace-only q, and negative vote thresholds', async () => {
+      apiFetch.mockResolvedValue({ content: [] })
+
+      await getReportFeed(
+        {
+          page: 0,
+          size: 20,
+          status: [],
+          objectType: [null, ''],
+          q: '   ',
+          minAgrees: -1,
+          minDisagrees: '',
+        },
+        null
+      )
+
+      const qs = apiFetch.mock.calls[0][0].split('?')[1]
+      const sp = new URLSearchParams(qs)
+      expect(sp.has('status')).toBe(false)
+      expect(sp.has('objectType')).toBe(false)
+      expect(sp.has('q')).toBe(false)
+      expect(sp.has('minAgrees')).toBe(false)
+      expect(sp.has('minDisagrees')).toBe(false)
+    })
   })
 
   describe('mapReportStatus', () => {

--- a/frontend/src/utils/feedFilterOptions.js
+++ b/frontend/src/utils/feedFilterOptions.js
@@ -1,0 +1,19 @@
+/**
+ * Centralized option lists for the report feed filters. Keep labels in sync with
+ * the backend enums (ReportStatus, FeedSort).
+ */
+
+export const STATUS_OPTIONS = [
+  { id: 'PENDING', label: 'Pending' },
+  { id: 'VERIFIED', label: 'Validated' },
+  { id: 'FIXED', label: 'Fixed' },
+  { id: 'REJECTED', label: 'Rejected' },
+]
+
+export const SORT_OPTIONS = [
+  { id: 'NEWEST', label: 'Newest' },
+  { id: 'OLDEST', label: 'Oldest' },
+  { id: 'MOST_AGREED', label: 'Most agreed' },
+  { id: 'MOST_CONTROVERSIAL', label: 'Most controversial' },
+  { id: 'DISTANCE', label: 'Nearest (needs location)' },
+]


### PR DESCRIPTION
# 📝 Description
Extends the report feed (`GET /api/reports/feed`) and its web UI with a full set of filters and sort options.

**Backend**
- `ReportFeedQuery` DTO gains `status[]`, `authorId`, `publishedAfter/Before`, `q` (case-insensitive description search), `minAgrees`, `minDisagrees`, `objectType[]`, `issueType[]`, and an explicit `sort` (`NEWEST` / `OLDEST` / `MOST_AGREED` / `MOST_CONTROVERSIAL` / `DISTANCE`).
- `ReportRepositoryImpl` now takes the full query DTO and emits a dynamic `ORDER BY` plus `EXISTS` joins for `report_objects` / `report_object_issues`. `findFeedWithinRadius` keeps the PostGIS proximity behaviour; `sort=DISTANCE` without coordinates is rejected with 400.
- `ReportService.feed` validates the new combinations (partial coords, inverted date range, `DISTANCE` without coords).
- Flyway `V6__report_feed_indexes.sql` adds the indexes needed by the new filters (`status`, `user_id`, `publish_date`, `agrees`, `report_objects.object_type`, `report_object_issues.issue_type`).

**Frontend**
- `getReportFeed` client serializes the new params, including repeated query params for multi-value enums; whitespace-only `q` and empty numeric inputs are dropped.
- Feed page exposes status chips, a sort dropdown, a debounced description search, and an Advanced filters panel with:
  - Color-coded object type chips (using each type's `markerColor`)
  - Issue type picker that only opens once an object type is selected, grouped per object type in click order, with the parent's color as a visual cue; orphan selections are auto-cleaned when an object type is removed
  - Author name autocomplete (uses existing `/api/users/search`; disabled for anonymous users)
  - Date range + min agrees / min disagrees inputs
- `placeholderData: keepPreviousData` keeps the list rendered during a filter-change refetch so the page no longer jumps to the top.
- Picking `Nearest` without a reference point shows an inline warning banner with quick CTAs to set location, instead of letting the request 400 out.

# 📊 Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

Manual checks:
- [ ] Each filter (status / sort / q / object / issue / author / date range / vote thresholds / proximity) shapes the request as expected
- [ ] Changing a filter does not jump the scroll position back to the top
- [ ] Selecting `Nearest` with no reference point shows the warning banner (no 400)
- [ ] Removing an object type drops the issues that were unique to it

# 📸 Screenshots / Recordings
<img width="1206" height="578" alt="image" src="https://github.com/user-attachments/assets/8421568f-1d4e-4406-be8b-25fa20a5ff5f" />

# ⏱️ Estimated Review Time
- [ ] < 5 min
- [ ] 5-15 min
- [x] > 15 min
