### PR TITLE
[Backend] Include Admins in User Search

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/repository/RegisteredUserRepository.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/repository/RegisteredUserRepository.java
@@ -58,8 +58,10 @@ public interface RegisteredUserRepository extends JpaRepository<RegisteredUser, 
             """)
     long countAboveForRank(@Param("points") int points);
 
-    // User search (#306 / #501): case-insensitive substring match across name OR email, regular users only.
-    @Query("SELECT u FROM RegisteredUser u WHERE u.role = com.bounswe2026group1.backend.model.UserRole.USER " +
+    // User search (#306 / #501): case-insensitive substring match across name OR email.
+    // Admins are included; BANNED accounts are excluded.
+    @Query("SELECT u FROM RegisteredUser u " +
+           "WHERE u.status = com.bounswe2026group1.backend.model.UserStatus.ACTIVE " +
            "AND (LOWER(u.name) LIKE LOWER(CONCAT('%', :q, '%')) OR LOWER(u.email) LIKE LOWER(CONCAT('%', :q, '%')))")
-    Page<RegisteredUser> searchRegularUsersByNameOrEmail(@Param("q") String q, Pageable pageable);
+    Page<RegisteredUser> searchUsersByNameOrEmail(@Param("q") String q, Pageable pageable);
 }

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RegisteredUserService.java
@@ -194,6 +194,7 @@ public class RegisteredUserService {
     /** User search (#306 / #501): paginated, case-insensitive substring match
      *  across name OR email. Empty / blank query is rejected with
      *  IllegalArgumentException so the controller can return 400.
+     *  Admins are included; BANNED accounts are excluded at the repository.
      *  Email is omitted in the DTO (privacy) — search results are public. */
     public Page<UserProfileDTO> searchUsers(String query, Pageable pageable) {
         if (query == null || query.isBlank()) {
@@ -201,7 +202,7 @@ public class RegisteredUserService {
         }
         String trimmed = query.trim();
         Page<RegisteredUser> page = registeredUserRepository
-                .searchRegularUsersByNameOrEmail(trimmed, pageable);
+                .searchUsersByNameOrEmail(trimmed, pageable);
         if (page.isEmpty()) return page.map(u -> buildDTO(u, false, 0L, 0L, List.of(), null));
 
         // Batch the contribution-stats queries so we stay flat at 3 queries

--- a/backend/src/test/java/com/bounswe2026group1/backend/repository/RegisteredUserRepositoryTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/repository/RegisteredUserRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.bounswe2026group1.backend.repository;
+
+import com.bounswe2026group1.backend.model.RegisteredUser;
+import com.bounswe2026group1.backend.model.UserRole;
+import com.bounswe2026group1.backend.model.UserStatus;
+import com.bounswe2026group1.backend.support.AbstractPostgisIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+class RegisteredUserRepositoryTest extends AbstractPostgisIntegrationTest {
+
+    @Autowired
+    private RegisteredUserRepository repository;
+
+    @Test
+    void searchUsersByNameOrEmail_includesAdminsAndExcludesBannedUsers() {
+        RegisteredUser regular = persist("Ada Lovelace", "ada@search.test", UserRole.USER, UserStatus.ACTIVE);
+        RegisteredUser admin = persist("Alan Turing", "alan@search.test", UserRole.ADMIN, UserStatus.ACTIVE);
+        RegisteredUser banned = persist("Albert Banned", "albert@search.test", UserRole.USER, UserStatus.BANNED);
+
+        Page<RegisteredUser> page = repository.searchUsersByNameOrEmail("search.test", PageRequest.of(0, 20));
+
+        List<Long> ids = page.getContent().stream().map(RegisteredUser::getId).toList();
+        assertTrue(ids.contains(regular.getId()));
+        assertTrue(ids.contains(admin.getId()), "admin accounts must surface in user search");
+        assertFalse(ids.contains(banned.getId()), "banned accounts must not surface");
+        assertEquals(2L, page.getTotalElements());
+    }
+
+    @Test
+    void searchUsersByNameOrEmail_caseInsensitiveSubstringMatchAcrossNameAndEmail() {
+        RegisteredUser byName = persist("Grace Hopper", "grace@case.test", UserRole.USER, UserStatus.ACTIVE);
+        RegisteredUser byEmail = persist("Other Person", "alan@case.test", UserRole.USER, UserStatus.ACTIVE);
+        persist("Unrelated", "u@elsewhere.test", UserRole.USER, UserStatus.ACTIVE);
+
+        Page<RegisteredUser> matchByName = repository.searchUsersByNameOrEmail("GRACE", PageRequest.of(0, 20));
+        Page<RegisteredUser> matchByEmail = repository.searchUsersByNameOrEmail("alan@", PageRequest.of(0, 20));
+
+        assertEquals(1L, matchByName.getTotalElements());
+        assertEquals(byName.getId(), matchByName.getContent().get(0).getId());
+
+        assertEquals(1L, matchByEmail.getTotalElements());
+        assertEquals(byEmail.getId(), matchByEmail.getContent().get(0).getId());
+    }
+
+    private RegisteredUser persist(String name, String email, UserRole role, UserStatus status) {
+        RegisteredUser u = new RegisteredUser();
+        u.setName(name);
+        u.setEmail(email);
+        u.setPassword("hashedPassword");
+        u.setRole(role);
+        u.setStatus(status);
+        return repository.save(u);
+    }
+}

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RegisteredUserServiceTest.java
@@ -560,7 +560,7 @@ class RegisteredUserServiceTest {
         org.springframework.data.domain.Page<RegisteredUser> results =
                 new org.springframework.data.domain.PageImpl<>(List.of(mockUser));
         when(registeredUserRepository
-                .searchRegularUsersByNameOrEmail("test", page))
+                .searchUsersByNameOrEmail("test", page))
                 .thenReturn(results);
         // singletonList — List.of(Object[]) gets varargs-unpacked into a
         // List<Long>, and doReturn skips compile-time checking, so the cast
@@ -587,7 +587,7 @@ class RegisteredUserServiceTest {
         org.springframework.data.domain.Page<RegisteredUser> results =
                 new org.springframework.data.domain.PageImpl<>(List.of());
         when(registeredUserRepository
-                .searchRegularUsersByNameOrEmail("foo", page))
+                .searchUsersByNameOrEmail("foo", page))
                 .thenReturn(results);
 
         registeredUserService.searchUsers("  foo  ", page);
@@ -595,14 +595,14 @@ class RegisteredUserServiceTest {
         // Whitespace stripped before passing to the repo. The repo method itself
         // is case-insensitive, so we don't need to lowercase here.
         verify(registeredUserRepository)
-                .searchRegularUsersByNameOrEmail("foo", page);
+                .searchUsersByNameOrEmail("foo", page);
     }
 
     @Test
     void searchUsers_emptyResults_returnsEmptyPage() {
         org.springframework.data.domain.Pageable page = org.springframework.data.domain.PageRequest.of(0, 20);
         when(registeredUserRepository
-                .searchRegularUsersByNameOrEmail("zzz", page))
+                .searchUsersByNameOrEmail("zzz", page))
                 .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of()));
 
         org.springframework.data.domain.Page<UserProfileDTO> dtos =


### PR DESCRIPTION
# 📝 Description
`GET /api/users/search` was filtering to `role = USER` only — admin accounts never appeared. This PR drops that role restriction so admins surface alongside regular users. As a small refinement, `BANNED` accounts are now excluded explicitly (matching how the leaderboard query already filters by `status = ACTIVE`).

The repository method is renamed from `searchRegularUsersByNameOrEmail` to `searchUsersByNameOrEmail` to reflect the new scope.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

Manual checks:
- [ ] Searching for a known admin's name returns them
- [ ] A banned account does not appear in any search

# 📸 Screenshots / Recordings
N/A

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
