### PR TITLE
[Backend] Permit ASYNC/ERROR Dispatches In Security Filter Chain To Suppress Spurious SSE Disconnect Warnings

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import jakarta.servlet.DispatcherType;
 import java.util.List;
 
 @Slf4j
@@ -54,6 +55,12 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        // SSE controllers commit the response on the initial REQUEST
+                        // dispatch; on async/error re-dispatches the SecurityContext is
+                        // empty, so Spring Security 6's AuthorizationFilter (which runs
+                        // on every dispatch type by default) would otherwise reject the
+                        // already-committed response and log a spurious warning.
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC, DispatcherType.ERROR).permitAll()
                         .requestMatchers(ROUTING_AND_AUTH_PUBLIC).permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**").permitAll()
                     .requestMatchers(org.springframework.http.HttpMethod.GET,


### PR DESCRIPTION
# 📝 Permit ASYNC/ERROR Dispatches In Security Filter Chain To Suppress Spurious SSE Disconnect Warnings

Fixes #650

Adds `.dispatcherTypeMatchers(DispatcherType.ASYNC, DispatcherType.ERROR).permitAll()` to the authorization rules so Spring Security 6's `AuthorizationFilter` only enforces auth on the initial `REQUEST` dispatch. SSE controllers commit the response early; on the container-driven async re-dispatch (triggered by client disconnect) the `SecurityContext` is empty, so the default filter chain rejected the already-committed response and logged `Cannot render error page for request [null] as the response has already been committed.` This change keeps auth enforcement intact (initial REQUEST is the only dispatch a client can originate) while silencing the noise.

# 📊 Type of Change
- [x]  Bug fix
- [ ]  New feature
- [ ]  Refactoring
- [ ]  Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [ ] I have added/updated tests
- [x] All tests passed

# 📸 Screenshots / Recordings
N/A — the only observable effect is the disappearance of the warning on SSE disconnects.

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min