### PR TITLE
[Backend] Wire AVOID_STAIRS To ORS avoid_features And Reported Ramps

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/service/OrsRoutingClient.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/OrsRoutingClient.java
@@ -4,6 +4,7 @@ import com.bounswe2026group1.backend.dto.routing.RouteStep;
 import com.bounswe2026group1.backend.dto.routing.RoutingDirectionsResult;
 import com.bounswe2026group1.backend.exception.RoutingException;
 import com.bounswe2026group1.backend.model.Location;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
 import com.bounswe2026group1.backend.model.TravelMode;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -13,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.ResourceAccessException;
@@ -41,6 +43,7 @@ public class OrsRoutingClient {
 
     /**
      * Fetches directions from ORS for the given start/end and travel mode.
+     * Backwards-compatible overload — equivalent to passing an empty constraint set.
      *
      * @param start         origin location
      * @param end           destination location
@@ -50,12 +53,34 @@ public class OrsRoutingClient {
      */
     public RoutingDirectionsResult fetchDirections(
             Location start, Location end, TravelMode travelMode, ObjectNode avoidPolygons) {
+        return fetchDirections(start, end, travelMode, avoidPolygons, Set.of());
+    }
+
+    /**
+     * Fetches directions from ORS for the given start/end and travel mode.
+     * Forwards selected constraints to ORS as native routing options
+     * (e.g. {@code AVOID_STAIRS} → {@code avoid_features: ["steps"]}), so that
+     * routes detour around OSM-tagged features regardless of whether a community
+     * report exists for that segment.
+     *
+     * @param start         origin location
+     * @param end           destination location
+     * @param travelMode    WALKING or WHEELCHAIR
+     * @param avoidPolygons optional GeoJSON MultiPolygon node to avoid, may be null
+     * @param constraints   caller's routing constraints; used to derive ORS-native
+     *                      {@code avoid_features} entries. Null or empty disables
+     *                      ORS-native feature filtering.
+     * @return parsed directions result
+     */
+    public RoutingDirectionsResult fetchDirections(
+            Location start, Location end, TravelMode travelMode,
+            ObjectNode avoidPolygons, Set<RoutingConstraint> constraints) {
         validateApiKey();
         validateLocation(start, "start");
         validateLocation(end, "end");
 
         String profile = mapProfile(travelMode);
-        String requestBody = buildRequestBody(start, end, avoidPolygons);
+        String requestBody = buildRequestBody(start, end, avoidPolygons, constraints);
 
         String responseJson;
         try {
@@ -88,7 +113,8 @@ public class OrsRoutingClient {
         }
     }
 
-    private String buildRequestBody(Location start, Location end, ObjectNode avoidPolygons) {
+    private String buildRequestBody(Location start, Location end, ObjectNode avoidPolygons,
+                                    Set<RoutingConstraint> constraints) {
         ObjectNode root = objectMapper.createObjectNode();
 
         ArrayNode coordinates = root.putArray("coordinates");
@@ -100,9 +126,19 @@ public class OrsRoutingClient {
         root.put("geometry", true);
         root.put("preference", "shortest");
 
-        if (avoidPolygons != null) {
+        List<String> avoidFeatures = deriveAvoidFeatures(constraints);
+        boolean hasPolygons = avoidPolygons != null;
+        boolean hasFeatures = !avoidFeatures.isEmpty();
+
+        if (hasPolygons || hasFeatures) {
             ObjectNode options = objectMapper.createObjectNode();
-            options.set("avoid_polygons", avoidPolygons);
+            if (hasPolygons) {
+                options.set("avoid_polygons", avoidPolygons);
+            }
+            if (hasFeatures) {
+                ArrayNode features = options.putArray("avoid_features");
+                avoidFeatures.forEach(features::add);
+            }
             root.set("options", options);
         }
 
@@ -111,6 +147,23 @@ public class OrsRoutingClient {
         } catch (Exception e) {
             throw new RoutingException("Failed to serialize OpenRouteService request", e);
         }
+    }
+
+    /**
+     * Maps high-level routing constraints to ORS-native {@code avoid_features} values.
+     * Only {@code AVOID_STAIRS} has a clean equivalent today
+     * ({@code highway=steps} ways via {@code "steps"}). Other constraints stay
+     * driven by report-based avoid_polygons.
+     */
+    private static List<String> deriveAvoidFeatures(Set<RoutingConstraint> constraints) {
+        if (constraints == null || constraints.isEmpty()) {
+            return List.of();
+        }
+        List<String> features = new ArrayList<>();
+        if (constraints.contains(RoutingConstraint.AVOID_STAIRS)) {
+            features.add("steps");
+        }
+        return features;
     }
 
     private RoutingDirectionsResult parseDirectionsResponse(String responseJson) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/OrsRoutingClient.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/OrsRoutingClient.java
@@ -166,6 +166,17 @@ public class OrsRoutingClient {
         return features;
     }
 
+    /**
+     * Whether the given constraint set would attach any ORS-native filters to
+     * the routing request, independent of report-driven avoid polygons. Used by
+     * callers (e.g. {@code RouteService}) to decide whether the Accessible Route
+     * alternative is meaningfully different from the Fastest Route even when
+     * no reports apply.
+     */
+    public static boolean producesNativeAvoidFeatures(Set<RoutingConstraint> constraints) {
+        return !deriveAvoidFeatures(constraints).isEmpty();
+    }
+
     private RoutingDirectionsResult parseDirectionsResponse(String responseJson) {
         try {
             JsonNode root = objectMapper.readTree(responseJson);

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -94,8 +94,8 @@ public class RouteService {
 
         List<RouteResponse> routes = new ArrayList<>();
 
-        // 1. Fastest walking route — no obstacle avoidance
-        RoutingDirectionsResult fastestResult = fetchOrNull(start, end, TravelMode.WALKING, null);
+        // 1. Fastest walking route — no obstacle avoidance, no ORS feature filters
+        RoutingDirectionsResult fastestResult = fetchOrNull(start, end, TravelMode.WALKING, null, Set.of());
         boolean hasObstacles = false;
 
         if (fastestResult != null) {
@@ -122,7 +122,7 @@ public class RouteService {
         // Wheelchair callers' accessible alternative IS the wheelchair-mode
         // route below; emitting a walking Accessible Route to them is noise.
         if (avoidPolygons != null && includeWalkingAccessibleAlternative) {
-            RoutingDirectionsResult accessibleResult = fetchOrNull(start, end, TravelMode.WALKING, avoidPolygons);
+            RoutingDirectionsResult accessibleResult = fetchOrNull(start, end, TravelMode.WALKING, avoidPolygons, constraints);
 
             if (accessibleResult != null) {
                 routes.add(RouteResponse.builder()
@@ -149,7 +149,7 @@ public class RouteService {
         if (includeWheelchairAlternative) {
             // Candidate A: direct wheelchair route with obstacle avoidance
             RoutingDirectionsResult wheelchairResult =
-                    fetchOrNull(start, end, TravelMode.WHEELCHAIR, avoidPolygons);
+                    fetchOrNull(start, end, TravelMode.WHEELCHAIR, avoidPolygons, constraints);
             if (wheelchairResult != null) {
                 bestWheelchair = RouteResponse.builder()
                         .routeLabel(wheelchairLabel)
@@ -182,9 +182,10 @@ public class RouteService {
             Location rampEntry = indexA <= indexB ? rampA : rampB;
             Location rampExit  = indexA <= indexB ? rampB : rampA;
 
-            RoutingDirectionsResult leg1 = fetchOrNull(start, rampEntry, TravelMode.WHEELCHAIR, avoidPolygons);
-            RoutingDirectionsResult leg2 = fetchOrNull(rampEntry, rampExit, TravelMode.WALKING, null);
-            RoutingDirectionsResult leg3 = fetchOrNull(rampExit, end, TravelMode.WHEELCHAIR, avoidPolygons);
+            RoutingDirectionsResult leg1 = fetchOrNull(start, rampEntry, TravelMode.WHEELCHAIR, avoidPolygons, constraints);
+            // leg 2 traverses the selected ramp itself — feature filters would defeat the purpose
+            RoutingDirectionsResult leg2 = fetchOrNull(rampEntry, rampExit, TravelMode.WALKING, null, Set.of());
+            RoutingDirectionsResult leg3 = fetchOrNull(rampExit, end, TravelMode.WHEELCHAIR, avoidPolygons, constraints);
 
                 if (leg1 != null && leg2 != null && leg3 != null) {
                     double totalDistance = leg1.getDistanceMeters() + leg2.getDistanceMeters() + leg3.getDistanceMeters();
@@ -271,9 +272,10 @@ public class RouteService {
         return 2 * R * Math.asin(Math.sqrt(h));
     }
 
-    private RoutingDirectionsResult fetchOrNull(Location start, Location end, TravelMode mode, ObjectNode polygons) {
+    private RoutingDirectionsResult fetchOrNull(Location start, Location end, TravelMode mode,
+                                                ObjectNode polygons, Set<RoutingConstraint> constraints) {
         try {
-            return orsRoutingClient.fetchDirections(start, end, mode, polygons);
+            return orsRoutingClient.fetchDirections(start, end, mode, polygons, constraints);
         } catch (Exception e) {
             log.warn("Failed to fetch {} route: {}", mode, e.getMessage());
             return null;

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -127,19 +127,35 @@ public class RouteService {
         boolean hasAvoidance = avoidPolygons != null || hasNativeFilters;
         if (hasAvoidance && includeWalkingAccessibleAlternative) {
             RoutingDirectionsResult accessibleResult = fetchOrNull(start, end, TravelMode.WALKING, avoidPolygons, constraints);
+            RouteResponse directAccessible = accessibleResult == null ? null :
+                    RouteResponse.builder()
+                            .routeLabel("Accessible Route")
+                            .distanceMeters(accessibleResult.getDistanceMeters())
+                            .durationSeconds(accessibleResult.getDurationSeconds())
+                            .mode(TravelMode.WALKING)
+                            .geometry(accessibleResult.getGeometry())
+                            .geoJsonGeometry(GeoJsonLineString.fromLocations(
+                                    PolylineDecoder.decode(accessibleResult.getGeometry())))
+                            .steps(accessibleResult.getSteps())
+                            .hasObstacles(false)
+                            .build();
 
-            if (accessibleResult != null) {
-                routes.add(RouteResponse.builder()
-                        .routeLabel("Accessible Route")
-                        .distanceMeters(accessibleResult.getDistanceMeters())
-                        .durationSeconds(accessibleResult.getDurationSeconds())
-                        .mode(TravelMode.WALKING)
-                        .geometry(accessibleResult.getGeometry())
-                        .geoJsonGeometry(GeoJsonLineString.fromLocations(
-                                PolylineDecoder.decode(accessibleResult.getGeometry())))
-                        .steps(accessibleResult.getSteps())
-                        .hasObstacles(false)
-                        .build());
+            // When AVOID_STAIRS is active, also consider routing through a reported
+            // FEATURE ramp (same pattern as the wheelchair branch below). Both legs
+            // use WALKING + the caller's constraints so the approach/exit respect
+            // avoid_features:["steps"]; the through-ramp leg stays unfiltered.
+            RouteResponse rampAssistedAccessible = null;
+            if (constraints != null && constraints.contains(RoutingConstraint.AVOID_STAIRS)
+                    && fastestResult != null && fastestResult.getGeometry() != null) {
+                List<Location> walkingPath = PolylineDecoder.decode(fastestResult.getGeometry());
+                rampAssistedAccessible = buildRampAssistedRoute(
+                        start, end, TravelMode.WALKING, avoidPolygons, constraints,
+                        walkingPath, "Accessible Route", TravelMode.WALKING);
+            }
+
+            RouteResponse bestAccessible = pickShorter(directAccessible, rampAssistedAccessible);
+            if (bestAccessible != null) {
+                routes.add(bestAccessible);
             }
         }
 
@@ -148,82 +164,33 @@ public class RouteService {
         // "Wheelchair Route" label) or wheelchair callers (their
         // "Accessible Route"). Walking / no-preference authed users get
         // nothing here.
-        RouteResponse bestWheelchair = null;
-
         if (includeWheelchairAlternative) {
             // Candidate A: direct wheelchair route with obstacle avoidance
             RoutingDirectionsResult wheelchairResult =
                     fetchOrNull(start, end, TravelMode.WHEELCHAIR, avoidPolygons, constraints);
-            if (wheelchairResult != null) {
-                bestWheelchair = RouteResponse.builder()
-                        .routeLabel(wheelchairLabel)
-                        .distanceMeters(wheelchairResult.getDistanceMeters())
-                        .durationSeconds(wheelchairResult.getDurationSeconds())
-                        .mode(TravelMode.WHEELCHAIR)
-                        .geometry(wheelchairResult.getGeometry())
-                        .geoJsonGeometry(GeoJsonLineString.fromLocations(
-                                PolylineDecoder.decode(wheelchairResult.getGeometry())))
-                        .steps(wheelchairResult.getSteps())
-                        .hasObstacles(false)
-                        .build();
-            }
+            RouteResponse directWheelchair = wheelchairResult == null ? null :
+                    RouteResponse.builder()
+                            .routeLabel(wheelchairLabel)
+                            .distanceMeters(wheelchairResult.getDistanceMeters())
+                            .durationSeconds(wheelchairResult.getDurationSeconds())
+                            .mode(TravelMode.WHEELCHAIR)
+                            .geometry(wheelchairResult.getGeometry())
+                            .geoJsonGeometry(GeoJsonLineString.fromLocations(
+                                    PolylineDecoder.decode(wheelchairResult.getGeometry())))
+                            .steps(wheelchairResult.getSteps())
+                            .hasObstacles(false)
+                            .build();
 
-            // Candidate B: multi-leg route through nearest ramp entry/exit
-            Report ramp = null;
+            // Candidate B: multi-leg route through nearest reported FEATURE ramp
+            RouteResponse rampAssistedWheelchair = null;
             if (fastestResult != null && fastestResult.getGeometry() != null) {
                 List<Location> walkingPath = PolylineDecoder.decode(fastestResult.getGeometry());
-                ramp = obstacleService.findRampOnPath(walkingPath);
+                rampAssistedWheelchair = buildRampAssistedRoute(
+                        start, end, TravelMode.WHEELCHAIR, avoidPolygons, constraints,
+                        walkingPath, wheelchairLabel, TravelMode.WHEELCHAIR);
             }
 
-            if (ramp != null && ramp.getEntryPoint() != null && ramp.getExitPoint() != null) {
-            List<Location> walkingPath = PolylineDecoder.decode(fastestResult.getGeometry());
-            Location rampA = ramp.getEntryPoint();
-            Location rampB = ramp.getExitPoint();
-            
-            int indexA = findMinIndex(rampA, walkingPath);
-            int indexB = findMinIndex(rampB, walkingPath);
-    
-            Location rampEntry = indexA <= indexB ? rampA : rampB;
-            Location rampExit  = indexA <= indexB ? rampB : rampA;
-
-            RoutingDirectionsResult leg1 = fetchOrNull(start, rampEntry, TravelMode.WHEELCHAIR, avoidPolygons, constraints);
-            // leg 2 traverses the selected ramp itself — feature filters would defeat the purpose
-            RoutingDirectionsResult leg2 = fetchOrNull(rampEntry, rampExit, TravelMode.WALKING, null, Set.of());
-            RoutingDirectionsResult leg3 = fetchOrNull(rampExit, end, TravelMode.WHEELCHAIR, avoidPolygons, constraints);
-
-                if (leg1 != null && leg2 != null && leg3 != null) {
-                    double totalDistance = leg1.getDistanceMeters() + leg2.getDistanceMeters() + leg3.getDistanceMeters();
-                    double totalDuration = leg1.getDurationSeconds() + leg2.getDurationSeconds() + leg3.getDurationSeconds();
-
-                    // Pick the ramp-assisted multi-leg if it's shorter than the direct wheelchair route
-                    if (bestWheelchair == null || totalDistance < bestWheelchair.getDistanceMeters()) {
-                        List<Location> combinedPath = new ArrayList<>();
-                        combinedPath.addAll(PolylineDecoder.decode(leg1.getGeometry()));
-                        combinedPath.addAll(PolylineDecoder.decode(leg2.getGeometry()));
-                        combinedPath.addAll(PolylineDecoder.decode(leg3.getGeometry()));
-
-                        List<RouteStep> combinedSteps = new ArrayList<>();
-                        if (leg1.getSteps() != null) combinedSteps.addAll(leg1.getSteps());
-                        combinedSteps.addAll(leg2.getSteps());
-                        combinedSteps.add(RouteStep.builder().instruction("Exit the ramp").maneuverType("ramp_exit").build());
-                        if (leg3.getSteps() != null) combinedSteps.addAll(leg3.getSteps());
-
-                        bestWheelchair = RouteResponse.builder()
-                                .routeLabel(wheelchairLabel)
-                                .distanceMeters(totalDistance)
-                                .durationSeconds(totalDuration)
-                                .mode(TravelMode.WHEELCHAIR)
-                                .geometry(PolylineEncoder.encode(combinedPath))
-                                .geoJsonGeometry(GeoJsonLineString.fromLocations(combinedPath))
-                                .steps(combinedSteps)
-                                .hasObstacles(false)
-                                .build();
-                    }
-                } else {
-                    log.warn("Ramp-assisted route via ramp skipped; leg 1, leg 2, or leg 3 returned null.");
-                }
-            }
-
+            RouteResponse bestWheelchair = pickShorter(directWheelchair, rampAssistedWheelchair);
             if (bestWheelchair != null) {
                 routes.add(bestWheelchair);
             }
@@ -250,6 +217,77 @@ public class RouteService {
         if (winner != null) {
             winner.setPreferred(true);
         }
+    }
+
+    /**
+     * Build a 3-leg route through the nearest reported FEATURE ramp on the
+     * given path: start → ramp entry (approach mode, constraints applied) →
+     * ramp exit (WALKING, unfiltered — the ramp itself) → end (approach mode,
+     * constraints applied). Returns null when no ramp is found or any leg
+     * fails to fetch, allowing the caller to fall back to the direct route.
+     */
+    private RouteResponse buildRampAssistedRoute(
+            Location start, Location end,
+            TravelMode approachMode,
+            ObjectNode avoidPolygons,
+            Set<RoutingConstraint> constraints,
+            List<Location> fastestPath,
+            String routeLabel,
+            TravelMode resultMode) {
+        Report ramp = obstacleService.findRampOnPath(fastestPath);
+        if (ramp == null || ramp.getEntryPoint() == null || ramp.getExitPoint() == null) {
+            return null;
+        }
+
+        Location rampA = ramp.getEntryPoint();
+        Location rampB = ramp.getExitPoint();
+
+        int indexA = findMinIndex(rampA, fastestPath);
+        int indexB = findMinIndex(rampB, fastestPath);
+        Location rampEntry = indexA <= indexB ? rampA : rampB;
+        Location rampExit  = indexA <= indexB ? rampB : rampA;
+
+        RoutingDirectionsResult leg1 = fetchOrNull(start, rampEntry, approachMode, avoidPolygons, constraints);
+        // Leg 2 traverses the ramp itself — feature filters would defeat the purpose.
+        RoutingDirectionsResult leg2 = fetchOrNull(rampEntry, rampExit, TravelMode.WALKING, null, Set.of());
+        RoutingDirectionsResult leg3 = fetchOrNull(rampExit, end, approachMode, avoidPolygons, constraints);
+
+        if (leg1 == null || leg2 == null || leg3 == null) {
+            log.warn("Ramp-assisted route skipped; leg 1, leg 2, or leg 3 returned null.");
+            return null;
+        }
+
+        double totalDistance = leg1.getDistanceMeters() + leg2.getDistanceMeters() + leg3.getDistanceMeters();
+        double totalDuration = leg1.getDurationSeconds() + leg2.getDurationSeconds() + leg3.getDurationSeconds();
+
+        List<Location> combinedPath = new ArrayList<>();
+        combinedPath.addAll(PolylineDecoder.decode(leg1.getGeometry()));
+        combinedPath.addAll(PolylineDecoder.decode(leg2.getGeometry()));
+        combinedPath.addAll(PolylineDecoder.decode(leg3.getGeometry()));
+
+        List<RouteStep> combinedSteps = new ArrayList<>();
+        if (leg1.getSteps() != null) combinedSteps.addAll(leg1.getSteps());
+        combinedSteps.addAll(leg2.getSteps());
+        combinedSteps.add(RouteStep.builder().instruction("Exit the ramp").maneuverType("ramp_exit").build());
+        if (leg3.getSteps() != null) combinedSteps.addAll(leg3.getSteps());
+
+        return RouteResponse.builder()
+                .routeLabel(routeLabel)
+                .distanceMeters(totalDistance)
+                .durationSeconds(totalDuration)
+                .mode(resultMode)
+                .geometry(PolylineEncoder.encode(combinedPath))
+                .geoJsonGeometry(GeoJsonLineString.fromLocations(combinedPath))
+                .steps(combinedSteps)
+                .hasObstacles(false)
+                .build();
+    }
+
+    /** Pick the shorter of two candidates by total distance. Null candidates are skipped. */
+    private static RouteResponse pickShorter(RouteResponse a, RouteResponse b) {
+        if (a == null) return b;
+        if (b == null) return a;
+        return a.getDistanceMeters() <= b.getDistanceMeters() ? a : b;
     }
 
     private int findMinIndex(Location target, List<Location> path) {

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -140,13 +140,18 @@ public class RouteService {
                             .hasObstacles(false)
                             .build();
 
-            // When AVOID_STAIRS is active, also consider routing through a reported
-            // FEATURE ramp (same pattern as the wheelchair branch below). Both legs
-            // use WALKING + the caller's constraints so the approach/exit respect
-            // avoid_features:["steps"]; the through-ramp leg stays unfiltered.
+            // When the caller wants ramps (REQUIRE_RAMPS is the natural fit — its
+            // label literally says "Prefer routes with ramps over steps") or stairs
+            // avoided (AVOID_STAIRS users benefit from going through known ramps),
+            // consider routing through a reported FEATURE ramp (same pattern as
+            // the wheelchair branch below). The approach/exit legs use WALKING +
+            // the caller's constraints (so avoid_features:["steps"] is honored
+            // when AVOID_STAIRS is set); the through-ramp leg stays unfiltered.
+            boolean wantsRampAssist = constraints != null
+                    && (constraints.contains(RoutingConstraint.REQUIRE_RAMPS)
+                        || constraints.contains(RoutingConstraint.AVOID_STAIRS));
             RouteResponse rampAssistedAccessible = null;
-            if (constraints != null && constraints.contains(RoutingConstraint.AVOID_STAIRS)
-                    && fastestResult != null && fastestResult.getGeometry() != null) {
+            if (wantsRampAssist && fastestResult != null && fastestResult.getGeometry() != null) {
                 List<Location> walkingPath = PolylineDecoder.decode(fastestResult.getGeometry());
                 rampAssistedAccessible = buildRampAssistedRoute(
                         start, end, TravelMode.WALKING, avoidPolygons, constraints,

--- a/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/service/RouteService.java
@@ -117,11 +117,15 @@ public class RouteService {
                     .build());
         }
 
-        // 2. Accessible walking route — computed when avoid polygons exist AND
-        // the caller would actually act on a walking-mode alternative.
-        // Wheelchair callers' accessible alternative IS the wheelchair-mode
-        // route below; emitting a walking Accessible Route to them is noise.
-        if (avoidPolygons != null && includeWalkingAccessibleAlternative) {
+        // 2. Accessible walking route — computed when avoidance is in effect
+        // (report-driven polygons or ORS-native filters like avoid_features:
+        // ["steps"] for AVOID_STAIRS) AND the caller would actually act on a
+        // walking-mode alternative. Wheelchair callers' accessible alternative
+        // IS the wheelchair-mode route below; emitting a walking Accessible
+        // Route to them is noise.
+        boolean hasNativeFilters = OrsRoutingClient.producesNativeAvoidFeatures(constraints);
+        boolean hasAvoidance = avoidPolygons != null || hasNativeFilters;
+        if (hasAvoidance && includeWalkingAccessibleAlternative) {
             RoutingDirectionsResult accessibleResult = fetchOrNull(start, end, TravelMode.WALKING, avoidPolygons, constraints);
 
             if (accessibleResult != null) {

--- a/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/controller/RoutingPreferencesRouteIntegrationTest.java
@@ -89,7 +89,7 @@ class RoutingPreferencesRouteIntegrationTest {
                 .geometry("")
                 .steps(List.of())
                 .build();
-        when(orsRoutingClient.fetchDirections(any(), any(), any(), any())).thenReturn(canned);
+        when(orsRoutingClient.fetchDirections(any(), any(), any(), any(), any())).thenReturn(canned);
         when(obstacleService.findClosestRampInBoundingBox(any(), any())).thenReturn(null);
         when(obstacleService.findObstaclesOnPath(any(), any())).thenReturn(List.of());
         when(obstacleService.buildAvoidPolygons(any())).thenReturn(null);

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/OrsRoutingClientTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/OrsRoutingClientTest.java
@@ -3,7 +3,11 @@ package com.bounswe2026group1.backend.service;
 import com.bounswe2026group1.backend.dto.routing.RoutingDirectionsResult;
 import com.bounswe2026group1.backend.exception.RoutingException;
 import com.bounswe2026group1.backend.model.Location;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
 import com.bounswe2026group1.backend.model.TravelMode;
+
+import java.util.EnumSet;
+import java.util.Set;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,6 +78,77 @@ class OrsRoutingClientTest {
         JsonNode body = objectMapper.readTree(bodyCaptor.getValue());
         JsonNode avoid = body.path("options").path("avoid_polygons");
         assertEquals("MultiPolygon", avoid.path("type").stringValue());
+    }
+
+    @Test
+    void fetchDirections_avoidStairsConstraint_addsAvoidFeaturesSteps() throws Exception {
+        when(orsHttpClient.postDirections(eq("foot-walking"), anyString()))
+                .thenReturn(minimalOrsSuccessJson());
+
+        client.fetchDirections(START, END, TravelMode.WALKING, null,
+                EnumSet.of(RoutingConstraint.AVOID_STAIRS));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(orsHttpClient).postDirections(eq("foot-walking"), bodyCaptor.capture());
+
+        JsonNode body = objectMapper.readTree(bodyCaptor.getValue());
+        JsonNode features = body.path("options").path("avoid_features");
+        assertTrue(features.isArray(), "options.avoid_features must be an array");
+        assertEquals(1, features.size());
+        assertEquals("steps", features.get(0).stringValue());
+    }
+
+    @Test
+    void fetchDirections_constraintsWithoutAvoidStairs_omitAvoidFeatures() throws Exception {
+        when(orsHttpClient.postDirections(eq("foot-walking"), anyString()))
+                .thenReturn(minimalOrsSuccessJson());
+
+        client.fetchDirections(START, END, TravelMode.WALKING, null,
+                EnumSet.of(RoutingConstraint.AVOID_NARROW_SIDEWALKS,
+                           RoutingConstraint.REQUIRE_HANDRAILS));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(orsHttpClient).postDirections(eq("foot-walking"), bodyCaptor.capture());
+
+        JsonNode body = objectMapper.readTree(bodyCaptor.getValue());
+        // No AVOID_STAIRS → no ORS-native feature filter, and since no polygons either,
+        // the options object should not appear at all.
+        assertTrue(body.path("options").isMissingNode() || body.path("options").isEmpty(),
+                "request body must not carry avoid_features when AVOID_STAIRS is absent");
+    }
+
+    @Test
+    void fetchDirections_avoidStairsAndPolygons_attachesBothUnderOptions() throws Exception {
+        when(orsHttpClient.postDirections(eq("wheelchair"), anyString()))
+                .thenReturn(minimalOrsSuccessJson());
+
+        var polygons = objectMapper.createObjectNode();
+        polygons.put("type", "MultiPolygon");
+        polygons.set("coordinates", objectMapper.createArrayNode());
+
+        client.fetchDirections(START, END, TravelMode.WHEELCHAIR, polygons,
+                EnumSet.of(RoutingConstraint.AVOID_STAIRS));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(orsHttpClient).postDirections(eq("wheelchair"), bodyCaptor.capture());
+
+        JsonNode options = objectMapper.readTree(bodyCaptor.getValue()).path("options");
+        assertEquals("MultiPolygon", options.path("avoid_polygons").path("type").stringValue());
+        assertEquals("steps", options.path("avoid_features").get(0).stringValue());
+    }
+
+    @Test
+    void fetchDirections_nullConstraintsOverload_behavesLikeEmptyConstraintSet() throws Exception {
+        when(orsHttpClient.postDirections(eq("foot-walking"), anyString()))
+                .thenReturn(minimalOrsSuccessJson());
+
+        // 5-arg form with null constraints — should not throw and should not add avoid_features.
+        client.fetchDirections(START, END, TravelMode.WALKING, null, (Set<RoutingConstraint>) null);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(orsHttpClient).postDirections(eq("foot-walking"), bodyCaptor.capture());
+        JsonNode body = objectMapper.readTree(bodyCaptor.getValue());
+        assertTrue(body.path("options").isMissingNode() || body.path("options").isEmpty());
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
@@ -49,7 +49,7 @@ class RouteServiceTest {
                 .geometry("")
                 .steps(List.of())
                 .build();
-        when(orsRoutingClient.fetchDirections(any(), any(), any(), any())).thenReturn(anyRoute);
+        when(orsRoutingClient.fetchDirections(any(), any(), any(), any(), any())).thenReturn(anyRoute);
 
         List<RouteResponse> routes = routeService.getRouteOptions(
                 new RouteRequest(41.0850, 29.0450, 41.0820, 29.0500, TravelMode.WALKING));
@@ -80,7 +80,7 @@ class RouteServiceTest {
                 .geometry("")
                 .steps(List.of())
                 .build();
-        when(orsRoutingClient.fetchDirections(any(), any(), eq(TravelMode.WHEELCHAIR), any()))
+        when(orsRoutingClient.fetchDirections(any(), any(), eq(TravelMode.WHEELCHAIR), any(), any()))
                 .thenReturn(wheelchairRoute);
 
         // Fastest WALKING route must succeed so the ramp-on-path search is triggered.
@@ -95,7 +95,7 @@ class RouteServiceTest {
         // 1st call: Fastest Route (WALKING) -> succeeds
         // 2nd call: Accessible Route (WALKING) -> succeeds
         // 3rd call: Leg 2 of Wheelchair (WALKING) -> fails
-        when(orsRoutingClient.fetchDirections(any(), any(), eq(TravelMode.WALKING), any()))
+        when(orsRoutingClient.fetchDirections(any(), any(), eq(TravelMode.WALKING), any(), any()))
                 .thenReturn(walkingRoute)
                 .thenReturn(walkingRoute)
                 .thenThrow(new RuntimeException("ors down"));

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
@@ -5,7 +5,10 @@ import com.bounswe2026group1.backend.dto.routing.RouteResponse;
 import com.bounswe2026group1.backend.dto.routing.RoutingDirectionsResult;
 import com.bounswe2026group1.backend.model.Location;
 import com.bounswe2026group1.backend.model.Report;
+import com.bounswe2026group1.backend.model.RoutingConstraint;
 import com.bounswe2026group1.backend.model.TravelMode;
+
+import java.util.EnumSet;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
@@ -59,6 +62,33 @@ class RouteServiceTest {
         assertTrue(hasAccessibleRoute,
                 "Accessible Route should be returned whenever avoid polygons exist, "
                         + "even if the fastest route has no obstacles on it. Routes: " + routes);
+    }
+
+    @Test
+    void accessibleRoute_isEmitted_whenAvoidStairsActiveEvenWithoutPolygons() {
+        // User opted into AVOID_STAIRS but no obstacle reports nearby — buildAvoidPolygons
+        // returns null (Mockito default). Pre-fix the Accessible Route was suppressed
+        // because the gate only checked avoidPolygons. With ORS-native avoid_features in
+        // play, the Accessible Route IS meaningfully different from Fastest and must
+        // be emitted.
+        RoutingDirectionsResult anyRoute = RoutingDirectionsResult.builder()
+                .distanceMeters(100.0)
+                .durationSeconds(60.0)
+                .geometry("")
+                .steps(List.of())
+                .build();
+        when(orsRoutingClient.fetchDirections(any(), any(), any(), any(), any())).thenReturn(anyRoute);
+
+        List<RouteResponse> routes = routeService.getRouteOptions(
+                new RouteRequest(41.0850, 29.0450, 41.0820, 29.0500, TravelMode.WALKING),
+                EnumSet.of(RoutingConstraint.AVOID_STAIRS),
+                TravelMode.WALKING);
+
+        boolean hasAccessibleRoute = routes.stream()
+                .anyMatch(r -> "Accessible Route".equals(r.getRouteLabel()));
+        assertTrue(hasAccessibleRoute,
+                "Accessible Route must be emitted when AVOID_STAIRS is active even without polygons. "
+                        + "Routes: " + routes);
     }
 
     @Test

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
@@ -92,6 +92,77 @@ class RouteServiceTest {
     }
 
     @Test
+    void walkingUserWithAvoidStairs_takesRampAssistedRoute_whenItIsShorterThanDirect() {
+        // Setup: walking user, AVOID_STAIRS active. The fastest walking route exists,
+        // a FEATURE ramp report covers part of it, and routing through the ramp
+        // (legs 3×100m = 300m) beats the direct stair-avoiding accessible route (500m).
+        Report ramp = new Report();
+        ramp.setEntryPoint(new Location(41.0840, 29.0460));
+        ramp.setExitPoint(new Location(41.0830, 29.0480));
+        when(obstacleService.findRampOnPath(any())).thenReturn(ramp);
+
+        // Direct accessible WALKING route — long detour around the stairs
+        RoutingDirectionsResult directAccessible = RoutingDirectionsResult.builder()
+                .distanceMeters(500.0).durationSeconds(360.0).geometry("").steps(List.of()).build();
+        // Each ramp-leg — sum is 300m, beats the direct
+        RoutingDirectionsResult legRoute = RoutingDirectionsResult.builder()
+                .distanceMeters(100.0).durationSeconds(60.0).geometry("").steps(List.of()).build();
+        // Fastest walking route (drives findRampOnPath input) — geometry must decode to ≥ 2 pts
+        RoutingDirectionsResult fastest = RoutingDirectionsResult.builder()
+                .distanceMeters(800.0).durationSeconds(540.0).geometry("_p~iG~psG_p~iG~psG").steps(List.of()).build();
+
+        // 1st call: Fastest WALKING (no constraints) → fastest
+        // 2nd call: Direct Accessible WALKING (with AVOID_STAIRS) → directAccessible
+        // 3rd call: leg1 WALKING (with AVOID_STAIRS) → legRoute
+        // 4th call: leg2 WALKING (unfiltered) → legRoute
+        // 5th call: leg3 WALKING (with AVOID_STAIRS) → legRoute
+        when(orsRoutingClient.fetchDirections(any(), any(), eq(TravelMode.WALKING), any(), any()))
+                .thenReturn(fastest)
+                .thenReturn(directAccessible)
+                .thenReturn(legRoute)
+                .thenReturn(legRoute)
+                .thenReturn(legRoute);
+
+        List<RouteResponse> routes = routeService.getRouteOptions(
+                new RouteRequest(41.0850, 29.0450, 41.0820, 29.0500, TravelMode.WALKING),
+                EnumSet.of(RoutingConstraint.AVOID_STAIRS),
+                TravelMode.WALKING);
+
+        RouteResponse accessible = routes.stream()
+                .filter(r -> "Accessible Route".equals(r.getRouteLabel()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(accessible != null,
+                "Accessible Route must be emitted. Routes: " + routes);
+        // Ramp-assisted (300m) wins over direct accessible (500m)
+        org.junit.jupiter.api.Assertions.assertEquals(300.0, accessible.getDistanceMeters(), 0.01,
+                "Accessible Route must be the ramp-assisted multi-leg (300m), not the direct (500m)");
+    }
+
+    @Test
+    void walkingUserWithAvoidStairs_keepsDirectAccessibleRoute_whenNoRampReportFound() {
+        // No ramp reported on the fastest path → buildRampAssistedRoute returns null,
+        // so the Accessible Route stays the direct foot-walking + avoid_features result.
+        when(obstacleService.findRampOnPath(any())).thenReturn(null);
+
+        RoutingDirectionsResult anyRoute = RoutingDirectionsResult.builder()
+                .distanceMeters(250.0).durationSeconds(180.0).geometry("_p~iG~psG_p~iG~psG").steps(List.of()).build();
+        when(orsRoutingClient.fetchDirections(any(), any(), any(), any(), any())).thenReturn(anyRoute);
+
+        List<RouteResponse> routes = routeService.getRouteOptions(
+                new RouteRequest(41.0850, 29.0450, 41.0820, 29.0500, TravelMode.WALKING),
+                EnumSet.of(RoutingConstraint.AVOID_STAIRS),
+                TravelMode.WALKING);
+
+        RouteResponse accessible = routes.stream()
+                .filter(r -> "Accessible Route".equals(r.getRouteLabel()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(accessible != null && accessible.getDistanceMeters() == 250.0,
+                "Accessible Route must be the direct result (250m) when no ramp report exists. Routes: " + routes);
+    }
+
+    @Test
     void rampAssistedRoute_isSkippedGracefully_whenLeg2WalkingCallFails() {
         // A ramp candidate exists, so the multi-leg branch is entered
         Report ramp = new Report();

--- a/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/service/RouteServiceTest.java
@@ -140,6 +140,51 @@ class RouteServiceTest {
     }
 
     @Test
+    void walkingUserWithRequireRamps_takesRampAssistedRoute_whenItIsShorter() {
+        // REQUIRE_RAMPS is the constraint whose label literally promises "Prefer routes
+        // with ramps over steps" — ramp-assisted routing should fire on it too, not
+        // only on AVOID_STAIRS. (Otherwise MOBILITY_LIMITED preset users — which include
+        // REQUIRE_RAMPS but not AVOID_STAIRS — never get positive ramp routing.)
+        Report ramp = new Report();
+        ramp.setEntryPoint(new Location(41.0840, 29.0460));
+        ramp.setExitPoint(new Location(41.0830, 29.0480));
+        when(obstacleService.findRampOnPath(any())).thenReturn(ramp);
+
+        // Avoid polygons must exist so the Accessible Route branch is entered at all
+        // (REQUIRE_RAMPS produces no native filters today, only polygons via reports).
+        ObjectNode avoidPolygons = JsonMapper.builder().build().createObjectNode();
+        when(obstacleService.buildAvoidPolygons(any())).thenReturn(avoidPolygons);
+
+        RoutingDirectionsResult directAccessible = RoutingDirectionsResult.builder()
+                .distanceMeters(500.0).durationSeconds(360.0).geometry("").steps(List.of()).build();
+        RoutingDirectionsResult legRoute = RoutingDirectionsResult.builder()
+                .distanceMeters(100.0).durationSeconds(60.0).geometry("").steps(List.of()).build();
+        RoutingDirectionsResult fastest = RoutingDirectionsResult.builder()
+                .distanceMeters(800.0).durationSeconds(540.0).geometry("_p~iG~psG_p~iG~psG").steps(List.of()).build();
+
+        when(orsRoutingClient.fetchDirections(any(), any(), eq(TravelMode.WALKING), any(), any()))
+                .thenReturn(fastest)         // 1. Fastest
+                .thenReturn(directAccessible)// 2. Direct Accessible
+                .thenReturn(legRoute)        // 3. leg1
+                .thenReturn(legRoute)        // 4. leg2
+                .thenReturn(legRoute);       // 5. leg3
+
+        List<RouteResponse> routes = routeService.getRouteOptions(
+                new RouteRequest(41.0850, 29.0450, 41.0820, 29.0500, TravelMode.WALKING),
+                EnumSet.of(RoutingConstraint.REQUIRE_RAMPS),
+                TravelMode.WALKING);
+
+        RouteResponse accessible = routes.stream()
+                .filter(r -> "Accessible Route".equals(r.getRouteLabel()))
+                .findFirst()
+                .orElse(null);
+        assertTrue(accessible != null,
+                "Accessible Route must be emitted for REQUIRE_RAMPS users. Routes: " + routes);
+        org.junit.jupiter.api.Assertions.assertEquals(300.0, accessible.getDistanceMeters(), 0.01,
+                "Accessible Route must be the ramp-assisted multi-leg (300m), not the direct (500m)");
+    }
+
+    @Test
     void walkingUserWithAvoidStairs_keepsDirectAccessibleRoute_whenNoRampReportFound() {
         // No ramp reported on the fastest path → buildRampAssistedRoute returns null,
         // so the Accessible Route stays the direct foot-walking + avoid_features result.


### PR DESCRIPTION
# 📝 Wire AVOID_STAIRS To ORS avoid_features And Reported Ramps
Fixes #657
Fixes #663

The `AVOID_STAIRS` constraint promised blanket stair avoidance in its label but the avoid-polygon builder only avoided **reported** stairs — a perfectly-built, unreported stair was never routed around. This PR makes the constraint live up to the label in two complementary ways:

**1. ORS-native stair avoidance (#657).** `OrsRoutingClient.fetchDirections` now accepts a `Set<RoutingConstraint>` alongside the existing avoid_polygons argument and forwards `AVOID_STAIRS` to ORS as `avoid_features: ["steps"]`. Any OSM-tagged `highway=steps` way is detoured at the routing engine level. Report-based avoid polygons remain in place as a complementary signal. A backward-compatible 4-arg overload preserves callers that don't have constraints in scope. The Accessible Route gate also relaxed so the alternative is emitted whenever **any** avoidance is active (polygons OR native filters), not only when polygons exist.

**2. Ramp-assisted Accessible Route for walking users (#663).** The existing 3-leg "route through nearest reported FEATURE ramp" logic in the wheelchair branch is extracted into a `buildRampAssistedRoute` helper parameterized by approach travel mode. Walking users with `AVOID_STAIRS` selected now get the same treatment: when a reported FEATURE ramp lies on the fastest path and routing through it is shorter than the direct stair-avoiding path, the Accessible Route returns the multi-leg geometry instead. Wheelchair behavior is unchanged after the refactor (same result via the new code path).

# 📊 Type of Change
- [x]  New feature

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed (702/702, 1 skipped — the live-ORS test gated on `ORS_API_KEY`)

# 📸 Screenshots / Recordings
<!-- N/A — backend-internal ORS request body change + routing alternative computation -->

# ⏱️ Estimated Review Time
- [x] 5-15 min
