### PR TITLE
[Web/Mobile/Backend] Follow Button Should Reflect Implicit Following From Votes And Comments

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/model/ReportSubscription.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/ReportSubscription.java
@@ -7,10 +7,12 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-/** Explicit "Follow Updates" subscription — a user opts in to receive
- *  notifications about a report even if they did not create, comment on,
- *  or vote on it. Commenters and voters are notified through their own
- *  cohort lookups, so we do not auto-create a subscription for them. */
+/** Single source of truth for the notification audience of a report.
+ *  A row is created when a user creates the report, votes on it, comments
+ *  on it, or hits the "Follow Updates" button. {@link com.bounswe2026group1.backend.service.NotificationService#resolveAudience}
+ *  reads only this table, so the Follow button (and pressing Unfollow) always
+ *  reflects whether the user actually receives STATUS_CHANGE / NEW_COMMENT
+ *  notifications. */
 @Entity
 @Table(name = "report_subscriptions",
         uniqueConstraints = @UniqueConstraint(

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/CommentService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/CommentService.java
@@ -23,6 +23,7 @@ public class CommentService {
     private final ReportRepository reportRepository;
     private final RegisteredUserRepository registeredUserRepository;
     private final NotificationService notificationService;
+    private final ReportSubscriptionService subscriptionService;
 
     public List<CommentResponse> getAll() {
         return commentRepository.findAll().stream().map(CommentResponse::fromEntity).toList();
@@ -57,6 +58,9 @@ public class CommentService {
         comment.setReport(reportRepository.getReferenceById(req.report().reportId()));
         comment.setAuthor(registeredUserRepository.getReferenceById(req.author().id()));
         Comment saved = commentRepository.save(comment);
+        // Commenter joins the notification audience as an explicit subscription
+        // row so the Follow button reflects it.
+        subscriptionService.subscribeInternal(saved.getReport(), saved.getAuthor());
         notificationService.notifyNewComment(saved);
         return CommentResponse.fromEntity(saved);
     }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/NotificationService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/NotificationService.java
@@ -9,11 +9,9 @@ import com.bounswe2026group1.backend.model.NotificationType;
 import com.bounswe2026group1.backend.model.RegisteredUser;
 import com.bounswe2026group1.backend.model.Report;
 import com.bounswe2026group1.backend.model.ReportStatus;
-import com.bounswe2026group1.backend.repository.CommentRepository;
 import com.bounswe2026group1.backend.repository.NotificationRepository;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.repository.ReportSubscriptionRepository;
-import com.bounswe2026group1.backend.repository.ReportVerificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -38,8 +36,6 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final RegisteredUserRepository registeredUserRepository;
     private final NotificationSseService notificationSseService;
-    private final CommentRepository commentRepository;
-    private final ReportVerificationRepository verificationRepository;
     private final ReportSubscriptionRepository subscriptionRepository;
 
     /** Persists a notification for a single recipient and pushes it to their
@@ -72,9 +68,11 @@ public class NotificationService {
     }
 
     /** Trigger: report status transitioned to PENDING, VERIFIED, REJECTED, or FIXED.
-     *  Notifies the report author, anyone who commented or voted on the report,
-     *  and any explicit subscribers, minus the actor whose action triggered the
-     *  change. Caller must only invoke this when the status actually changed. */
+     *  Notifies every explicit subscriber of the report (author, voters,
+     *  commenters, and Follow-button subscribers all live in the same
+     *  {@code report_subscriptions} table), minus the actor whose action
+     *  triggered the change. Caller must only invoke this when the status
+     *  actually changed. */
     public void notifyStatusChange(Report report, Long actorUserId) {
         if (report == null || report.getCreatedBy() == null) return;
         ReportStatus status = report.getStatus();
@@ -86,7 +84,7 @@ public class NotificationService {
         Long reportId = report.getReportId();
         Long authorId = report.getCreatedBy().getId();
 
-        Set<Long> audience = resolveAudience(reportId, authorId, actorUserId);
+        Set<Long> audience = resolveAudience(reportId, actorUserId);
         Map<Long, RegisteredUser> recipientsById = loadRecipients(audience);
         for (Long recipientId : audience) {
             RegisteredUser recipient = recipientsById.get(recipientId);
@@ -111,8 +109,10 @@ public class NotificationService {
         };
     }
 
-    /** Trigger: someone commented on a report. Notifies the report author,
-     *  prior commenters, voters, and explicit subscribers, minus the commenter. */
+    /** Trigger: someone commented on a report. Notifies every subscriber of
+     *  the report — author, voters, commenters, and Follow-button subscribers
+     *  all live in the same {@code report_subscriptions} table — minus the
+     *  commenter themselves. */
     public void notifyNewComment(Comment comment) {
         if (comment == null || comment.getReport() == null) return;
         RegisteredUser reportAuthor = comment.getReport().getCreatedBy();
@@ -124,7 +124,7 @@ public class NotificationService {
         Long authorId = reportAuthor.getId();
         String commenterName = commenter == null ? "Someone" : commenter.getName();
 
-        Set<Long> audience = resolveAudience(reportId, authorId, actorUserId);
+        Set<Long> audience = resolveAudience(reportId, actorUserId);
         Map<Long, RegisteredUser> recipientsById = loadRecipients(audience);
         for (Long recipientId : audience) {
             RegisteredUser recipient = recipientsById.get(recipientId);
@@ -161,14 +161,14 @@ public class NotificationService {
         return NotificationResponse.fromEntity(notification);
     }
 
-    /** Author + commenters + voters + subscribers, deduped, minus the actor and any nulls.
-     *  Returns user ids only; callers hydrate the recipients via {@link #loadRecipients}. */
-    Set<Long> resolveAudience(Long reportId, Long authorId, Long actorUserId) {
-        LinkedHashSet<Long> audience = new LinkedHashSet<>();
-        if (authorId != null) audience.add(authorId);
-        audience.addAll(commentRepository.findCommenterUserIdsByReportId(reportId));
-        audience.addAll(verificationRepository.findVoterUserIdsByReportId(reportId));
-        audience.addAll(subscriptionRepository.findSubscriberUserIdsByReportId(reportId));
+    /** Subscribers of the report, deduped, minus the actor and any nulls.
+     *  {@code report_subscriptions} is the single source of truth — author,
+     *  voters, and commenters are inserted by their respective service-layer
+     *  triggers, so we no longer need separate cohort lookups here. Returns
+     *  user ids only; callers hydrate the recipients via {@link #loadRecipients}. */
+    Set<Long> resolveAudience(Long reportId, Long actorUserId) {
+        LinkedHashSet<Long> audience = new LinkedHashSet<>(
+                subscriptionRepository.findSubscriberUserIdsByReportId(reportId));
         audience.remove(null);
         if (actorUserId != null) audience.remove(actorUserId);
         return audience;

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportService.java
@@ -45,6 +45,7 @@ public class ReportService {
     private final PublicSseService publicSseService;
     private final NotificationService notificationService;
     private final GamificationService gamificationService;
+    private final ReportSubscriptionService subscriptionService;
     private final S3MediaService s3MediaService;
     private final MeasurementValidator measurementValidator;
     private final OverpassService overpassService;
@@ -225,6 +226,9 @@ public class ReportService {
         broadcastAfterCommit(() -> publicSseService.broadcastReportCreated(finalSaved));
 
         gamificationService.awardOnReportSubmit(user, saved.getReportId());
+        // Author goes into the notification audience as an explicit subscription
+        // row, so the Follow button reflects it and Unfollow really works.
+        subscriptionService.subscribeInternal(saved, user);
 
         ReportResponse response = ReportResponse.fromEntity(saved, null, buildObjectResponses(saved),
                 resolveActiveFixRequest(user.getId(), saved.getReportId()));
@@ -506,6 +510,13 @@ public class ReportService {
         } else if (withdrawn) {
             gamificationService.deductOnVoteWithdraw(user, saved.getReportId());
         }
+        // Voting puts the user in the notification audience. Subscribe on every
+        // path that ends with an active vote (fresh cast or flipped direction);
+        // skip on withdraw, where the user opted out. Idempotent if the row
+        // already exists from a prior action.
+        if (!withdrawn) {
+            subscriptionService.subscribeInternal(saved, user);
+        }
         String op = switch (newStatus) { case VERIFIED -> "verify"; case REJECTED -> "reject"; default -> "pending"; };
         broadcastAfterCommit(() -> publicSseService.broadcastReportUpdated(saved, op));
         if (newStatus != previousStatus) {
@@ -562,6 +573,9 @@ public class ReportService {
             gamificationService.awardOnVoteCast(user, saved.getReportId());
         } else if (withdrawn) {
             gamificationService.deductOnVoteWithdraw(user, saved.getReportId());
+        }
+        if (!withdrawn) {
+            subscriptionService.subscribeInternal(saved, user);
         }
         String op = switch (newStatus) { case VERIFIED -> "verify"; case REJECTED -> "reject"; default -> "pending"; };
         broadcastAfterCommit(() -> publicSseService.broadcastReportUpdated(saved, op));

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/ReportSubscriptionService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/ReportSubscriptionService.java
@@ -41,6 +41,26 @@ public class ReportSubscriptionService {
                 });
     }
 
+    /** Internal entry-point for service-layer code that already has the user
+     *  and report entities in hand (report-create, vote-cast, comment-create).
+     *  Idempotent — re-subscribing a user is a no-op. We accept Hibernate
+     *  reference proxies, so this stays a single round trip when the caller
+     *  already holds the entity. */
+    @Transactional
+    public void subscribeInternal(Report report, RegisteredUser user) {
+        if (report == null || user == null) return;
+        Long userId = user.getId();
+        Long reportId = report.getReportId();
+        if (userId == null || reportId == null) return;
+        subscriptionRepository.findByUserIdAndReportReportId(userId, reportId)
+                .orElseGet(() -> {
+                    ReportSubscription sub = new ReportSubscription();
+                    sub.setUser(user);
+                    sub.setReport(report);
+                    return subscriptionRepository.save(sub);
+                });
+    }
+
     /** Unsubscribe is idempotent: deleting a row that does not exist is a no-op. */
     @Transactional
     public void unsubscribe(Long reportId, String email) {

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -24,3 +24,39 @@ CREATE TABLE IF NOT EXISTS report_object_issues (
 -- One-time backfill for rows that predate the status/points columns
 UPDATE registered_users SET status = 'ACTIVE' WHERE status IS NULL;
 UPDATE registered_users SET points = 0        WHERE points IS NULL;
+
+-- Backfill report_subscriptions for rows that predate the single-source-of-truth
+-- audience refactor. NotificationService.resolveAudience now reads only from
+-- report_subscriptions, so authors / voters / commenters of pre-existing
+-- reports need their rows materialised or they would silently stop receiving
+-- STATUS_CHANGE / NEW_COMMENT notifications. Idempotent — the NOT EXISTS guard
+-- and the unique (user_id, report_id) constraint make it safe to re-run.
+-- Hibernate (ddl-auto=update) creates the report_subscriptions table before
+-- schema.sql runs (defer-datasource-initialization=true), so we can reference
+-- it directly. Plain statements only — ScriptUtils chokes on PL/pgSQL DO blocks.
+INSERT INTO report_subscriptions (user_id, report_id, created_at)
+SELECT r.user_id, r.report_id, NOW()
+FROM reports r
+WHERE r.user_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM report_subscriptions s
+      WHERE s.user_id = r.user_id AND s.report_id = r.report_id
+  );
+
+INSERT INTO report_subscriptions (user_id, report_id, created_at)
+SELECT DISTINCT v.user_id, v.report_id, NOW()
+FROM report_verifications v
+WHERE v.user_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM report_subscriptions s
+      WHERE s.user_id = v.user_id AND s.report_id = v.report_id
+  );
+
+INSERT INTO report_subscriptions (user_id, report_id, created_at)
+SELECT DISTINCT c.author_id, c.report_id, NOW()
+FROM comments c
+WHERE c.author_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM report_subscriptions s
+      WHERE s.user_id = c.author_id AND s.report_id = c.report_id
+  );

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/CommentServiceTest.java
@@ -33,6 +33,7 @@ class CommentServiceTest {
     @Mock private ReportRepository reportRepository;
     @Mock private RegisteredUserRepository registeredUserRepository;
     @Mock private NotificationService notificationService;
+    @Mock private ReportSubscriptionService subscriptionService;
 
     @InjectMocks
     private CommentService commentService;
@@ -77,6 +78,9 @@ class CommentServiceTest {
         assertEquals(99L, out.id());
         verify(notificationService).notifyNewComment(any(Comment.class));
         verify(commentRepository).save(any(Comment.class));
+        // Commenter is auto-added to the notification audience so the Follow
+        // button reflects it.
+        verify(subscriptionService).subscribeInternal(report, author);
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/NotificationServiceTest.java
@@ -11,11 +11,9 @@ import com.bounswe2026group1.backend.model.Report;
 import com.bounswe2026group1.backend.model.ReportEnvironment;
 import com.bounswe2026group1.backend.model.ReportStatus;
 import com.bounswe2026group1.backend.model.ReportType;
-import com.bounswe2026group1.backend.repository.CommentRepository;
 import com.bounswe2026group1.backend.repository.NotificationRepository;
 import com.bounswe2026group1.backend.repository.RegisteredUserRepository;
 import com.bounswe2026group1.backend.repository.ReportSubscriptionRepository;
-import com.bounswe2026group1.backend.repository.ReportVerificationRepository;
 import com.bounswe2026group1.backend.util.GeoUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +28,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -53,8 +50,6 @@ class NotificationServiceTest {
     @Mock private NotificationRepository notificationRepository;
     @Mock private RegisteredUserRepository registeredUserRepository;
     @Mock private NotificationSseService notificationSseService;
-    @Mock private CommentRepository commentRepository;
-    @Mock private ReportVerificationRepository verificationRepository;
     @Mock private ReportSubscriptionRepository subscriptionRepository;
 
     @InjectMocks
@@ -77,10 +72,9 @@ class NotificationServiceTest {
         ReflectionTestUtils.setField(report, "reportId", 100L);
     }
 
-    private void stubEmptyAudience() {
-        when(commentRepository.findCommenterUserIdsByReportId(100L)).thenReturn(Collections.emptyList());
-        when(verificationRepository.findVoterUserIdsByReportId(100L)).thenReturn(Collections.emptyList());
-        when(subscriptionRepository.findSubscriberUserIdsByReportId(100L)).thenReturn(Collections.emptyList());
+    private void stubAudience(Long... userIds) {
+        when(subscriptionRepository.findSubscriberUserIdsByReportId(100L))
+                .thenReturn(java.util.Arrays.asList(userIds));
     }
 
     private void stubSaveAssignsId() {
@@ -105,7 +99,8 @@ class NotificationServiceTest {
 
     @Test
     void notifyStatusChange_persistsStatusChangeForReportAuthor() {
-        stubEmptyAudience();
+        // Author is in the subscriber list (auto-subscribed at report create).
+        stubAudience(author.getId());
         stubSaveAssignsId();
         stubFindAllByIdReturns(author);
         report.setStatus(ReportStatus.VERIFIED);
@@ -127,7 +122,7 @@ class NotificationServiceTest {
 
     @Test
     void notifyStatusChange_persistsRevertToPendingWithDistinctPhrasing() {
-        stubEmptyAudience();
+        stubAudience(author.getId());
         stubSaveAssignsId();
         stubFindAllByIdReturns(author);
         report.setStatus(ReportStatus.PENDING);
@@ -148,7 +143,7 @@ class NotificationServiceTest {
 
     @Test
     void notifyStatusChange_persistsStatusChangeForFixedTransition() {
-        stubEmptyAudience();
+        stubAudience(author.getId());
         stubSaveAssignsId();
         stubFindAllByIdReturns(author);
         report.setStatus(ReportStatus.FIXED);
@@ -168,15 +163,12 @@ class NotificationServiceTest {
     }
 
     @Test
-    void notifyStatusChange_fansOutToCommentersVotersSubscribers_excludingActor() {
-        // Bob (commenter) is the actor; Carol (voter) and Dave (subscriber) should each receive one,
-        // plus Alice (author).
-        when(commentRepository.findCommenterUserIdsByReportId(100L))
-                .thenReturn(List.of(commenter.getId()));
-        when(verificationRepository.findVoterUserIdsByReportId(100L))
-                .thenReturn(List.of(voter.getId()));
-        when(subscriptionRepository.findSubscriberUserIdsByReportId(100L))
-                .thenReturn(List.of(subscriber.getId()));
+    void notifyStatusChange_fansOutToSubscribers_excludingActor() {
+        // Bob (commenter) is the actor; everyone else is in the subscriber table
+        // (author via auto-subscribe at create, voter via auto-subscribe at vote,
+        // commenter via auto-subscribe at comment, plus explicit Follow subscriber).
+        // Bob still appears in the subscriber list but is removed as the actor.
+        stubAudience(author.getId(), commenter.getId(), voter.getId(), subscriber.getId());
         stubSaveAssignsId();
         stubFindAllByIdReturns(author, voter, subscriber);
         report.setStatus(ReportStatus.VERIFIED);
@@ -200,12 +192,7 @@ class NotificationServiceTest {
 
     @Test
     void notifyStatusChange_fetchesAllRecipientsInASingleQuery() {
-        when(commentRepository.findCommenterUserIdsByReportId(100L))
-                .thenReturn(List.of(commenter.getId()));
-        when(verificationRepository.findVoterUserIdsByReportId(100L))
-                .thenReturn(List.of(voter.getId()));
-        when(subscriptionRepository.findSubscriberUserIdsByReportId(100L))
-                .thenReturn(List.of(subscriber.getId()));
+        stubAudience(author.getId(), commenter.getId(), voter.getId(), subscriber.getId());
         stubSaveAssignsId();
         stubFindAllByIdReturns(author, voter, subscriber);
         report.setStatus(ReportStatus.VERIFIED);
@@ -218,14 +205,10 @@ class NotificationServiceTest {
     }
 
     @Test
-    void notifyStatusChange_dedupesUsersSpanningMultipleCohorts() {
-        // Carol both commented AND voted AND is subscribed; she should still get only one notification.
-        when(commentRepository.findCommenterUserIdsByReportId(100L))
-                .thenReturn(List.of(voter.getId()));
-        when(verificationRepository.findVoterUserIdsByReportId(100L))
-                .thenReturn(List.of(voter.getId()));
-        when(subscriptionRepository.findSubscriberUserIdsByReportId(100L))
-                .thenReturn(List.of(voter.getId()));
+    void notifyStatusChange_dedupesDuplicateSubscriberIds() {
+        // A duplicate row in the projection (e.g. due to a race) must still yield
+        // a single notification per user.
+        stubAudience(author.getId(), voter.getId(), voter.getId(), voter.getId());
         stubSaveAssignsId();
         stubFindAllByIdReturns(author, voter);
         report.setStatus(ReportStatus.VERIFIED);
@@ -243,8 +226,10 @@ class NotificationServiceTest {
 
     @Test
     void notifyStatusChange_excludesActorEvenWhenActorIsAuthor() {
-        // Author votes on her own report, flipping the status. She should not be notified.
-        stubEmptyAudience();
+        // Author votes on her own report, flipping the status. She is in the
+        // subscriber list (auto-subscribed at create) but should still be
+        // dropped as the actor.
+        stubAudience(author.getId());
         report.setStatus(ReportStatus.VERIFIED);
 
         notificationService.notifyStatusChange(report, author.getId());
@@ -254,7 +239,7 @@ class NotificationServiceTest {
 
     @Test
     void notifyNewComment_persistsCommentNotificationForReportAuthor() {
-        stubEmptyAudience();
+        stubAudience(author.getId());
         stubSaveAssignsId();
         stubFindAllByIdReturns(author);
         Comment comment = new Comment();
@@ -276,15 +261,10 @@ class NotificationServiceTest {
     }
 
     @Test
-    void notifyNewComment_fansOutToVotersAndSubscribers_excludingCommenter() {
-        // Bob (commenter) is the actor; Carol (voter) and Dave (subscriber) get notifications,
-        // plus Alice (author).
-        when(commentRepository.findCommenterUserIdsByReportId(100L))
-                .thenReturn(List.of(commenter.getId()));
-        when(verificationRepository.findVoterUserIdsByReportId(100L))
-                .thenReturn(List.of(voter.getId()));
-        when(subscriptionRepository.findSubscriberUserIdsByReportId(100L))
-                .thenReturn(List.of(subscriber.getId()));
+    void notifyNewComment_fansOutToSubscribers_excludingCommenter() {
+        // Bob (commenter) is the actor; everyone else is in the subscriber list
+        // and should receive a notification.
+        stubAudience(author.getId(), commenter.getId(), voter.getId(), subscriber.getId());
         stubSaveAssignsId();
         stubFindAllByIdReturns(author, voter, subscriber);
 
@@ -306,7 +286,7 @@ class NotificationServiceTest {
 
     @Test
     void notifyNewComment_skipsWhenAuthorCommentsOnOwnReport() {
-        stubEmptyAudience();
+        stubAudience(author.getId());
         Comment comment = new Comment();
         comment.setId(56L);
         comment.setReport(report);

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportServiceTest.java
@@ -50,6 +50,7 @@ class ReportServiceTest {
     @Mock private NominatimReverseGeocoder reverseGeocoder;
     @Mock private NotificationService notificationService;
     @Mock private GamificationService gamificationService;
+    @Mock private ReportSubscriptionService subscriptionService;
     @Mock private UserBadgeRepository userBadgeRepository;
 
     @InjectMocks
@@ -763,6 +764,16 @@ class ReportServiceTest {
     }
 
     @Test
+    void create_autoSubscribesAuthorToReport() {
+        when(registeredUserRepository.findById(1L)).thenReturn(Optional.of(testUser));
+        when(reportRepository.save(any(Report.class))).thenReturn(testReport);
+
+        reportService.create(testRequest);
+
+        verify(subscriptionService).subscribeInternal(eq(testReport), eq(testUser));
+    }
+
+    @Test
     void verifyReport_freshCast_awardsVoteCastPoints() {
         ReflectionTestUtils.setField(reportService, "verificationThreshold", 5);
         testUser.setEmail("user@test.com");
@@ -776,6 +787,8 @@ class ReportServiceTest {
 
         verify(gamificationService).awardOnVoteCast(eq(testUser), any());
         verify(gamificationService, never()).deductOnVoteWithdraw(any(), any());
+        // Voter joins the notification audience as a subscription row.
+        verify(subscriptionService).subscribeInternal(eq(testReport), eq(testUser));
     }
 
     @Test
@@ -794,6 +807,8 @@ class ReportServiceTest {
 
         verify(gamificationService).deductOnVoteWithdraw(eq(testUser), any());
         verify(gamificationService, never()).awardOnVoteCast(any(), any());
+        // Vote withdraw — do not re-subscribe; the user is actively backing off.
+        verify(subscriptionService, never()).subscribeInternal(any(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/ReportSubscriptionServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/ReportSubscriptionServiceTest.java
@@ -123,6 +123,41 @@ class ReportSubscriptionServiceTest {
     }
 
     @Test
+    void subscribeInternal_persistsRowForFreshSubscriber() {
+        report.setReportId(50L);
+        when(subscriptionRepository.findByUserIdAndReportReportId(1L, 50L)).thenReturn(Optional.empty());
+        when(subscriptionRepository.save(any(ReportSubscription.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        subscriptionService.subscribeInternal(report, user);
+
+        ArgumentCaptor<ReportSubscription> captor = ArgumentCaptor.forClass(ReportSubscription.class);
+        verify(subscriptionRepository).save(captor.capture());
+        assertEquals(user, captor.getValue().getUser());
+        assertEquals(report, captor.getValue().getReport());
+    }
+
+    @Test
+    void subscribeInternal_isIdempotent_whenRowAlreadyExists() {
+        report.setReportId(50L);
+        ReportSubscription existing = new ReportSubscription();
+        when(subscriptionRepository.findByUserIdAndReportReportId(1L, 50L)).thenReturn(Optional.of(existing));
+
+        subscriptionService.subscribeInternal(report, user);
+
+        verify(subscriptionRepository, never()).save(any());
+    }
+
+    @Test
+    void subscribeInternal_isNoOpOnNullArgsOrMissingIds() {
+        subscriptionService.subscribeInternal(null, user);
+        subscriptionService.subscribeInternal(report, null);
+        // Report has no reportId yet — service should bail out, not blow up.
+        subscriptionService.subscribeInternal(report, user);
+
+        verify(subscriptionRepository, never()).save(any());
+    }
+
+    @Test
     void isSubscribed_returnsRepositoryAnswer() {
         when(registeredUserRepository.findByEmail("alice@example.com")).thenReturn(Optional.of(user));
         when(subscriptionRepository.existsByUserIdAndReportReportId(1L, 100L)).thenReturn(true);

--- a/frontend/src/components/ReportPanel.jsx
+++ b/frontend/src/components/ReportPanel.jsx
@@ -402,6 +402,12 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
       // balance before the SSE event lands.
       queryClient.invalidateQueries({ queryKey: ['leaderboard'] })
       queryClient.invalidateQueries({ queryKey: currentUserKey })
+      // Backend auto-subscribes the voter (except on withdraw). Mirror that
+      // optimistically so the Follow button flips without a panel reopen.
+      if (mappedUpdated.userVote) {
+        setFollowing(true)
+        onFollowChange?.(true)
+      }
     },
     onError: () => {
       setVoteError('Failed to submit vote. Please try again.')
@@ -475,6 +481,12 @@ function ReportPanel({ report, userVote, onVoteChange, onClose, onVoteUpdate, on
       console.log('[handleCommentSubmit] Created comment:', created)
       setComments(prev => [created, ...prev])
       setNewComment('')
+      // Backend auto-subscribes the commenter — mirror it so the Follow
+      // button reflects the new state without waiting for a panel reopen.
+      if (!following) {
+        setFollowing(true)
+        onFollowChange?.(true)
+      }
     } catch (err) {
       console.error('[handleCommentSubmit] Error submitting comment:', err)
     } finally {

--- a/mobile/lib/screens/report_detail_screen.dart
+++ b/mobile/lib/screens/report_detail_screen.dart
@@ -504,6 +504,11 @@ class _ReportDetailScreenState extends State<ReportDetailScreen> {
       );
       _commentController.clear();
       await _loadComments();
+      // Backend auto-subscribes the commenter. Mirror it locally so the
+      // Follow button flips immediately rather than only after a screen reopen.
+      if (mounted && _isFollowing != true) {
+        setState(() => _isFollowing = true);
+      }
     } on ApiException catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -604,6 +609,12 @@ class _ReportDetailScreenState extends State<ReportDetailScreen> {
         await api.unverifyReport(report.reportId);
       }
       await _refreshReport();
+      // Backend auto-subscribes voters (except on withdraw — _myVote becomes
+      // null then). Mirror it so the Follow button reflects the new state
+      // without waiting for the user to re-enter the screen.
+      if (mounted && _myVote != null && _isFollowing != true) {
+        setState(() => _isFollowing = true);
+      }
     } catch (e) {
       if (mounted) {
         setState(() {


### PR DESCRIPTION
# 📝 Follow Button Should Reflect Implicit Following From Votes And Comments

We are really close to the deadline, so this fix covers every subteam.

Fixes #647

When you press Agree (or Disagree, or comment, or create the report) you immediately start receiving STATUS_CHANGE / NEW_COMMENT notifications, because `NotificationService.resolveAudience` unioned author + commenters + voters + explicit subscribers — but the Follow button only read from the explicit `ReportSubscription` table, so it stayed on "Follow Updates" and never reflected that the user was already in the audience. This PR makes `report_subscriptions` the single source of truth: author / vote / comment triggers each insert an idempotent subscription row, and `resolveAudience` is reduced to a single read of that table. As a bonus, pressing Unfollow now actually stops further notifications even for users who voted or commented. Web and mobile mirror the new subscription state locally after a vote/comment so the button flips without a panel/screen reopen.

# 📊 Type of Change
- [x] Bug fix
- [x] Refactoring

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed (backend 693, web ReportPanel 40)

## What changed

### Backend
- `ReportSubscriptionService.subscribeInternal(report, user)` — new service-layer helper, idempotent on the existing `(user_id, report_id)` unique constraint.
- `ReportService.create` auto-subscribes the author after gamification.
- `ReportService.verifyReport` / `unverifyReport` auto-subscribe the voter on every fresh-or-modified vote (withdraw is intentionally not re-subscribed — the user is opting out).
- `CommentService.create` auto-subscribes the commenter.
- `NotificationService.resolveAudience` now reads only from `subscriptionRepository`; the `CommentRepository` and `ReportVerificationRepository` dependencies were removed.
- `schema.sql` backfills `report_subscriptions` rows for pre-existing authors, voters, and commenters so they keep receiving notifications. Idempotent and re-runnable.

### Web
- `ReportPanel` — after a successful vote (with an active userVote, i.e. not a withdraw) or comment submission, flips local `following` state to true so the button updates without waiting for a panel reopen.

### Mobile
- `ReportDetailScreen` — same mirror on `_isFollowing` after a successful vote (when `_myVote != null`) or `_submitComment`.

# 📸 Screenshots / Recordings
N/A (no visual layout changes — only state-driven button copy/style).

# ⏱️ Estimated Review Time
- [x] 5-15 min