### PR TITLE
[Web] Remove "Within 500m of your location" Text From Home Screen

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -709,7 +709,6 @@ function Home() {
                   </div>
                   <div>
                     <p className="text-xs font-bold text-on-surface">{reports.length} Active Reports</p>
-                    <p className="text-[10px] text-on-surface-variant">Within 500m of your location</p>
                   </div>
                 </div>
                 <div className="bg-primary/5 rounded-2xl p-4">


### PR DESCRIPTION
# 📝 Description
Fixes #641

This PR removes the redundant "Within 500m of your location" text from the home screen to provide a cleaner UI. Parent container margins and paddings have been verified to ensure the layout remains visually consistent after the text removal. This copy only appeared on the web home screen; the mobile app did not display this label.

# 📊 Type of Change
- [x] Bug fix / UI Tweak
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] Removed the text from Web UI
- [x] I have added/updated tests (if snapshot tests were affected)
- [x] All tests passed

# 📸 Screenshots / Recordings

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min