### PR TITLE
[Backend] Fix Report Delete Failing When Subscriptions Exist

### DIFF
--- a/backend/src/main/java/com/bounswe2026group1/backend/model/Report.java
+++ b/backend/src/main/java/com/bounswe2026group1/backend/model/Report.java
@@ -101,6 +101,9 @@ public class Report {
     @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FixRequest> fixRequests = new ArrayList<>();
 
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReportSubscription> subscriptions = new ArrayList<>();
+
     public Report(RegisteredUser createdBy, Point location, String description,
                   ReportType reportType, ReportEnvironment environment) {
         this.createdBy = createdBy;

--- a/backend/src/test/java/com/bounswe2026group1/backend/repository/ReportSubscriptionRepositoryTest.java
+++ b/backend/src/test/java/com/bounswe2026group1/backend/repository/ReportSubscriptionRepositoryTest.java
@@ -8,6 +8,8 @@ import com.bounswe2026group1.backend.model.ReportType;
 import com.bounswe2026group1.backend.model.UserRole;
 import com.bounswe2026group1.backend.support.AbstractPostgisIntegrationTest;
 import com.bounswe2026group1.backend.util.GeoUtils;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +33,9 @@ class ReportSubscriptionRepositoryTest extends AbstractPostgisIntegrationTest {
 
     @Autowired
     private ReportRepository reportRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     private RegisteredUser alice;
     private RegisteredUser bob;
@@ -83,6 +88,29 @@ class ReportSubscriptionRepositoryTest extends AbstractPostgisIntegrationTest {
 
         assertEquals(1, ids.size());
         assertEquals(bob.getId(), ids.get(0));
+    }
+
+    @Test
+    void deletingReport_cascadesToSubscriptions() {
+        ReportSubscription sub = new ReportSubscription();
+        sub.setUser(bob);
+        sub.setReport(report);
+        subscriptionRepository.save(sub);
+
+        Long reportId = report.getReportId();
+
+        // Mirror production: ReportService.delete fetches the report fresh and
+        // cascade-loads its associations. Without clearing the persistence
+        // context, the orphaned sub sits in the session and trips a transient
+        // reference check at flush time.
+        entityManager.flush();
+        entityManager.clear();
+
+        Report reloaded = reportRepository.findById(reportId).orElseThrow();
+        reportRepository.delete(reloaded);
+        reportRepository.flush();
+
+        assertFalse(subscriptionRepository.existsByUserIdAndReportReportId(bob.getId(), reportId));
     }
 
     private RegisteredUser persistUser(String email, String name) {


### PR DESCRIPTION
# 📝 Description
Fixes the 500 Internal Server Error returned by `DELETE /api/reports/{id}` for reports created after the `ReportSubscription` feature landed (2026-05-01).

Every report author is auto-subscribed via `subscriptionService.subscribeInternal(...)` at create time, but `Report` had no cascade for the `report_subscriptions` side. The orphan row's FK on `report_id` blocked the parent delete, producing a 500 on the owner-delete path (and the same would silently affect admin delete and the FIXED-report lifecycle scheduler).

The fix adds `@OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)` for `List<ReportSubscription> subscriptions` on `Report`, so Hibernate deletes the subscription rows in the same transaction before removing the report. No schema migration is required — the existing FK is untouched; only the order of DELETE statements changes.

# 📊 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

# ✅ Acceptance Criteria / Checklist
- [x] Project builds successfully
- [x] I have performed a self-review
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have added/updated tests
- [x] All tests passed

# ⏱️ Estimated Review Time
- [x] < 5 min
- [ ] 5-15 min
- [ ] > 15 min
