### PR TITLE
[Web] Login Page Misreports Network And Server Errors As Invalid Credentials

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -40,9 +40,14 @@ function Login() {
       const from = location.state?.from?.pathname ?? '/'
       navigate(from, { replace: true })
     } catch (err) {
-      // Always show a generic message regardless of the actual error to avoid
-      // leaking whether the email exists in the system.
-      setError('Invalid email or password.')
+      // Generic message on 401 to avoid leaking whether the email exists;
+      // for network/5xx errors, surface the real cause so a transient backend
+      // failure isn't misread as bad credentials.
+      if (err?.status === 401) {
+        setError('Invalid email or password.')
+      } else {
+        setError(err?.message || 'Could not reach the server. Please try again.')
+      }
     } finally {
       setIsLoading(false)
     }

--- a/frontend/src/pages/Login.test.jsx
+++ b/frontend/src/pages/Login.test.jsx
@@ -183,7 +183,7 @@ describe('Login page', () => {
     })
 
     it('shows an error message on failed login', async () => {
-      authService.loginUser.mockRejectedValue(new Error('Unauthorized'))
+      authService.loginUser.mockRejectedValue(Object.assign(new Error('Unauthorized'), { status: 401 }))
       const user = userEvent.setup()
       renderLogin()
 
@@ -197,7 +197,7 @@ describe('Login page', () => {
     })
 
     it('does not navigate on failed login', async () => {
-      authService.loginUser.mockRejectedValue(new Error('Unauthorized'))
+      authService.loginUser.mockRejectedValue(Object.assign(new Error('Unauthorized'), { status: 401 }))
       const user = userEvent.setup()
       renderLogin()
 
@@ -210,7 +210,7 @@ describe('Login page', () => {
 
     it('clears a previous error when resubmitting', async () => {
       authService.loginUser
-        .mockRejectedValueOnce(new Error('Unauthorized'))
+        .mockRejectedValueOnce(Object.assign(new Error('Unauthorized'), { status: 401 }))
         .mockResolvedValue({ token: 'tok' })
       const user = userEvent.setup()
       renderLogin()

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -48,7 +48,9 @@ export async function apiFetch(path, options = {}) {
     }
     const error = await res.json().catch(() => ({ message: res.statusText }))
     const msg = pickErrorMessage(error, res.statusText)
-    throw new Error(msg)
+    const err = new Error(msg)
+    err.status = res.status
+    throw err
   }
 
   if (res.status === 204) return null


### PR DESCRIPTION
# 📝 Login Page Misreports Network and Server Errors as Invalid Credentials

Fixes #645

Login's catch block masks every thrown error as `Invalid email or password.`, which makes transient backend failures (cold-start, 5xx, network blips) look like wrong credentials — users re-click Sign In and the second attempt succeeds against a now-warm backend, making login feel flaky. Branch on HTTP status instead: keep the generic message on 401 (no email enumeration), surface the real cause otherwise. To make this possible, `apiFetch` now attaches `.status` to the thrown `Error`.

# 📊 Type of Change
- [x] Bug fix

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# ⏱️ Estimated Review Time
- [x] < 5 min